### PR TITLE
feat: return 409 Conflict on unique constraint violation

### DIFF
--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -266,7 +266,15 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 }
 
                 res.json(inserted[0]);
-            } catch (error) {
+            } catch (error: any) {
+                // Handle Unique Constraint Violation (Duplicate URI)
+                if (error?.code === '23505') {
+                    return res.status(409).json({
+                        error: 'Conflict',
+                        details: `A resource with this unique identifier already exists for ${typeName}.`
+                    });
+                }
+
                 const message = error instanceof Error ? error.message : 'Unknown error';
                 res.status(500).json({ error: message });
             }
@@ -348,7 +356,15 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 }
 
                 res.json(updated[0]);
-            } catch (error) {
+            } catch (error: any) {
+                // FIXED: Handle Unique Constraint Violation (Duplicate URI during Update)
+                if (error?.code === '23505') {
+                    return res.status(409).json({
+                        error: 'Conflict',
+                        details: `A resource with this unique identifier already exists for ${typeName}.`
+                    });
+                }
+
                 const message = error instanceof Error ? error.message : 'Unknown error';
                 res.status(500).json({ error: message });
             }


### PR DESCRIPTION
### Description
This PR addresses the handling of duplicate resource identifiers (URIs) for Templates and Agreements.

Previously, attempting to create a resource with a `uri` that already existed would trigger a database-level constraint violation, resulting in an unhandled `500 Internal Server Error`. This behavior was noted in the discussion of Issue #64 regarding behavior for managing unique identifiers.

### Changes
* **Modified `server/handlers/crud.ts`**: Updated the `POST` and `PUT` error handlers to explicitly catch PostgreSQL error code `23505` (`unique_violation`).
* **Response Handling**: The server now returns a standard `409 Conflict` HTTP status code with a descriptive error message when a uniqueness constraint is violated, rather than a generic server error.

### Related Issues
* Addresses parts of #64 (Handling conflicts for URI uniqueness).

### Verification
* Ran `npm test` in `server/` directory.
* **Result**: All 37 tests passed, confirming no regression in existing CRUD logic.
