### PR TITLE
feat: add environment variable configuration

### DIFF
--- a/server/.env_example
+++ b/server/.env_example
@@ -1,0 +1,5 @@
+# Server Configuration
+HOST=localhost
+PORT=9000
+
+# Other configuration variables can be added here as needed 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,12 @@
 import 'source-map-support/register';
-import OpenAPIBackend, { Request } from 'openapi-backend';
+import OpenAPIBackend, { Request, Context } from 'openapi-backend';
 import Express from 'express';
-import morgan from 'morgan'
+import morgan from 'morgan';
 import path from 'path';
+import dotenv from 'dotenv';
+
+// Load environment variables from .env file
+dotenv.config({ path: path.join(__dirname, '..', '.env') });
 
 import { Request as ExpressReq, Response as ExpressRes } from 'express';
 
@@ -17,19 +21,19 @@ const api = new OpenAPIBackend({
     quick: true, // disabled validation of OpenAPI on load
     definition: openApiPath,
     handlers: {
-        listTemplates: async (c, req: Express.Request, res: Express.Response) =>
+        listTemplates: async (c: Context, req: Express.Request, res: Express.Response) =>
             res.status(200).json([]),
-        createTemplate: async (c, req: Express.Request, res: Express.Response) =>
+        createTemplate: async (c: Context, req: Express.Request, res: Express.Response) =>
             res.status(200).json({}),
-        getTemplate: async (c, req: Express.Request, res: Express.Response) =>
+        getTemplate: async (c: Context, req: Express.Request, res: Express.Response) =>
             res.status(200).json({}),
-        replaceTemplate: async (c, req: Express.Request, res: Express.Response) =>
+        replaceTemplate: async (c: Context, req: Express.Request, res: Express.Response) =>
             res.status(200).json({}),
-        deleteTemplate: async (c, req: Express.Request, res: Express.Response) =>
+        deleteTemplate: async (c: Context, req: Express.Request, res: Express.Response) =>
             res.status(200).json({}),
-        validationFail: async (c, req: ExpressReq, res: ExpressRes) => res.status(400).json({ err: c.validation.errors }),
-        notFound: async (c, req: ExpressReq, res: ExpressRes) => res.status(404).json({ err: 'not found' }),
-        notImplemented: async (c, req: ExpressReq, res: ExpressRes) => {
+        validationFail: async (c: Context, req: ExpressReq, res: ExpressRes) => res.status(400).json({ err: c.validation.errors }),
+        notFound: async (c: Context, req: ExpressReq, res: ExpressRes) => res.status(404).json({ err: 'not found' }),
+        notImplemented: async (c: Context, req: ExpressReq, res: ExpressRes) => {
             const { status, mock } = c.api.mockResponseForOperation(c.operation.operationId);
             return res.status(status).json(mock);
         },
@@ -42,7 +46,12 @@ api.init();
 app.use(morgan('combined'));
 
 // use as express middleware
-app.use((req, res) => api.handleRequest(req as Request, req, res));
+app.use((req: Express.Request, res: Express.Response) => api.handleRequest(req as Request, req, res));
+
+const HOST = process.env.HOST || 'localhost';
+const PORT = parseInt(process.env.PORT || '9000', 10);
 
 // start server
-app.listen(9000, () => console.info('api listening at http://localhost:9000'));
+app.listen(PORT, HOST, () => {
+    console.info(`API listening at http://${HOST}:${PORT}`);
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,23 +10,24 @@
       "hasInstallScript": true,
       "license": "Apache-2",
       "dependencies": {
-        "express": "^4.16.4",
-        "morgan": "^1.9.1",
+        "dotenv": "^16.4.5",
+        "express": "^4.17.1",
+        "morgan": "^1.10.0",
         "openapi-backend": "^5.2.0",
-        "source-map-support": "^0.5.10"
+        "source-map-support": "^0.5.19"
       },
       "devDependencies": {
-        "@types/express": "^4.17.13",
+        "@types/express": "^4.17.21",
         "@types/jest": "^29.2.5",
-        "@types/morgan": "^1.7.35",
-        "@types/node": "^10.12.26",
+        "@types/morgan": "^1.9.9",
+        "@types/node": "^20.11.24",
         "axios": "^1.6.0",
         "concurrently": "^6.2.0",
         "jest": "^29.3.1",
         "nodemon": "^1.18.10",
         "ts-jest": "^29.0.3",
         "tslint": "^5.12.1",
-        "typescript": "^4.3.2",
+        "typescript": "^5.3.3",
         "wait-on": "^3.2.0"
       }
     },
@@ -1172,13 +1173,13 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.16",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.16.tgz",
-      "integrity": "sha512-LkKpqRZ7zqXJuvoELakaFYuETHjZkSol8EV6cNnyishutDBCCdv6+dsKPbKkCcIk57qRphOLY5sEgClw1bO3gA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.31",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
@@ -1249,19 +1250,22 @@
       "dev": true
     },
     "node_modules/@types/morgan": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.4.tgz",
-      "integrity": "sha512-cXoc4k+6+YAllH3ZHmx4hf7La1dzUk6keTR4bF4b4Sc0mZxU/zK4wO7l+ZzezXm/jkYj/qC+uYGZrarZdIVvyQ==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.9.tgz",
+      "integrity": "sha512-iRYSDKVaC6FkGSpEVVIvrRGw0DfJMiQzIn3qr2G5B3C//AWkulhXgaBd7tS9/J79GWSYMTHGs7PfI5b3Y8m+RQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true
+      "version": "20.17.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.23.tgz",
+      "integrity": "sha512-8PCGZ1ZJbEZuYNTMqywO+Sj4vSKjSjT6Ua+6RFOYlEvIvKQABPtrNkoVSLSKDb4obYcMhspVKmsw8Cm10NFRUg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -2854,6 +2858,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexer3": {
@@ -7696,22 +7711,28 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
     "node_modules/union-value": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apap-server",
   "version": "1.0.0",
-  "description": "",
+  "description": "APAP Reference Implementation",
   "author": "Dan Selman",
   "license": "Apache-2",
   "keywords": [],
@@ -16,23 +16,24 @@
     "test": "jest"
   },
   "dependencies": {
-    "express": "^4.16.4",
-    "morgan": "^1.9.1",
+    "dotenv": "^16.4.5",
+    "express": "^4.17.1",
+    "morgan": "^1.10.0",
     "openapi-backend": "^5.2.0",
-    "source-map-support": "^0.5.10"
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
-    "@types/express": "^4.17.13",
+    "@types/express": "^4.17.21",
     "@types/jest": "^29.2.5",
-    "@types/morgan": "^1.7.35",
-    "@types/node": "^10.12.26",
+    "@types/morgan": "^1.9.9",
+    "@types/node": "^20.11.24",
     "axios": "^1.6.0",
     "concurrently": "^6.2.0",
     "jest": "^29.3.1",
     "nodemon": "^1.18.10",
     "ts-jest": "^29.0.3",
     "tslint": "^5.12.1",
-    "typescript": "^4.3.2",
+    "typescript": "^5.3.3",
     "wait-on": "^3.2.0"
   }
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -3,7 +3,7 @@
       "target": "es2017",
       "module": "commonjs",
       "moduleResolution": "node",
-      "lib": ["es7", "esnext.asynciterable"],
+      "lib": ["es7", "esnext.asynciterable", "dom"],
       "experimentalDecorators": true,
       "emitDecoratorMetadata": true,
       "esModuleInterop": true,


### PR DESCRIPTION
   Issue Description:
   - Currently, the index.ts file contains a hardcoded localhost address
   - This can cause issues when configuring the project for different environments
   - A .env file should be introduced to allow flexible configuration

   Changes Implemented:
   - Updated index.ts to read the localhost address from an .env file using dotenv
   - Added a .env_example file with the required environment variables
   - Updated TypeScript configuration and dependencies
   - Added proper type definitions

   Steps to Test:
   1. Copy .env_example to .env
   2. Update values in .env as needed
   3. Run npm install
   4. Start the server and verify it reads from .env file