### PR TITLE
Add optional request attribute to Template (#52)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -32,11 +32,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "base64",
-          "mimeType"
-        ],
+        "required": ["$class", "base64", "mimeType"],
         "$decorators": {
           "description": [
             "Bytes and mime type for a blob of data, such as images, files, etc."
@@ -58,14 +54,9 @@
             "$ref": "#/components/schemas/org.accordproject.commonmark@0.5.0.Document"
           }
         },
-        "required": [
-          "$class",
-          "templateMark"
-        ],
+        "required": ["$class", "templateMark"],
         "$decorators": {
-          "description": [
-            "The text for a template"
-          ]
+          "description": ["The text for a template"]
         }
       },
       "org.accordproject.protocol@1.0.0.TemplateModel": {
@@ -90,14 +81,9 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Model"
           }
         },
-        "required": [
-          "$class",
-          "typeName"
-        ],
+        "required": ["$class", "typeName"],
         "$decorators": {
-          "description": [
-            "The concept declaration associated with a template"
-          ]
+          "description": ["The concept declaration associated with a template"]
         }
       },
       "org.accordproject.protocol@1.0.0.SharedModel": {
@@ -119,42 +105,26 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Model"
           }
         },
-        "required": [
-          "$class",
-          "modelId",
-          "model"
-        ],
+        "required": ["$class", "modelId", "model"],
         "$decorators": {
-          "description": [
-            "A shared data model"
-          ],
+          "description": ["A shared data model"],
           "resource": []
         }
       },
       "org.accordproject.protocol@1.0.0.CodeType": {
         "title": "CodeType",
         "description": "An instance of org.accordproject.protocol@1.0.0.CodeType",
-        "enum": [
-          "ES2015",
-          "WASM_BYTES"
-        ],
+        "enum": ["ES2015", "WASM_BYTES"],
         "$decorators": {
-          "description": [
-            "The type (language) of code"
-          ]
+          "description": ["The type (language) of code"]
         }
       },
       "org.accordproject.protocol@1.0.0.CodeEncodingType": {
         "title": "CodeEncodingType",
         "description": "An instance of org.accordproject.protocol@1.0.0.CodeEncodingType",
-        "enum": [
-          "PLAIN_TEXT",
-          "BASE64"
-        ],
+        "enum": ["PLAIN_TEXT", "BASE64"],
         "$decorators": {
-          "description": [
-            "Code encoding scheme"
-          ]
+          "description": ["Code encoding scheme"]
         }
       },
       "org.accordproject.protocol@1.0.0.Code": {
@@ -178,16 +148,9 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "type",
-          "encoding",
-          "value"
-        ],
+        "required": ["$class", "type", "encoding", "value"],
         "$decorators": {
-          "description": [
-            "Executable code"
-          ]
+          "description": ["Executable code"]
         }
       },
       "org.accordproject.protocol@1.0.0.Function": {
@@ -218,16 +181,9 @@
             "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.Code"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "requestType",
-          "code"
-        ],
+        "required": ["$class", "name", "requestType", "code"],
         "$decorators": {
-          "description": [
-            "A function for a template"
-          ]
+          "description": ["A function for a template"]
         }
       },
       "org.accordproject.protocol@1.0.0.Logic": {
@@ -251,14 +207,9 @@
             }
           }
         },
-        "required": [
-          "$class",
-          "functions"
-        ],
+        "required": ["$class", "functions"],
         "$decorators": {
-          "description": [
-            "The functions for a template"
-          ]
+          "description": ["The functions for a template"]
         }
       },
       "org.accordproject.protocol@1.0.0.Template": {
@@ -308,8 +259,14 @@
           },
           "logic": {
             "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.Logic"
+          },
+          "request": {
+            "type": "object",
+            "description": "Optional sample request JSON for testing the template logic, aligned with CTA file sample requests",
+            "additionalProperties": true
           }
         },
+
         "required": [
           "$class",
           "name",
@@ -321,9 +278,7 @@
         ],
         "$decorators": {
           "resource": [],
-          "description": [
-            "An Accord Project template"
-          ]
+          "description": ["An Accord Project template"]
         }
       },
       "org.accordproject.protocol@1.0.0.KeyValue": {
@@ -344,15 +299,9 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "key",
-          "value"
-        ],
+        "required": ["$class", "key", "value"],
         "$decorators": {
-          "description": [
-            "A key/value pair"
-          ]
+          "description": ["A key/value pair"]
         }
       },
       "org.accordproject.protocol@1.0.0.Metadata": {
@@ -373,14 +322,9 @@
             }
           }
         },
-        "required": [
-          "$class",
-          "values"
-        ],
+        "required": ["$class", "values"],
         "$decorators": {
-          "description": [
-            "Generic metadata comprised of key/value pairs"
-          ]
+          "description": ["Generic metadata comprised of key/value pairs"]
         }
       },
       "org.accordproject.protocol@1.0.0.Agreement": {
@@ -505,16 +449,9 @@
             "description": "The instance identifier for this type"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "signatory",
-          "partyId"
-        ],
+        "required": ["$class", "name", "signatory", "partyId"],
         "$decorators": {
-          "description": [
-            "A Party to an Agreement"
-          ]
+          "description": ["A Party to an Agreement"]
         }
       },
       "org.accordproject.protocol@1.0.0.Address": {
@@ -547,14 +484,9 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "streetRoad"
-        ],
+        "required": ["$class", "streetRoad"],
         "$decorators": {
-          "description": [
-            "An Address of an Agreement Party"
-          ]
+          "description": ["An Address of an Agreement Party"]
         }
       },
       "org.accordproject.protocol@1.0.0.HistoryEntry": {
@@ -578,16 +510,9 @@
             "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.Metadata"
           }
         },
-        "required": [
-          "$class",
-          "agreementStatus",
-          "data",
-          "metadata"
-        ],
+        "required": ["$class", "agreementStatus", "data", "metadata"],
         "$decorators": {
-          "description": [
-            "A history entry for an Agreement"
-          ]
+          "description": ["A history entry for an Agreement"]
         }
       },
       "org.accordproject.protocol@1.0.0.Signature": {
@@ -618,16 +543,9 @@
             }
           }
         },
-        "required": [
-          "$class",
-          "signatory",
-          "metadata",
-          "signatureImage"
-        ],
+        "required": ["$class", "signatory", "metadata", "signatureImage"],
         "$decorators": {
-          "description": [
-            "A signature of an Agreement Party"
-          ]
+          "description": ["A signature of an Agreement Party"]
         }
       },
       "org.accordproject.protocol@1.0.0.ConversionOptions": {
@@ -642,13 +560,9 @@
             "description": "The class identifier for org.accordproject.protocol@1.0.0.ConversionOptions"
           }
         },
-        "required": [
-          "$class"
-        ],
+        "required": ["$class"],
         "$decorators": {
-          "description": [
-            "Abstract conversion options"
-          ]
+          "description": ["Abstract conversion options"]
         }
       },
       "org.accordproject.protocol@1.0.0.PdfConversionOptions": {
@@ -666,13 +580,9 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class"
-        ],
+        "required": ["$class"],
         "$decorators": {
-          "description": [
-            "PDF conversion options"
-          ]
+          "description": ["PDF conversion options"]
         }
       },
       "org.accordproject.protocol@1.0.0.FeatureType": {
@@ -689,9 +599,7 @@
           "SHARED_MODEL_MANAGE"
         ],
         "$decorators": {
-          "description": [
-            "Server feature identifiers"
-          ]
+          "description": ["Server feature identifiers"]
         }
       },
       "org.accordproject.protocol@1.0.0.Capabilities": {
@@ -712,14 +620,9 @@
             }
           }
         },
-        "required": [
-          "$class",
-          "features"
-        ],
+        "required": ["$class", "features"],
         "$decorators": {
-          "description": [
-            "Server capabilities"
-          ]
+          "description": ["Server capabilities"]
         }
       },
       "org.accordproject.protocol@1.0.0.TriggerRequest": {
@@ -740,15 +643,9 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "functionName",
-          "payload"
-        ],
+        "required": ["$class", "functionName", "payload"],
         "$decorators": {
-          "description": [
-            "Trigger a function with a JSON payload"
-          ]
+          "description": ["Trigger a function with a JSON payload"]
         }
       },
       "org.accordproject.protocol@1.0.0.TriggerResponse": {
@@ -775,29 +672,17 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "isError"
-        ],
+        "required": ["$class", "isError"],
         "$decorators": {
-          "description": [
-            "Response of triggering a function"
-          ]
+          "description": ["Response of triggering a function"]
         }
       },
       "org.accordproject.protocol@1.0.0.AgreementStatusType": {
         "title": "AgreementStatusType",
         "description": "An instance of org.accordproject.protocol@1.0.0.AgreementStatusType",
-        "enum": [
-          "DRAFT",
-          "SIGNNG",
-          "COMPLETED",
-          "SUPERSEDED"
-        ],
+        "enum": ["DRAFT", "SIGNNG", "COMPLETED", "SUPERSEDED"],
         "$decorators": {
-          "description": [
-            "Runtime status of an agreement"
-          ]
+          "description": ["Runtime status of an agreement"]
         }
       },
       "org.accordproject.party@0.2.0.Party": {
@@ -816,10 +701,7 @@
             "description": "The instance identifier for this type"
           }
         },
-        "required": [
-          "$class",
-          "partyId"
-        ]
+        "required": ["$class", "partyId"]
       },
       "concerto.metamodel@0.4.0.Position": {
         "title": "Position",
@@ -842,12 +724,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class",
-          "line",
-          "column",
-          "offset"
-        ]
+        "required": ["$class", "line", "column", "offset"]
       },
       "concerto.metamodel@0.4.0.Range": {
         "title": "Range",
@@ -870,11 +747,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "start",
-          "end"
-        ]
+        "required": ["$class", "start", "end"]
       },
       "concerto.metamodel@0.4.0.TypeIdentifier": {
         "title": "TypeIdentifier",
@@ -894,10 +767,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "name"
-        ]
+        "required": ["$class", "name"]
       },
       "concerto.metamodel@0.4.0.DecoratorLiteral": {
         "title": "DecoratorLiteral",
@@ -914,9 +784,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "concerto.metamodel@0.4.0.DecoratorString": {
         "title": "DecoratorString",
@@ -936,10 +804,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "value"
-        ]
+        "required": ["$class", "value"]
       },
       "concerto.metamodel@0.4.0.DecoratorNumber": {
         "title": "DecoratorNumber",
@@ -959,10 +824,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "value"
-        ]
+        "required": ["$class", "value"]
       },
       "concerto.metamodel@0.4.0.DecoratorBoolean": {
         "title": "DecoratorBoolean",
@@ -982,10 +844,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "value"
-        ]
+        "required": ["$class", "value"]
       },
       "concerto.metamodel@0.4.0.DecoratorTypeReference": {
         "title": "DecoratorTypeReference",
@@ -1008,11 +867,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "type",
-          "isArray"
-        ]
+        "required": ["$class", "type", "isArray"]
       },
       "concerto.metamodel@0.4.0.Decorator": {
         "title": "Decorator",
@@ -1054,10 +909,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "name"
-        ]
+        "required": ["$class", "name"]
       },
       "concerto.metamodel@0.4.0.Identified": {
         "title": "Identified",
@@ -1071,9 +923,7 @@
             "description": "The class identifier for concerto.metamodel@0.4.0.Identified"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "concerto.metamodel@0.4.0.IdentifiedBy": {
         "title": "IdentifiedBy",
@@ -1090,10 +940,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "name"
-        ]
+        "required": ["$class", "name"]
       },
       "concerto.metamodel@0.4.0.Declaration": {
         "title": "Declaration",
@@ -1120,10 +967,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "name"
-        ]
+        "required": ["$class", "name"]
       },
       "concerto.metamodel@0.4.0.EnumDeclaration": {
         "title": "EnumDeclaration",
@@ -1156,11 +1000,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "properties",
-          "name"
-        ]
+        "required": ["$class", "properties", "name"]
       },
       "concerto.metamodel@0.4.0.EnumProperty": {
         "title": "EnumProperty",
@@ -1187,10 +1027,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "name"
-        ]
+        "required": ["$class", "name"]
       },
       "concerto.metamodel@0.4.0.ConceptDeclaration": {
         "title": "ConceptDeclaration",
@@ -1267,12 +1104,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "isAbstract",
-          "properties",
-          "name"
-        ]
+        "required": ["$class", "isAbstract", "properties", "name"]
       },
       "concerto.metamodel@0.4.0.AssetDeclaration": {
         "title": "AssetDeclaration",
@@ -1349,12 +1181,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "isAbstract",
-          "properties",
-          "name"
-        ]
+        "required": ["$class", "isAbstract", "properties", "name"]
       },
       "concerto.metamodel@0.4.0.ParticipantDeclaration": {
         "title": "ParticipantDeclaration",
@@ -1431,12 +1258,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "isAbstract",
-          "properties",
-          "name"
-        ]
+        "required": ["$class", "isAbstract", "properties", "name"]
       },
       "concerto.metamodel@0.4.0.TransactionDeclaration": {
         "title": "TransactionDeclaration",
@@ -1513,12 +1335,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "isAbstract",
-          "properties",
-          "name"
-        ]
+        "required": ["$class", "isAbstract", "properties", "name"]
       },
       "concerto.metamodel@0.4.0.EventDeclaration": {
         "title": "EventDeclaration",
@@ -1595,12 +1412,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "isAbstract",
-          "properties",
-          "name"
-        ]
+        "required": ["$class", "isAbstract", "properties", "name"]
       },
       "concerto.metamodel@0.4.0.Property": {
         "title": "Property",
@@ -1633,12 +1445,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
+        "required": ["$class", "name", "isArray", "isOptional"]
       },
       "concerto.metamodel@0.4.0.RelationshipProperty": {
         "title": "RelationshipProperty",
@@ -1674,13 +1481,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "type",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
+        "required": ["$class", "type", "name", "isArray", "isOptional"]
       },
       "concerto.metamodel@0.4.0.ObjectProperty": {
         "title": "ObjectProperty",
@@ -1719,13 +1520,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "type",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
+        "required": ["$class", "type", "name", "isArray", "isOptional"]
       },
       "concerto.metamodel@0.4.0.BooleanProperty": {
         "title": "BooleanProperty",
@@ -1761,12 +1556,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
+        "required": ["$class", "name", "isArray", "isOptional"]
       },
       "concerto.metamodel@0.4.0.DateTimeProperty": {
         "title": "DateTimeProperty",
@@ -1799,12 +1589,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
+        "required": ["$class", "name", "isArray", "isOptional"]
       },
       "concerto.metamodel@0.4.0.StringProperty": {
         "title": "StringProperty",
@@ -1843,12 +1628,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
+        "required": ["$class", "name", "isArray", "isOptional"]
       },
       "concerto.metamodel@0.4.0.StringRegexValidator": {
         "title": "StringRegexValidator",
@@ -1868,11 +1648,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "pattern",
-          "flags"
-        ]
+        "required": ["$class", "pattern", "flags"]
       },
       "concerto.metamodel@0.4.0.DoubleProperty": {
         "title": "DoubleProperty",
@@ -1911,12 +1687,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
+        "required": ["$class", "name", "isArray", "isOptional"]
       },
       "concerto.metamodel@0.4.0.DoubleDomainValidator": {
         "title": "DoubleDomainValidator",
@@ -1936,9 +1707,7 @@
             "type": "number"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "concerto.metamodel@0.4.0.IntegerProperty": {
         "title": "IntegerProperty",
@@ -1977,12 +1746,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
+        "required": ["$class", "name", "isArray", "isOptional"]
       },
       "concerto.metamodel@0.4.0.IntegerDomainValidator": {
         "title": "IntegerDomainValidator",
@@ -2002,9 +1766,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "concerto.metamodel@0.4.0.LongProperty": {
         "title": "LongProperty",
@@ -2043,12 +1805,7 @@
             "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
+        "required": ["$class", "name", "isArray", "isOptional"]
       },
       "concerto.metamodel@0.4.0.LongDomainValidator": {
         "title": "LongDomainValidator",
@@ -2068,9 +1825,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "concerto.metamodel@0.4.0.Import": {
         "title": "Import",
@@ -2090,10 +1845,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "namespace"
-        ]
+        "required": ["$class", "namespace"]
       },
       "concerto.metamodel@0.4.0.ImportAll": {
         "title": "ImportAll",
@@ -2113,10 +1865,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "namespace"
-        ]
+        "required": ["$class", "namespace"]
       },
       "concerto.metamodel@0.4.0.ImportType": {
         "title": "ImportType",
@@ -2139,11 +1888,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "namespace"
-        ]
+        "required": ["$class", "name", "namespace"]
       },
       "concerto.metamodel@0.4.0.Model": {
         "title": "Model",
@@ -2210,10 +1955,7 @@
             }
           }
         },
-        "required": [
-          "$class",
-          "namespace"
-        ]
+        "required": ["$class", "namespace"]
       },
       "concerto.metamodel@0.4.0.Models": {
         "title": "Models",
@@ -2233,10 +1975,7 @@
             }
           }
         },
-        "required": [
-          "$class",
-          "models"
-        ]
+        "required": ["$class", "models"]
       },
       "org.accordproject.commonmark@0.5.0.Node": {
         "title": "Node",
@@ -2347,9 +2086,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Root": {
         "title": "Root",
@@ -2460,9 +2197,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Child": {
         "title": "Child",
@@ -2573,9 +2308,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Text": {
         "title": "Text",
@@ -2686,9 +2419,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Attribute": {
         "title": "Attribute",
@@ -2708,11 +2439,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "$class",
-          "name",
-          "value"
-        ]
+        "required": ["$class", "name", "value"]
       },
       "org.accordproject.commonmark@0.5.0.TagInfo": {
         "title": "TagInfo",
@@ -2868,9 +2595,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Code": {
         "title": "Code",
@@ -2984,9 +2709,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.HtmlInline": {
         "title": "HtmlInline",
@@ -3100,9 +2823,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.HtmlBlock": {
         "title": "HtmlBlock",
@@ -3216,9 +2937,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Emph": {
         "title": "Emph",
@@ -3329,9 +3048,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Strong": {
         "title": "Strong",
@@ -3442,9 +3159,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.BlockQuote": {
         "title": "BlockQuote",
@@ -3555,9 +3270,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Heading": {
         "title": "Heading",
@@ -3671,10 +3384,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class",
-          "level"
-        ]
+        "required": ["$class", "level"]
       },
       "org.accordproject.commonmark@0.5.0.ThematicBreak": {
         "title": "ThematicBreak",
@@ -3785,9 +3495,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Softbreak": {
         "title": "Softbreak",
@@ -3898,9 +3606,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Linebreak": {
         "title": "Linebreak",
@@ -4011,9 +3717,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Link": {
         "title": "Link",
@@ -4130,11 +3834,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class",
-          "destination",
-          "title"
-        ]
+        "required": ["$class", "destination", "title"]
       },
       "org.accordproject.commonmark@0.5.0.Image": {
         "title": "Image",
@@ -4251,11 +3951,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class",
-          "destination",
-          "title"
-        ]
+        "required": ["$class", "destination", "title"]
       },
       "org.accordproject.commonmark@0.5.0.Paragraph": {
         "title": "Paragraph",
@@ -4366,9 +4062,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.List": {
         "title": "List",
@@ -4491,11 +4185,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class",
-          "type",
-          "tight"
-        ]
+        "required": ["$class", "type", "tight"]
       },
       "org.accordproject.commonmark@0.5.0.Item": {
         "title": "Item",
@@ -4606,9 +4296,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.Document": {
         "title": "Document",
@@ -4722,10 +4410,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class",
-          "xmlns"
-        ]
+        "required": ["$class", "xmlns"]
       },
       "org.accordproject.commonmark@0.5.0.Table": {
         "title": "Table",
@@ -4836,9 +4521,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.TableHead": {
         "title": "TableHead",
@@ -4949,9 +4632,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.TableBody": {
         "title": "TableBody",
@@ -5062,9 +4743,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.TableRow": {
         "title": "TableRow",
@@ -5175,9 +4854,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.HeaderCell": {
         "title": "HeaderCell",
@@ -5288,9 +4965,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       },
       "org.accordproject.commonmark@0.5.0.TableCell": {
         "title": "TableCell",
@@ -5401,9 +5076,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "$class"
-        ]
+        "required": ["$class"]
       }
     }
   },
@@ -5430,9 +5103,7 @@
         "operationId": "listSharedmodels",
         "summary": "List All Sharedmodels",
         "description": "Gets a list of all `sharedmodel` entities.",
-        "tags": [
-          "sharedmodels"
-        ]
+        "tags": ["sharedmodels"]
       },
       "post": {
         "requestBody": {
@@ -5454,9 +5125,7 @@
         "operationId": "createSharedmodel",
         "summary": "Create a Sharedmodel",
         "description": "Creates a new instance of a `sharedmodel`.",
-        "tags": [
-          "sharedmodels"
-        ]
+        "tags": ["sharedmodels"]
       }
     },
     "/sharedmodels/{modelId}": {
@@ -5478,9 +5147,7 @@
         "operationId": "getSharedmodel",
         "summary": "Get a sharedmodel",
         "description": "Gets the details of a single instance of a `sharedmodel`.",
-        "tags": [
-          "sharedmodels"
-        ]
+        "tags": ["sharedmodels"]
       },
       "put": {
         "requestBody": {
@@ -5502,9 +5169,7 @@
         "operationId": "replaceSharedmodel",
         "summary": "Update a sharedmodel",
         "description": "Updates an existing `sharedmodel`.",
-        "tags": [
-          "sharedmodels"
-        ]
+        "tags": ["sharedmodels"]
       },
       "delete": {
         "responses": {
@@ -5515,9 +5180,7 @@
         "operationId": "deleteSharedmodel",
         "summary": "Delete a sharedmodel",
         "description": "Deletes an existing `sharedmodel`.",
-        "tags": [
-          "sharedmodels"
-        ]
+        "tags": ["sharedmodels"]
       },
       "parameters": [
         {
@@ -5553,9 +5216,7 @@
         "operationId": "listTemplates",
         "summary": "List All Templates",
         "description": "Gets a list of all `template` entities.",
-        "tags": [
-          "templates"
-        ]
+        "tags": ["templates"]
       },
       "post": {
         "requestBody": {
@@ -5577,9 +5238,7 @@
         "operationId": "createTemplate",
         "summary": "Create a Template",
         "description": "Creates a new instance of a `template`.",
-        "tags": [
-          "templates"
-        ]
+        "tags": ["templates"]
       }
     },
     "/templates/{name}": {
@@ -5601,9 +5260,7 @@
         "operationId": "getTemplate",
         "summary": "Get a template",
         "description": "Gets the details of a single instance of a `template`.",
-        "tags": [
-          "templates"
-        ]
+        "tags": ["templates"]
       },
       "put": {
         "requestBody": {
@@ -5625,9 +5282,7 @@
         "operationId": "replaceTemplate",
         "summary": "Update a template",
         "description": "Updates an existing `template`.",
-        "tags": [
-          "templates"
-        ]
+        "tags": ["templates"]
       },
       "delete": {
         "responses": {
@@ -5638,9 +5293,7 @@
         "operationId": "deleteTemplate",
         "summary": "Delete a template",
         "description": "Deletes an existing `template`.",
-        "tags": [
-          "templates"
-        ]
+        "tags": ["templates"]
       },
       "parameters": [
         {
@@ -5676,9 +5329,7 @@
         "operationId": "listAgreements",
         "summary": "List All Agreements",
         "description": "Gets a list of all `agreement` entities.",
-        "tags": [
-          "agreements"
-        ]
+        "tags": ["agreements"]
       },
       "post": {
         "requestBody": {
@@ -5700,9 +5351,7 @@
         "operationId": "createAgreement",
         "summary": "Create a Agreement",
         "description": "Creates a new instance of a `agreement`.",
-        "tags": [
-          "agreements"
-        ]
+        "tags": ["agreements"]
       }
     },
     "/agreements/{agreementId}": {
@@ -5724,9 +5373,7 @@
         "operationId": "getAgreement",
         "summary": "Get a agreement",
         "description": "Gets the details of a single instance of a `agreement`.",
-        "tags": [
-          "agreements"
-        ]
+        "tags": ["agreements"]
       },
       "put": {
         "requestBody": {
@@ -5748,9 +5395,7 @@
         "operationId": "replaceAgreement",
         "summary": "Update a agreement",
         "description": "Updates an existing `agreement`.",
-        "tags": [
-          "agreements"
-        ]
+        "tags": ["agreements"]
       },
       "delete": {
         "responses": {
@@ -5761,9 +5406,7 @@
         "operationId": "deleteAgreement",
         "summary": "Delete a agreement",
         "description": "Deletes an existing `agreement`.",
-        "tags": [
-          "agreements"
-        ]
+        "tags": ["agreements"]
       },
       "parameters": [
         {
@@ -5808,9 +5451,7 @@
         "operationId": "convertAgreementPdf",
         "summary": "Convert agreement to PDF",
         "description": "Converts an existing `agreement` to PDF.",
-        "tags": [
-          "agreements"
-        ]
+        "tags": ["agreements"]
       },
       "parameters": [
         {
@@ -5854,9 +5495,7 @@
         "operationId": "triggerAgreement",
         "summary": "Trigger an agreement",
         "description": "Sends data to an existing agreement.",
-        "tags": [
-          "agreements"
-        ]
+        "tags": ["agreements"]
       },
       "parameters": [
         {
@@ -5889,9 +5528,7 @@
         "operationId": "getCapabilities",
         "summary": "Get server capabilities",
         "description": "Retrieve the supported features of the server.",
-        "tags": [
-          "capabilities"
-        ]
+        "tags": ["capabilities"]
       }
     }
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,48 +1,86 @@
-import 'source-map-support/register';
-import OpenAPIBackend, { Request } from 'openapi-backend';
-import Express from 'express';
-import morgan from 'morgan'
-import path from 'path';
+import "source-map-support/register";
+import OpenAPIBackend, { Request } from "openapi-backend";
+import Express from "express";
+import morgan from "morgan";
+import path from "path";
+import { Template } from "./types/template";
 
-import { Request as ExpressReq, Response as ExpressRes } from 'express';
+import { Request as ExpressReq, Response as ExpressRes } from "express";
 
 const app = Express();
 app.use(Express.json());
 
-const openApiPath = path.join(__dirname, '..', '..', 'openapi.json');
+const openApiPath = path.join(__dirname, "..", "..", "openapi.json");
 console.log(openApiPath);
 
 // define api
 const api = new OpenAPIBackend({
-    quick: true, // disabled validation of OpenAPI on load
-    definition: openApiPath,
-    handlers: {
-        listTemplates: async (c, req: Express.Request, res: Express.Response) =>
-            res.status(200).json([]),
-        createTemplate: async (c, req: Express.Request, res: Express.Response) =>
-            res.status(200).json({}),
-        getTemplate: async (c, req: Express.Request, res: Express.Response) =>
-            res.status(200).json({}),
-        replaceTemplate: async (c, req: Express.Request, res: Express.Response) =>
-            res.status(200).json({}),
-        deleteTemplate: async (c, req: Express.Request, res: Express.Response) =>
-            res.status(200).json({}),
-        validationFail: async (c, req: ExpressReq, res: ExpressRes) => res.status(400).json({ err: c.validation.errors }),
-        notFound: async (c, req: ExpressReq, res: ExpressRes) => res.status(404).json({ err: 'not found' }),
-        notImplemented: async (c, req: ExpressReq, res: ExpressRes) => {
-            const { status, mock } = c.api.mockResponseForOperation(c.operation.operationId);
-            return res.status(status).json(mock);
-        },
+  quick: true, // disabled validation of OpenAPI on load
+  definition: openApiPath,
+  handlers: {
+    listTemplates: async (c, req: Express.Request, res: Express.Response) =>
+      res.status(200).json([]),
+    createTemplate: async (c, req: ExpressReq, res: ExpressRes) => {
+      const templateData = req.body as Template;
+      const {
+        $class,
+        name,
+        author,
+        displayName,
+        version,
+        description,
+        license,
+        keywords,
+        logo,
+        templateModel,
+        text,
+        logic,
+        request,
+      } = templateData;
+      return res
+        .status(201)
+        .json({
+          $class,
+          name,
+          author,
+          displayName,
+          version,
+          description,
+          license,
+          keywords,
+          logo,
+          templateModel,
+          text,
+          logic,
+          request,
+        });
     },
+    getTemplate: async (c, req: Express.Request, res: Express.Response) =>
+      res.status(200).json({}),
+    replaceTemplate: async (c, req: Express.Request, res: Express.Response) =>
+      res.status(200).json({}),
+    deleteTemplate: async (c, req: Express.Request, res: Express.Response) =>
+      res.status(200).json({}),
+    validationFail: async (c, req: ExpressReq, res: ExpressRes) =>
+      res.status(400).json({ err: c.validation.errors }),
+    notFound: async (c, req: ExpressReq, res: ExpressRes) =>
+      res.status(404).json({ err: "not found" }),
+    notImplemented: async (c, req: ExpressReq, res: ExpressRes) => {
+      const { status, mock } = c.api.mockResponseForOperation(
+        c.operation.operationId
+      );
+      return res.status(status).json(mock);
+    },
+  },
 });
 
 api.init();
 
 // logging
-app.use(morgan('combined'));
+app.use(morgan("combined"));
 
 // use as express middleware
 app.use((req, res) => api.handleRequest(req as Request, req, res));
 
 // start server
-app.listen(9000, () => console.info('api listening at http://localhost:9000'));
+app.listen(9000, () => console.info("api listening at http://localhost:9000"));

--- a/server/types/template.ts
+++ b/server/types/template.ts
@@ -1,0 +1,15 @@
+export interface Template {
+  $class: string;
+  name: string;
+  author: string;
+  displayName?: string;
+  version: string;
+  description?: string;
+  license: string;
+  keywords?: string[];
+  logo?: any; // Placeholder for org.accordproject.protocol@1.0.0.Blob
+  templateModel: any; // Placeholder for org.accordproject.protocol@1.0.0.TemplateModel
+  text: any; // Placeholder for org.accordproject.protocol@1.0.0.Text
+  logic?: any; // Placeholder for org.accordproject.protocol@1.0.0.Logic
+  request?: Record<string, any>; // Optional sample request
+}

--- a/specification.md
+++ b/specification.md
@@ -4,6 +4,16 @@ This document describes the 1.0.x version of the language server protocol. An im
 
 Note: edits to this specification can be made via a pull request against [this markdown document](specification.md).
 
+### Template Schema
+The `org.accordproject.protocol@1.0.0.Template` object now includes an optional `request` attribute:
+- `request` (optional): A JSON object representing a sample request for testing the template’s logic, aligned with CTA file sample requests. Example:
+  ```json
+  {
+    "partyA": "Alice",
+    "partyB": "Bob",
+    "amount": 1000
+  }
+
 ## Open API
 
 The protocol is defined via an [Open API document](./openapi.json), which specified the required API methods as well as their expected request and response data formats.


### PR DESCRIPTION
Added an optional request attribute to org.accordproject.protocol@1.0.0.Template in openapi.json, updated server implementation and documented in specification.md. Successfully tested with a sample request, aligning APAP with CTA files for testing template logic.

![Screenshot (583)](https://github.com/user-attachments/assets/25af7fb2-e5bd-4674-9f5a-125fdc2ad541)

