### PR TITLE
feat: add obligation definitions to protocol

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -398,147 +398,32 @@
                   </li>
                 
                   <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Node" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Node</a>
+                    <a href="#tocS_org.accordproject.protocol@1.0.0.ObligationStatus" class="toc-h2 toc-link" data-title="">org.accordproject.protocol@1.0.0.ObligationStatus</a>
                     
                   </li>
                 
                   <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Root" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Root</a>
+                    <a href="#tocS_org.accordproject.protocol@1.0.0.BaseObligation" class="toc-h2 toc-link" data-title="">org.accordproject.protocol@1.0.0.BaseObligation</a>
                     
                   </li>
                 
                   <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Child" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Child</a>
+                    <a href="#tocS_org.accordproject.protocol@1.0.0.OwnershipTransferObligation" class="toc-h2 toc-link" data-title="">org.accordproject.protocol@1.0.0.OwnershipTransferObligation</a>
                     
                   </li>
                 
                   <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Text" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Text</a>
+                    <a href="#tocS_org.accordproject.protocol@1.0.0.PaymentObligation" class="toc-h2 toc-link" data-title="">org.accordproject.protocol@1.0.0.PaymentObligation</a>
                     
                   </li>
                 
                   <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Attribute" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Attribute</a>
+                    <a href="#tocS_org.accordproject.protocol@1.0.0.EscrowReleaseObligation" class="toc-h2 toc-link" data-title="">org.accordproject.protocol@1.0.0.EscrowReleaseObligation</a>
                     
                   </li>
                 
                   <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.TagInfo" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.TagInfo</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.CodeBlock" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.CodeBlock</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Code" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Code</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.HtmlInline" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.HtmlInline</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.HtmlBlock" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.HtmlBlock</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Emph" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Emph</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Strong" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Strong</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.BlockQuote" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.BlockQuote</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Heading" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Heading</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.ThematicBreak" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.ThematicBreak</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Softbreak" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Softbreak</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Linebreak" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Linebreak</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Link" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Link</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Image" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Image</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Paragraph" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Paragraph</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.List" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.List</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Item" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Item</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Document" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Document</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Table" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Table</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.TableHead" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.TableHead</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.TableBody" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.TableBody</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.TableRow" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.TableRow</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.HeaderCell" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.HeaderCell</a>
-                    
-                  </li>
-                
-                  <li>
-                    <a href="#tocS_org.accordproject.commonmark@0.5.0.TableCell" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.TableCell</a>
+                    <a href="#tocS_org.accordproject.protocol@1.0.0.AccessControlObligation" class="toc-h2 toc-link" data-title="">org.accordproject.protocol@1.0.0.AccessControlObligation</a>
                     
                   </li>
                 
@@ -729,6 +614,151 @@
                 
                   <li>
                     <a href="#tocS_concerto.metamodel@0.4.0.Models" class="toc-h2 toc-link" data-title="">concerto.metamodel@0.4.0.Models</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Node" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Node</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Root" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Root</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Child" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Child</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Text" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Text</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Attribute" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Attribute</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.TagInfo" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.TagInfo</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.CodeBlock" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.CodeBlock</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Code" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Code</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.HtmlInline" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.HtmlInline</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.HtmlBlock" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.HtmlBlock</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Emph" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Emph</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Strong" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Strong</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.BlockQuote" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.BlockQuote</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Heading" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Heading</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.ThematicBreak" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.ThematicBreak</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Softbreak" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Softbreak</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Linebreak" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Linebreak</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Link" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Link</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Image" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Image</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Paragraph" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Paragraph</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.List" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.List</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Item" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Item</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Document" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Document</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.Table" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.Table</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.TableHead" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.TableHead</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.TableBody" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.TableBody</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.TableRow" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.TableRow</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.HeaderCell" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.HeaderCell</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#tocS_org.accordproject.commonmark@0.5.0.TableCell" class="toc-h2 toc-link" data-title="">org.accordproject.commonmark@0.5.0.TableCell</a>
                     
                   </li>
                 
@@ -26268,7 +26298,7 @@ This operation does not require authentication
 <blockquote>
 <p>200 Response</p>
 </blockquote>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.TriggerResponse"</span><span class="token punctuation">,</span><br>  <span class="token property">"result"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isError"</span><span class="token operator">:</span> <span class="token boolean">true</span><span class="token punctuation">,</span><br>  <span class="token property">"errorMessage"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"errorDetails"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span></code></pre>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.TriggerResponse"</span><span class="token punctuation">,</span><br>  <span class="token property">"result"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"obligations"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.BaseObligation"</span><span class="token punctuation">,</span><br>      <span class="token property">"status"</span><span class="token operator">:</span> <span class="token string">"ACTIVE"</span><span class="token punctuation">,</span><br>      <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"isError"</span><span class="token operator">:</span> <span class="token boolean">true</span><span class="token punctuation">,</span><br>  <span class="token property">"errorMessage"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"errorDetails"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span></code></pre>
 <h3 id="triggeragreement-responses">Responses</h3>
 <table>
 <thead>
@@ -27973,7 +28003,7 @@ This operation does not require authentication
 <a id="schema_org.accordproject.protocol@1.0.0.TriggerResponse"></a>
 <a id="tocSorg.accordproject.protocol@1.0.0.triggerresponse"></a>
 <a id="tocsorg.accordproject.protocol@1.0.0.triggerresponse"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.TriggerResponse"</span><span class="token punctuation">,</span><br>  <span class="token property">"result"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isError"</span><span class="token operator">:</span> <span class="token boolean">true</span><span class="token punctuation">,</span><br>  <span class="token property">"errorMessage"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"errorDetails"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.TriggerResponse"</span><span class="token punctuation">,</span><br>  <span class="token property">"result"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"obligations"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.BaseObligation"</span><span class="token punctuation">,</span><br>      <span class="token property">"status"</span><span class="token operator">:</span> <span class="token string">"ACTIVE"</span><span class="token punctuation">,</span><br>      <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"isError"</span><span class="token operator">:</span> <span class="token boolean">true</span><span class="token punctuation">,</span><br>  <span class="token property">"errorMessage"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"errorDetails"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>TriggerResponse</p>
 <h3 id="properties-30">Properties</h3>
 <table>
@@ -28002,6 +28032,132 @@ This operation does not require authentication
 <td>none</td>
 </tr>
 <tr>
+<td>obligations</td>
+<td>[anyOf]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaorg.accordproject.protocol@1.0.0.baseobligation">org.accordproject.protocol@1.0.0.BaseObligation</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.BaseObligation</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaorg.accordproject.protocol@1.0.0.ownershiptransferobligation">org.accordproject.protocol@1.0.0.OwnershipTransferObligation</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.OwnershipTransferObligation</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaorg.accordproject.protocol@1.0.0.paymentobligation">org.accordproject.protocol@1.0.0.PaymentObligation</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.PaymentObligation</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaorg.accordproject.protocol@1.0.0.escrowreleaseobligation">org.accordproject.protocol@1.0.0.EscrowReleaseObligation</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.EscrowReleaseObligation</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaorg.accordproject.protocol@1.0.0.accesscontrolobligation">org.accordproject.protocol@1.0.0.AccessControlObligation</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.AccessControlObligation</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
 <td>isError</td>
 <td>boolean</td>
 <td>true</td>
@@ -28024,6 +28180,4165 @@ This operation does not require authentication
 </tr>
 </tbody>
 </table>
+<h2 id="tocS_org.accordproject.protocol@1.0.0.ObligationStatus">org.accordproject.protocol@1.0.0.ObligationStatus</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.obligationstatus"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.ObligationStatus"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.obligationstatus"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.obligationstatus"></a>
+<pre class="language-json"><code class="language-json"><span class="token string">"ACTIVE"</span><br></code></pre>
+<p>ObligationStatus</p>
+<h3 id="properties-31">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>ObligationStatus</td>
+<td>any</td>
+<td>false</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.ObligationStatus</td>
+</tr>
+</tbody>
+</table>
+<h4 id="enumerated-values-6">Enumerated Values</h4>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>ObligationStatus</td>
+<td>ACTIVE</td>
+</tr>
+<tr>
+<td>ObligationStatus</td>
+<td>FULFILLED</td>
+</tr>
+<tr>
+<td>ObligationStatus</td>
+<td>VIOLATED</td>
+</tr>
+<tr>
+<td>ObligationStatus</td>
+<td>PARTIALLY_FULFILLED</td>
+</tr>
+<tr>
+<td>ObligationStatus</td>
+<td>DISPUTED</td>
+</tr>
+<tr>
+<td>ObligationStatus</td>
+<td>UNDER_REVIEW</td>
+</tr>
+<tr>
+<td>ObligationStatus</td>
+<td>RESOLVED_WITH_ADJUSTMENT</td>
+</tr>
+<tr>
+<td>ObligationStatus</td>
+<td>CANCELLED</td>
+</tr>
+<tr>
+<td>ObligationStatus</td>
+<td>SUPERSEDED</td>
+</tr>
+<tr>
+<td>ObligationStatus</td>
+<td>ERROR</td>
+</tr>
+<tr>
+<td>ObligationStatus</td>
+<td>OTHER</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_org.accordproject.protocol@1.0.0.BaseObligation">org.accordproject.protocol@1.0.0.BaseObligation</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.baseobligation"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.BaseObligation"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.baseobligation"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.baseobligation"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.BaseObligation"</span><span class="token punctuation">,</span><br>  <span class="token property">"status"</span><span class="token operator">:</span> <span class="token string">"ACTIVE"</span><span class="token punctuation">,</span><br>  <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>BaseObligation</p>
+<h3 id="properties-32">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for org.accordproject.protocol@1.0.0.BaseObligation</td>
+</tr>
+<tr>
+<td>status</td>
+<td><a href="#schemaorg.accordproject.protocol@1.0.0.obligationstatus">org.accordproject.protocol@1.0.0.ObligationStatus</a></td>
+<td>true</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.ObligationStatus</td>
+</tr>
+<tr>
+<td>description</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_org.accordproject.protocol@1.0.0.OwnershipTransferObligation">org.accordproject.protocol@1.0.0.OwnershipTransferObligation</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.ownershiptransferobligation"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.OwnershipTransferObligation"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.ownershiptransferobligation"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.ownershiptransferobligation"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.OwnershipTransferObligation"</span><span class="token punctuation">,</span><br>  <span class="token property">"assetIdentifier"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"currentOwner"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"newOwner"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"status"</span><span class="token operator">:</span> <span class="token string">"ACTIVE"</span><span class="token punctuation">,</span><br>  <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>OwnershipTransferObligation</p>
+<h3 id="properties-33">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for org.accordproject.protocol@1.0.0.OwnershipTransferObligation</td>
+</tr>
+<tr>
+<td>assetIdentifier</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>currentOwner</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>newOwner</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>status</td>
+<td><a href="#schemaorg.accordproject.protocol@1.0.0.obligationstatus">org.accordproject.protocol@1.0.0.ObligationStatus</a></td>
+<td>true</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.ObligationStatus</td>
+</tr>
+<tr>
+<td>description</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_org.accordproject.protocol@1.0.0.PaymentObligation">org.accordproject.protocol@1.0.0.PaymentObligation</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.paymentobligation"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.PaymentObligation"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.paymentobligation"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.paymentobligation"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.PaymentObligation"</span><span class="token punctuation">,</span><br>  <span class="token property">"debtor"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"creditor"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"amount"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"currency"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"status"</span><span class="token operator">:</span> <span class="token string">"ACTIVE"</span><span class="token punctuation">,</span><br>  <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>PaymentObligation</p>
+<h3 id="properties-34">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for org.accordproject.protocol@1.0.0.PaymentObligation</td>
+</tr>
+<tr>
+<td>debtor</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>creditor</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>amount</td>
+<td>number</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>currency</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>status</td>
+<td><a href="#schemaorg.accordproject.protocol@1.0.0.obligationstatus">org.accordproject.protocol@1.0.0.ObligationStatus</a></td>
+<td>true</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.ObligationStatus</td>
+</tr>
+<tr>
+<td>description</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_org.accordproject.protocol@1.0.0.EscrowReleaseObligation">org.accordproject.protocol@1.0.0.EscrowReleaseObligation</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.escrowreleaseobligation"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.EscrowReleaseObligation"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.escrowreleaseobligation"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.escrowreleaseobligation"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.EscrowReleaseObligation"</span><span class="token punctuation">,</span><br>  <span class="token property">"escrowAgent"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"beneficiary"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"tokenIdentifier"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"amount"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"status"</span><span class="token operator">:</span> <span class="token string">"ACTIVE"</span><span class="token punctuation">,</span><br>  <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>EscrowReleaseObligation</p>
+<h3 id="properties-35">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for org.accordproject.protocol@1.0.0.EscrowReleaseObligation</td>
+</tr>
+<tr>
+<td>escrowAgent</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>beneficiary</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>tokenIdentifier</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>amount</td>
+<td>number</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>status</td>
+<td><a href="#schemaorg.accordproject.protocol@1.0.0.obligationstatus">org.accordproject.protocol@1.0.0.ObligationStatus</a></td>
+<td>true</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.ObligationStatus</td>
+</tr>
+<tr>
+<td>description</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_org.accordproject.protocol@1.0.0.AccessControlObligation">org.accordproject.protocol@1.0.0.AccessControlObligation</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.accesscontrolobligation"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.AccessControlObligation"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.accesscontrolobligation"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.accesscontrolobligation"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.protocol@1.0.0.AccessControlObligation"</span><span class="token punctuation">,</span><br>  <span class="token property">"grantee"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"resourceIdentifier"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"permission"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"status"</span><span class="token operator">:</span> <span class="token string">"ACTIVE"</span><span class="token punctuation">,</span><br>  <span class="token property">"description"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>AccessControlObligation</p>
+<h3 id="properties-36">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for org.accordproject.protocol@1.0.0.AccessControlObligation</td>
+</tr>
+<tr>
+<td>grantee</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>resourceIdentifier</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>permission</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>status</td>
+<td><a href="#schemaorg.accordproject.protocol@1.0.0.obligationstatus">org.accordproject.protocol@1.0.0.ObligationStatus</a></td>
+<td>true</td>
+<td>none</td>
+<td>An instance of org.accordproject.protocol@1.0.0.ObligationStatus</td>
+</tr>
+<tr>
+<td>description</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_org.accordproject.party@0.2.0.Party">org.accordproject.party@0.2.0.Party</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.party@0.2.0.party"></a>
+<a id="schema_org.accordproject.party@0.2.0.Party"></a>
+<a id="tocSorg.accordproject.party@0.2.0.party"></a>
+<a id="tocsorg.accordproject.party@0.2.0.party"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.party@0.2.0.Party"</span><span class="token punctuation">,</span><br>  <span class="token property">"partyId"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>Party</p>
+<h3 id="properties-37">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for org.accordproject.party@0.2.0.Party</td>
+</tr>
+<tr>
+<td>partyId</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The instance identifier for this type</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.Position">concerto.metamodel@0.4.0.Position</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.position"></a>
+<a id="schema_concerto.metamodel@0.4.0.Position"></a>
+<a id="tocSconcerto.metamodel@0.4.0.position"></a>
+<a id="tocsconcerto.metamodel@0.4.0.position"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>Position</p>
+<h3 id="properties-38">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.Position</td>
+</tr>
+<tr>
+<td>line</td>
+<td>integer</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>column</td>
+<td>integer</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>offset</td>
+<td>integer</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.Range">concerto.metamodel@0.4.0.Range</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.range"></a>
+<a id="schema_concerto.metamodel@0.4.0.Range"></a>
+<a id="tocSconcerto.metamodel@0.4.0.range"></a>
+<a id="tocsconcerto.metamodel@0.4.0.range"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>  <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>    <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>    <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>Range</p>
+<h3 id="properties-39">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.Range</td>
+</tr>
+<tr>
+<td>start</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.position">concerto.metamodel@0.4.0.Position</a></td>
+<td>true</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Position</td>
+</tr>
+<tr>
+<td>end</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.position">concerto.metamodel@0.4.0.Position</a></td>
+<td>true</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Position</td>
+</tr>
+<tr>
+<td>source</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.TypeIdentifier">concerto.metamodel@0.4.0.TypeIdentifier</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.typeidentifier"></a>
+<a id="schema_concerto.metamodel@0.4.0.TypeIdentifier"></a>
+<a id="tocSconcerto.metamodel@0.4.0.typeidentifier"></a>
+<a id="tocsconcerto.metamodel@0.4.0.typeidentifier"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>TypeIdentifier</p>
+<h3 id="properties-40">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.TypeIdentifier</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>namespace</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorLiteral">concerto.metamodel@0.4.0.DecoratorLiteral</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decoratorliteral"></a>
+<a id="schema_concerto.metamodel@0.4.0.DecoratorLiteral"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decoratorliteral"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decoratorliteral"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>DecoratorLiteral</p>
+<h3 id="properties-41">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.DecoratorLiteral</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorString">concerto.metamodel@0.4.0.DecoratorString</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decoratorstring"></a>
+<a id="schema_concerto.metamodel@0.4.0.DecoratorString"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decoratorstring"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decoratorstring"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorString"</span><span class="token punctuation">,</span><br>  <span class="token property">"value"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>DecoratorString</p>
+<h3 id="properties-42">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.DecoratorString</td>
+</tr>
+<tr>
+<td>value</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorNumber">concerto.metamodel@0.4.0.DecoratorNumber</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decoratornumber"></a>
+<a id="schema_concerto.metamodel@0.4.0.DecoratorNumber"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decoratornumber"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decoratornumber"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorNumber"</span><span class="token punctuation">,</span><br>  <span class="token property">"value"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>DecoratorNumber</p>
+<h3 id="properties-43">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.DecoratorNumber</td>
+</tr>
+<tr>
+<td>value</td>
+<td>number</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorBoolean">concerto.metamodel@0.4.0.DecoratorBoolean</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decoratorboolean"></a>
+<a id="schema_concerto.metamodel@0.4.0.DecoratorBoolean"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decoratorboolean"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decoratorboolean"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorBoolean"</span><span class="token punctuation">,</span><br>  <span class="token property">"value"</span><span class="token operator">:</span> <span class="token boolean">true</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>DecoratorBoolean</p>
+<h3 id="properties-44">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.DecoratorBoolean</td>
+</tr>
+<tr>
+<td>value</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorTypeReference">concerto.metamodel@0.4.0.DecoratorTypeReference</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decoratortypereference"></a>
+<a id="schema_concerto.metamodel@0.4.0.DecoratorTypeReference"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decoratortypereference"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decoratortypereference"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorTypeReference"</span><span class="token punctuation">,</span><br>  <span class="token property">"type"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>DecoratorTypeReference</p>
+<h3 id="properties-45">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.DecoratorTypeReference</td>
+</tr>
+<tr>
+<td>type</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
+<td>true</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
+</tr>
+<tr>
+<td>isArray</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.Decorator">concerto.metamodel@0.4.0.Decorator</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decorator"></a>
+<a id="schema_concerto.metamodel@0.4.0.Decorator"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decorator"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decorator"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>Decorator</p>
+<h3 id="properties-46">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.Decorator</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>arguments</td>
+<td>[anyOf]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.decoratorliteral">concerto.metamodel@0.4.0.DecoratorLiteral</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DecoratorLiteral</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.decoratorstring">concerto.metamodel@0.4.0.DecoratorString</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DecoratorString</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.decoratornumber">concerto.metamodel@0.4.0.DecoratorNumber</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DecoratorNumber</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.decoratorboolean">concerto.metamodel@0.4.0.DecoratorBoolean</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DecoratorBoolean</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.decoratortypereference">concerto.metamodel@0.4.0.DecoratorTypeReference</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DecoratorTypeReference</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.Identified">concerto.metamodel@0.4.0.Identified</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.identified"></a>
+<a id="schema_concerto.metamodel@0.4.0.Identified"></a>
+<a id="tocSconcerto.metamodel@0.4.0.identified"></a>
+<a id="tocsconcerto.metamodel@0.4.0.identified"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>Identified</p>
+<h3 id="properties-47">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.Identified</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.IdentifiedBy">concerto.metamodel@0.4.0.IdentifiedBy</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.identifiedby"></a>
+<a id="schema_concerto.metamodel@0.4.0.IdentifiedBy"></a>
+<a id="tocSconcerto.metamodel@0.4.0.identifiedby"></a>
+<a id="tocsconcerto.metamodel@0.4.0.identifiedby"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.IdentifiedBy"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>IdentifiedBy</p>
+<h3 id="properties-48">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.IdentifiedBy</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.Declaration">concerto.metamodel@0.4.0.Declaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.declaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.Declaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.declaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.declaration"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Declaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>Declaration</p>
+<h3 id="properties-49">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.Declaration</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.EnumDeclaration">concerto.metamodel@0.4.0.EnumDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.enumdeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.EnumDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.enumdeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.enumdeclaration"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.EnumDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.EnumProperty"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>EnumDeclaration</p>
+<h3 id="properties-50">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.EnumDeclaration</td>
+</tr>
+<tr>
+<td>properties</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.enumproperty">concerto.metamodel@0.4.0.EnumProperty</a>]</td>
+<td>true</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.EnumProperty]</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.EnumProperty">concerto.metamodel@0.4.0.EnumProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.enumproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.EnumProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.enumproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.enumproperty"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.EnumProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>EnumProperty</p>
+<h3 id="properties-51">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.EnumProperty</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.ConceptDeclaration">concerto.metamodel@0.4.0.ConceptDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.conceptdeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.ConceptDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.conceptdeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.conceptdeclaration"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.ConceptDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"isAbstract"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"identified"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"superType"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>ConceptDeclaration</p>
+<h3 id="properties-52">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.ConceptDeclaration</td>
+</tr>
+<tr>
+<td>isAbstract</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>identified</td>
+<td>any</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.identified">concerto.metamodel@0.4.0.Identified</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Identified</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.identifiedby">concerto.metamodel@0.4.0.IdentifiedBy</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IdentifiedBy</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>superType</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
+</tr>
+<tr>
+<td>properties</td>
+<td>[anyOf]</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.property">concerto.metamodel@0.4.0.Property</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Property</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.relationshipproperty">concerto.metamodel@0.4.0.RelationshipProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.RelationshipProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.objectproperty">concerto.metamodel@0.4.0.ObjectProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.ObjectProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.booleanproperty">concerto.metamodel@0.4.0.BooleanProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.BooleanProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.datetimeproperty">concerto.metamodel@0.4.0.DateTimeProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DateTimeProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.stringproperty">concerto.metamodel@0.4.0.StringProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.StringProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.doubleproperty">concerto.metamodel@0.4.0.DoubleProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DoubleProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.integerproperty">concerto.metamodel@0.4.0.IntegerProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IntegerProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.longproperty">concerto.metamodel@0.4.0.LongProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.LongProperty</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.AssetDeclaration">concerto.metamodel@0.4.0.AssetDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.assetdeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.AssetDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.assetdeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.assetdeclaration"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.AssetDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"isAbstract"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"identified"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"superType"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>AssetDeclaration</p>
+<h3 id="properties-53">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.AssetDeclaration</td>
+</tr>
+<tr>
+<td>isAbstract</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>identified</td>
+<td>any</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.identified">concerto.metamodel@0.4.0.Identified</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Identified</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.identifiedby">concerto.metamodel@0.4.0.IdentifiedBy</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IdentifiedBy</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>superType</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
+</tr>
+<tr>
+<td>properties</td>
+<td>[anyOf]</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.property">concerto.metamodel@0.4.0.Property</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Property</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.relationshipproperty">concerto.metamodel@0.4.0.RelationshipProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.RelationshipProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.objectproperty">concerto.metamodel@0.4.0.ObjectProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.ObjectProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.booleanproperty">concerto.metamodel@0.4.0.BooleanProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.BooleanProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.datetimeproperty">concerto.metamodel@0.4.0.DateTimeProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DateTimeProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.stringproperty">concerto.metamodel@0.4.0.StringProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.StringProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.doubleproperty">concerto.metamodel@0.4.0.DoubleProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DoubleProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.integerproperty">concerto.metamodel@0.4.0.IntegerProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IntegerProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.longproperty">concerto.metamodel@0.4.0.LongProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.LongProperty</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.ParticipantDeclaration">concerto.metamodel@0.4.0.ParticipantDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.participantdeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.ParticipantDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.participantdeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.participantdeclaration"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.ParticipantDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"isAbstract"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"identified"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"superType"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>ParticipantDeclaration</p>
+<h3 id="properties-54">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.ParticipantDeclaration</td>
+</tr>
+<tr>
+<td>isAbstract</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>identified</td>
+<td>any</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.identified">concerto.metamodel@0.4.0.Identified</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Identified</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.identifiedby">concerto.metamodel@0.4.0.IdentifiedBy</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IdentifiedBy</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>superType</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
+</tr>
+<tr>
+<td>properties</td>
+<td>[anyOf]</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.property">concerto.metamodel@0.4.0.Property</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Property</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.relationshipproperty">concerto.metamodel@0.4.0.RelationshipProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.RelationshipProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.objectproperty">concerto.metamodel@0.4.0.ObjectProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.ObjectProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.booleanproperty">concerto.metamodel@0.4.0.BooleanProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.BooleanProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.datetimeproperty">concerto.metamodel@0.4.0.DateTimeProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DateTimeProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.stringproperty">concerto.metamodel@0.4.0.StringProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.StringProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.doubleproperty">concerto.metamodel@0.4.0.DoubleProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DoubleProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.integerproperty">concerto.metamodel@0.4.0.IntegerProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IntegerProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.longproperty">concerto.metamodel@0.4.0.LongProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.LongProperty</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.TransactionDeclaration">concerto.metamodel@0.4.0.TransactionDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.transactiondeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.TransactionDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.transactiondeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.transactiondeclaration"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TransactionDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"isAbstract"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"identified"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"superType"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>TransactionDeclaration</p>
+<h3 id="properties-55">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.TransactionDeclaration</td>
+</tr>
+<tr>
+<td>isAbstract</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>identified</td>
+<td>any</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.identified">concerto.metamodel@0.4.0.Identified</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Identified</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.identifiedby">concerto.metamodel@0.4.0.IdentifiedBy</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IdentifiedBy</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>superType</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
+</tr>
+<tr>
+<td>properties</td>
+<td>[anyOf]</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.property">concerto.metamodel@0.4.0.Property</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Property</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.relationshipproperty">concerto.metamodel@0.4.0.RelationshipProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.RelationshipProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.objectproperty">concerto.metamodel@0.4.0.ObjectProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.ObjectProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.booleanproperty">concerto.metamodel@0.4.0.BooleanProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.BooleanProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.datetimeproperty">concerto.metamodel@0.4.0.DateTimeProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DateTimeProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.stringproperty">concerto.metamodel@0.4.0.StringProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.StringProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.doubleproperty">concerto.metamodel@0.4.0.DoubleProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DoubleProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.integerproperty">concerto.metamodel@0.4.0.IntegerProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IntegerProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.longproperty">concerto.metamodel@0.4.0.LongProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.LongProperty</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.EventDeclaration">concerto.metamodel@0.4.0.EventDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.eventdeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.EventDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.eventdeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.eventdeclaration"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.EventDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"isAbstract"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"identified"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"superType"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>EventDeclaration</p>
+<h3 id="properties-56">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.EventDeclaration</td>
+</tr>
+<tr>
+<td>isAbstract</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>identified</td>
+<td>any</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.identified">concerto.metamodel@0.4.0.Identified</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Identified</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.identifiedby">concerto.metamodel@0.4.0.IdentifiedBy</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IdentifiedBy</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>superType</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
+</tr>
+<tr>
+<td>properties</td>
+<td>[anyOf]</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.property">concerto.metamodel@0.4.0.Property</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Property</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.relationshipproperty">concerto.metamodel@0.4.0.RelationshipProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.RelationshipProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.objectproperty">concerto.metamodel@0.4.0.ObjectProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.ObjectProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.booleanproperty">concerto.metamodel@0.4.0.BooleanProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.BooleanProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.datetimeproperty">concerto.metamodel@0.4.0.DateTimeProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DateTimeProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.stringproperty">concerto.metamodel@0.4.0.StringProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.StringProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.doubleproperty">concerto.metamodel@0.4.0.DoubleProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DoubleProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.integerproperty">concerto.metamodel@0.4.0.IntegerProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IntegerProperty</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.longproperty">concerto.metamodel@0.4.0.LongProperty</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.LongProperty</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.Property">concerto.metamodel@0.4.0.Property</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.property"></a>
+<a id="schema_concerto.metamodel@0.4.0.Property"></a>
+<a id="tocSconcerto.metamodel@0.4.0.property"></a>
+<a id="tocsconcerto.metamodel@0.4.0.property"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>Property</p>
+<h3 id="properties-57">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.Property</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isArray</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isOptional</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.RelationshipProperty">concerto.metamodel@0.4.0.RelationshipProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.relationshipproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.RelationshipProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.relationshipproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.relationshipproperty"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.RelationshipProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"type"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>RelationshipProperty</p>
+<h3 id="properties-58">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.RelationshipProperty</td>
+</tr>
+<tr>
+<td>type</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
+<td>true</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isArray</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isOptional</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.ObjectProperty">concerto.metamodel@0.4.0.ObjectProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.objectproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.ObjectProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.objectproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.objectproperty"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.ObjectProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"type"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>ObjectProperty</p>
+<h3 id="properties-59">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.ObjectProperty</td>
+</tr>
+<tr>
+<td>defaultValue</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>type</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
+<td>true</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isArray</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isOptional</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.BooleanProperty">concerto.metamodel@0.4.0.BooleanProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.booleanproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.BooleanProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.booleanproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.booleanproperty"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.BooleanProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token boolean">true</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>BooleanProperty</p>
+<h3 id="properties-60">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.BooleanProperty</td>
+</tr>
+<tr>
+<td>defaultValue</td>
+<td>boolean</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isArray</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isOptional</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.DateTimeProperty">concerto.metamodel@0.4.0.DateTimeProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.datetimeproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.DateTimeProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.datetimeproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.datetimeproperty"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DateTimeProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>DateTimeProperty</p>
+<h3 id="properties-61">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.DateTimeProperty</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isArray</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isOptional</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.StringProperty">concerto.metamodel@0.4.0.StringProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.stringproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.StringProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.stringproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.stringproperty"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.StringProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"validator"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.StringRegexValidator"</span><span class="token punctuation">,</span><br>    <span class="token property">"pattern"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"flags"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>StringProperty</p>
+<h3 id="properties-62">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.StringProperty</td>
+</tr>
+<tr>
+<td>defaultValue</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>validator</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.stringregexvalidator">concerto.metamodel@0.4.0.StringRegexValidator</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.StringRegexValidator</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isArray</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isOptional</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.StringRegexValidator">concerto.metamodel@0.4.0.StringRegexValidator</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.stringregexvalidator"></a>
+<a id="schema_concerto.metamodel@0.4.0.StringRegexValidator"></a>
+<a id="tocSconcerto.metamodel@0.4.0.stringregexvalidator"></a>
+<a id="tocsconcerto.metamodel@0.4.0.stringregexvalidator"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.StringRegexValidator"</span><span class="token punctuation">,</span><br>  <span class="token property">"pattern"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"flags"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>StringRegexValidator</p>
+<h3 id="properties-63">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.StringRegexValidator</td>
+</tr>
+<tr>
+<td>pattern</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>flags</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.DoubleProperty">concerto.metamodel@0.4.0.DoubleProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.doubleproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.DoubleProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.doubleproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.doubleproperty"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DoubleProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"validator"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DoubleDomainValidator"</span><span class="token punctuation">,</span><br>    <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>DoubleProperty</p>
+<h3 id="properties-64">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.DoubleProperty</td>
+</tr>
+<tr>
+<td>defaultValue</td>
+<td>number</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>validator</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.doubledomainvalidator">concerto.metamodel@0.4.0.DoubleDomainValidator</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.DoubleDomainValidator</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isArray</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isOptional</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.DoubleDomainValidator">concerto.metamodel@0.4.0.DoubleDomainValidator</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
+<a id="schema_concerto.metamodel@0.4.0.DoubleDomainValidator"></a>
+<a id="tocSconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
+<a id="tocsconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DoubleDomainValidator"</span><span class="token punctuation">,</span><br>  <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>DoubleDomainValidator</p>
+<h3 id="properties-65">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.DoubleDomainValidator</td>
+</tr>
+<tr>
+<td>lower</td>
+<td>number</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>upper</td>
+<td>number</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.IntegerProperty">concerto.metamodel@0.4.0.IntegerProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.integerproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.IntegerProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.integerproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.integerproperty"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.IntegerProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"validator"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.IntegerDomainValidator"</span><span class="token punctuation">,</span><br>    <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>IntegerProperty</p>
+<h3 id="properties-66">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.IntegerProperty</td>
+</tr>
+<tr>
+<td>defaultValue</td>
+<td>integer</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>validator</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.integerdomainvalidator">concerto.metamodel@0.4.0.IntegerDomainValidator</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.IntegerDomainValidator</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isArray</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isOptional</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.IntegerDomainValidator">concerto.metamodel@0.4.0.IntegerDomainValidator</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
+<a id="schema_concerto.metamodel@0.4.0.IntegerDomainValidator"></a>
+<a id="tocSconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
+<a id="tocsconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.IntegerDomainValidator"</span><span class="token punctuation">,</span><br>  <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>IntegerDomainValidator</p>
+<h3 id="properties-67">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.IntegerDomainValidator</td>
+</tr>
+<tr>
+<td>lower</td>
+<td>integer</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>upper</td>
+<td>integer</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.LongProperty">concerto.metamodel@0.4.0.LongProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.longproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.LongProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.longproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.longproperty"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.LongProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"validator"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.LongDomainValidator"</span><span class="token punctuation">,</span><br>    <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>LongProperty</p>
+<h3 id="properties-68">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.LongProperty</td>
+</tr>
+<tr>
+<td>defaultValue</td>
+<td>integer</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>validator</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.longdomainvalidator">concerto.metamodel@0.4.0.LongDomainValidator</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.LongDomainValidator</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isArray</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>isOptional</td>
+<td>boolean</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>decorators</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
+</tr>
+<tr>
+<td>location</td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Range</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.LongDomainValidator">concerto.metamodel@0.4.0.LongDomainValidator</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.longdomainvalidator"></a>
+<a id="schema_concerto.metamodel@0.4.0.LongDomainValidator"></a>
+<a id="tocSconcerto.metamodel@0.4.0.longdomainvalidator"></a>
+<a id="tocsconcerto.metamodel@0.4.0.longdomainvalidator"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.LongDomainValidator"</span><span class="token punctuation">,</span><br>  <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>LongDomainValidator</p>
+<h3 id="properties-69">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.LongDomainValidator</td>
+</tr>
+<tr>
+<td>lower</td>
+<td>integer</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>upper</td>
+<td>integer</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.Import">concerto.metamodel@0.4.0.Import</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.import"></a>
+<a id="schema_concerto.metamodel@0.4.0.Import"></a>
+<a id="tocSconcerto.metamodel@0.4.0.import"></a>
+<a id="tocsconcerto.metamodel@0.4.0.import"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Import"</span><span class="token punctuation">,</span><br>  <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"uri"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>Import</p>
+<h3 id="properties-70">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.Import</td>
+</tr>
+<tr>
+<td>namespace</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>uri</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.ImportAll">concerto.metamodel@0.4.0.ImportAll</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.importall"></a>
+<a id="schema_concerto.metamodel@0.4.0.ImportAll"></a>
+<a id="tocSconcerto.metamodel@0.4.0.importall"></a>
+<a id="tocsconcerto.metamodel@0.4.0.importall"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.ImportAll"</span><span class="token punctuation">,</span><br>  <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"uri"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>ImportAll</p>
+<h3 id="properties-71">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.ImportAll</td>
+</tr>
+<tr>
+<td>namespace</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>uri</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.ImportType">concerto.metamodel@0.4.0.ImportType</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.importtype"></a>
+<a id="schema_concerto.metamodel@0.4.0.ImportType"></a>
+<a id="tocSconcerto.metamodel@0.4.0.importtype"></a>
+<a id="tocsconcerto.metamodel@0.4.0.importtype"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.ImportType"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"uri"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>ImportType</p>
+<h3 id="properties-72">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.ImportType</td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>namespace</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>uri</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.Model">concerto.metamodel@0.4.0.Model</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.model"></a>
+<a id="schema_concerto.metamodel@0.4.0.Model"></a>
+<a id="tocSconcerto.metamodel@0.4.0.model"></a>
+<a id="tocsconcerto.metamodel@0.4.0.model"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Model"</span><span class="token punctuation">,</span><br>  <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"sourceUri"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"concertoVersion"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"imports"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Import"</span><span class="token punctuation">,</span><br>      <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"uri"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"declarations"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Declaration"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>Model</p>
+<h3 id="properties-73">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.Model</td>
+</tr>
+<tr>
+<td>namespace</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>sourceUri</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>concertoVersion</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>imports</td>
+<td>[anyOf]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.import">concerto.metamodel@0.4.0.Import</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Import</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.importall">concerto.metamodel@0.4.0.ImportAll</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.ImportAll</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.importtype">concerto.metamodel@0.4.0.ImportType</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.ImportType</td>
+</tr>
+</tbody>
+</table>
+<p>continued</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>declarations</td>
+<td>[anyOf]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p>anyOf</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.declaration">concerto.metamodel@0.4.0.Declaration</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.Declaration</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.enumdeclaration">concerto.metamodel@0.4.0.EnumDeclaration</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.EnumDeclaration</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.conceptdeclaration">concerto.metamodel@0.4.0.ConceptDeclaration</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.ConceptDeclaration</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.assetdeclaration">concerto.metamodel@0.4.0.AssetDeclaration</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.AssetDeclaration</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.participantdeclaration">concerto.metamodel@0.4.0.ParticipantDeclaration</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.ParticipantDeclaration</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.transactiondeclaration">concerto.metamodel@0.4.0.TransactionDeclaration</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.TransactionDeclaration</td>
+</tr>
+</tbody>
+</table>
+<p>or</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>» <em>anonymous</em></td>
+<td><a href="#schemaconcerto.metamodel@0.4.0.eventdeclaration">concerto.metamodel@0.4.0.EventDeclaration</a></td>
+<td>false</td>
+<td>none</td>
+<td>An instance of concerto.metamodel@0.4.0.EventDeclaration</td>
+</tr>
+</tbody>
+</table>
+<h2 id="tocS_concerto.metamodel@0.4.0.Models">concerto.metamodel@0.4.0.Models</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.models"></a>
+<a id="schema_concerto.metamodel@0.4.0.Models"></a>
+<a id="tocSconcerto.metamodel@0.4.0.models"></a>
+<a id="tocsconcerto.metamodel@0.4.0.models"></a>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Models"</span><span class="token punctuation">,</span><br>  <span class="token property">"models"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Model"</span><span class="token punctuation">,</span><br>      <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"sourceUri"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"concertoVersion"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"imports"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Import"</span><span class="token punctuation">,</span><br>          <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"uri"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"declarations"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Declaration"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>              <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>              <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>                <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>                  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">,</span><br>                    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">,</span><br>                    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>                  <span class="token punctuation">}</span><br>                <span class="token punctuation">}</span><br>              <span class="token punctuation">]</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><br><span class="token punctuation">}</span><br></code></pre>
+<p>Models</p>
+<h3 id="properties-74">Properties</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Required</th>
+<th>Restrictions</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>$class</td>
+<td>string</td>
+<td>true</td>
+<td>none</td>
+<td>The class identifier for concerto.metamodel@0.4.0.Models</td>
+</tr>
+<tr>
+<td>models</td>
+<td>[<a href="#schemaconcerto.metamodel@0.4.0.model">concerto.metamodel@0.4.0.Model</a>]</td>
+<td>true</td>
+<td>none</td>
+<td>[An instance of concerto.metamodel@0.4.0.Model]</td>
+</tr>
+</tbody>
+</table>
 <h2 id="tocS_org.accordproject.commonmark@0.5.0.Node">org.accordproject.commonmark@0.5.0.Node</h2>
 <!-- backwards compatibility -->
 <a id="schemaorg.accordproject.commonmark@0.5.0.node"></a>
@@ -28032,7 +32347,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.node"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Node</p>
-<h3 id="properties-31">Properties</h3>
+<h3 id="properties-75">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -28670,7 +32985,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.root"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Root"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Root</p>
-<h3 id="properties-32">Properties</h3>
+<h3 id="properties-76">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -29308,7 +33623,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.child"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Child"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Child</p>
-<h3 id="properties-33">Properties</h3>
+<h3 id="properties-77">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -29946,7 +34261,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.text"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Text"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Text</p>
-<h3 id="properties-34">Properties</h3>
+<h3 id="properties-78">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -30584,7 +34899,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.attribute"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Attribute"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"value"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Attribute</p>
-<h3 id="properties-35">Properties</h3>
+<h3 id="properties-79">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -30627,7 +34942,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.taginfo"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.TagInfo"</span><span class="token punctuation">,</span><br>  <span class="token property">"tagName"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"attributeString"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"attributes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Attribute"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"value"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"content"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"closed"</span><span class="token operator">:</span> <span class="token boolean">true</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>TagInfo</p>
-<h3 id="properties-36">Properties</h3>
+<h3 id="properties-80">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -30691,7 +35006,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.codeblock"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.CodeBlock"</span><span class="token punctuation">,</span><br>  <span class="token property">"info"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"tag"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.TagInfo"</span><span class="token punctuation">,</span><br>    <span class="token property">"tagName"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"attributeString"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"attributes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>      <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Attribute"</span><span class="token punctuation">,</span><br>        <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>        <span class="token property">"value"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">]</span><span class="token punctuation">,</span><br>    <span class="token property">"content"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"closed"</span><span class="token operator">:</span> <span class="token boolean">true</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>CodeBlock</p>
-<h3 id="properties-37">Properties</h3>
+<h3 id="properties-81">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -31343,7 +35658,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.code"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Code"</span><span class="token punctuation">,</span><br>  <span class="token property">"info"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Code</p>
-<h3 id="properties-38">Properties</h3>
+<h3 id="properties-82">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -31988,7 +36303,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.htmlinline"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.HtmlInline"</span><span class="token punctuation">,</span><br>  <span class="token property">"tag"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.TagInfo"</span><span class="token punctuation">,</span><br>    <span class="token property">"tagName"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"attributeString"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"attributes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>      <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Attribute"</span><span class="token punctuation">,</span><br>        <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>        <span class="token property">"value"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">]</span><span class="token punctuation">,</span><br>    <span class="token property">"content"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"closed"</span><span class="token operator">:</span> <span class="token boolean">true</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>HtmlInline</p>
-<h3 id="properties-39">Properties</h3>
+<h3 id="properties-83">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -32633,7 +36948,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.htmlblock"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.HtmlBlock"</span><span class="token punctuation">,</span><br>  <span class="token property">"tag"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.TagInfo"</span><span class="token punctuation">,</span><br>    <span class="token property">"tagName"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"attributeString"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"attributes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>      <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Attribute"</span><span class="token punctuation">,</span><br>        <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>        <span class="token property">"value"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">]</span><span class="token punctuation">,</span><br>    <span class="token property">"content"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"closed"</span><span class="token operator">:</span> <span class="token boolean">true</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>HtmlBlock</p>
-<h3 id="properties-40">Properties</h3>
+<h3 id="properties-84">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -33278,7 +37593,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.emph"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Emph"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Emph</p>
-<h3 id="properties-41">Properties</h3>
+<h3 id="properties-85">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -33916,7 +38231,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.strong"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Strong"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Strong</p>
-<h3 id="properties-42">Properties</h3>
+<h3 id="properties-86">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -34554,7 +38869,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.blockquote"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.BlockQuote"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>BlockQuote</p>
-<h3 id="properties-43">Properties</h3>
+<h3 id="properties-87">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -35192,7 +39507,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.heading"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Heading"</span><span class="token punctuation">,</span><br>  <span class="token property">"level"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Heading</p>
-<h3 id="properties-44">Properties</h3>
+<h3 id="properties-88">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -35837,7 +40152,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.thematicbreak"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.ThematicBreak"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>ThematicBreak</p>
-<h3 id="properties-45">Properties</h3>
+<h3 id="properties-89">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -36475,7 +40790,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.softbreak"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Softbreak"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Softbreak</p>
-<h3 id="properties-46">Properties</h3>
+<h3 id="properties-90">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -37113,7 +41428,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.linebreak"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Linebreak"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Linebreak</p>
-<h3 id="properties-47">Properties</h3>
+<h3 id="properties-91">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -37751,7 +42066,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.link"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Link"</span><span class="token punctuation">,</span><br>  <span class="token property">"destination"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"title"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Link</p>
-<h3 id="properties-48">Properties</h3>
+<h3 id="properties-92">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -38403,7 +42718,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.image"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Image"</span><span class="token punctuation">,</span><br>  <span class="token property">"destination"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"title"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Image</p>
-<h3 id="properties-49">Properties</h3>
+<h3 id="properties-93">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -39055,7 +43370,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.paragraph"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Paragraph"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Paragraph</p>
-<h3 id="properties-50">Properties</h3>
+<h3 id="properties-94">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -39693,7 +44008,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.list"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.List"</span><span class="token punctuation">,</span><br>  <span class="token property">"type"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"start"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"tight"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"delimiter"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>List</p>
-<h3 id="properties-51">Properties</h3>
+<h3 id="properties-95">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -40359,7 +44674,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.item"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Item"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Item</p>
-<h3 id="properties-52">Properties</h3>
+<h3 id="properties-96">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -40997,7 +45312,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.document"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Document"</span><span class="token punctuation">,</span><br>  <span class="token property">"xmlns"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Document</p>
-<h3 id="properties-53">Properties</h3>
+<h3 id="properties-97">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -41642,7 +45957,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.table"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Table"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>Table</p>
-<h3 id="properties-54">Properties</h3>
+<h3 id="properties-98">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -42280,7 +46595,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.tablehead"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.TableHead"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>TableHead</p>
-<h3 id="properties-55">Properties</h3>
+<h3 id="properties-99">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -42918,7 +47233,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.tablebody"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.TableBody"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>TableBody</p>
-<h3 id="properties-56">Properties</h3>
+<h3 id="properties-100">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -43556,7 +47871,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.tablerow"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.TableRow"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>TableRow</p>
-<h3 id="properties-57">Properties</h3>
+<h3 id="properties-101">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -44194,7 +48509,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.headercell"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.HeaderCell"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>HeaderCell</p>
-<h3 id="properties-58">Properties</h3>
+<h3 id="properties-102">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -44832,7 +49147,7 @@ This operation does not require authentication
 <a id="tocsorg.accordproject.commonmark@0.5.0.tablecell"></a>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.TableCell"</span><span class="token punctuation">,</span><br>  <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>      <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.commonmark@0.5.0.Node"</span><span class="token punctuation">,</span><br>          <span class="token property">"text"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"nodes"</span><span class="token operator">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"startLine"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"endLine"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
 <p>TableCell</p>
-<h3 id="properties-59">Properties</h3>
+<h3 id="properties-103">Properties</h3>
 <table>
 <thead>
 <tr>
@@ -45459,3768 +49774,6 @@ This operation does not require authentication
 <td>false</td>
 <td>none</td>
 <td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_org.accordproject.party@0.2.0.Party">org.accordproject.party@0.2.0.Party</h2>
-<!-- backwards compatibility -->
-<a id="schemaorg.accordproject.party@0.2.0.party"></a>
-<a id="schema_org.accordproject.party@0.2.0.Party"></a>
-<a id="tocSorg.accordproject.party@0.2.0.party"></a>
-<a id="tocsorg.accordproject.party@0.2.0.party"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"org.accordproject.party@0.2.0.Party"</span><span class="token punctuation">,</span><br>  <span class="token property">"partyId"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>Party</p>
-<h3 id="properties-60">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for org.accordproject.party@0.2.0.Party</td>
-</tr>
-<tr>
-<td>partyId</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The instance identifier for this type</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.Position">concerto.metamodel@0.4.0.Position</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.position"></a>
-<a id="schema_concerto.metamodel@0.4.0.Position"></a>
-<a id="tocSconcerto.metamodel@0.4.0.position"></a>
-<a id="tocsconcerto.metamodel@0.4.0.position"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>Position</p>
-<h3 id="properties-61">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.Position</td>
-</tr>
-<tr>
-<td>line</td>
-<td>integer</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>column</td>
-<td>integer</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>offset</td>
-<td>integer</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.Range">concerto.metamodel@0.4.0.Range</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.range"></a>
-<a id="schema_concerto.metamodel@0.4.0.Range"></a>
-<a id="tocSconcerto.metamodel@0.4.0.range"></a>
-<a id="tocsconcerto.metamodel@0.4.0.range"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>  <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>    <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>    <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>Range</p>
-<h3 id="properties-62">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.Range</td>
-</tr>
-<tr>
-<td>start</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.position">concerto.metamodel@0.4.0.Position</a></td>
-<td>true</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Position</td>
-</tr>
-<tr>
-<td>end</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.position">concerto.metamodel@0.4.0.Position</a></td>
-<td>true</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Position</td>
-</tr>
-<tr>
-<td>source</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.TypeIdentifier">concerto.metamodel@0.4.0.TypeIdentifier</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.typeidentifier"></a>
-<a id="schema_concerto.metamodel@0.4.0.TypeIdentifier"></a>
-<a id="tocSconcerto.metamodel@0.4.0.typeidentifier"></a>
-<a id="tocsconcerto.metamodel@0.4.0.typeidentifier"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>TypeIdentifier</p>
-<h3 id="properties-63">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.TypeIdentifier</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>namespace</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorLiteral">concerto.metamodel@0.4.0.DecoratorLiteral</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decoratorliteral"></a>
-<a id="schema_concerto.metamodel@0.4.0.DecoratorLiteral"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decoratorliteral"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decoratorliteral"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>DecoratorLiteral</p>
-<h3 id="properties-64">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.DecoratorLiteral</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorString">concerto.metamodel@0.4.0.DecoratorString</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decoratorstring"></a>
-<a id="schema_concerto.metamodel@0.4.0.DecoratorString"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decoratorstring"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decoratorstring"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorString"</span><span class="token punctuation">,</span><br>  <span class="token property">"value"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>DecoratorString</p>
-<h3 id="properties-65">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.DecoratorString</td>
-</tr>
-<tr>
-<td>value</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorNumber">concerto.metamodel@0.4.0.DecoratorNumber</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decoratornumber"></a>
-<a id="schema_concerto.metamodel@0.4.0.DecoratorNumber"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decoratornumber"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decoratornumber"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorNumber"</span><span class="token punctuation">,</span><br>  <span class="token property">"value"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>DecoratorNumber</p>
-<h3 id="properties-66">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.DecoratorNumber</td>
-</tr>
-<tr>
-<td>value</td>
-<td>number</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorBoolean">concerto.metamodel@0.4.0.DecoratorBoolean</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decoratorboolean"></a>
-<a id="schema_concerto.metamodel@0.4.0.DecoratorBoolean"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decoratorboolean"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decoratorboolean"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorBoolean"</span><span class="token punctuation">,</span><br>  <span class="token property">"value"</span><span class="token operator">:</span> <span class="token boolean">true</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>DecoratorBoolean</p>
-<h3 id="properties-67">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.DecoratorBoolean</td>
-</tr>
-<tr>
-<td>value</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorTypeReference">concerto.metamodel@0.4.0.DecoratorTypeReference</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decoratortypereference"></a>
-<a id="schema_concerto.metamodel@0.4.0.DecoratorTypeReference"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decoratortypereference"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decoratortypereference"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorTypeReference"</span><span class="token punctuation">,</span><br>  <span class="token property">"type"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>DecoratorTypeReference</p>
-<h3 id="properties-68">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.DecoratorTypeReference</td>
-</tr>
-<tr>
-<td>type</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
-<td>true</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
-</tr>
-<tr>
-<td>isArray</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.Decorator">concerto.metamodel@0.4.0.Decorator</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decorator"></a>
-<a id="schema_concerto.metamodel@0.4.0.Decorator"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decorator"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decorator"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>Decorator</p>
-<h3 id="properties-69">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.Decorator</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>arguments</td>
-<td>[anyOf]</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.decoratorliteral">concerto.metamodel@0.4.0.DecoratorLiteral</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DecoratorLiteral</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.decoratorstring">concerto.metamodel@0.4.0.DecoratorString</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DecoratorString</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.decoratornumber">concerto.metamodel@0.4.0.DecoratorNumber</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DecoratorNumber</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.decoratorboolean">concerto.metamodel@0.4.0.DecoratorBoolean</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DecoratorBoolean</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.decoratortypereference">concerto.metamodel@0.4.0.DecoratorTypeReference</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DecoratorTypeReference</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.Identified">concerto.metamodel@0.4.0.Identified</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.identified"></a>
-<a id="schema_concerto.metamodel@0.4.0.Identified"></a>
-<a id="tocSconcerto.metamodel@0.4.0.identified"></a>
-<a id="tocsconcerto.metamodel@0.4.0.identified"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>Identified</p>
-<h3 id="properties-70">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.Identified</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.IdentifiedBy">concerto.metamodel@0.4.0.IdentifiedBy</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.identifiedby"></a>
-<a id="schema_concerto.metamodel@0.4.0.IdentifiedBy"></a>
-<a id="tocSconcerto.metamodel@0.4.0.identifiedby"></a>
-<a id="tocsconcerto.metamodel@0.4.0.identifiedby"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.IdentifiedBy"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>IdentifiedBy</p>
-<h3 id="properties-71">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.IdentifiedBy</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.Declaration">concerto.metamodel@0.4.0.Declaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.declaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.Declaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.declaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.declaration"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Declaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>Declaration</p>
-<h3 id="properties-72">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.Declaration</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.EnumDeclaration">concerto.metamodel@0.4.0.EnumDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.enumdeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.EnumDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.enumdeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.enumdeclaration"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.EnumDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.EnumProperty"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>EnumDeclaration</p>
-<h3 id="properties-73">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.EnumDeclaration</td>
-</tr>
-<tr>
-<td>properties</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.enumproperty">concerto.metamodel@0.4.0.EnumProperty</a>]</td>
-<td>true</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.EnumProperty]</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.EnumProperty">concerto.metamodel@0.4.0.EnumProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.enumproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.EnumProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.enumproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.enumproperty"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.EnumProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>EnumProperty</p>
-<h3 id="properties-74">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.EnumProperty</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.ConceptDeclaration">concerto.metamodel@0.4.0.ConceptDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.conceptdeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.ConceptDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.conceptdeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.conceptdeclaration"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.ConceptDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"isAbstract"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"identified"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"superType"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>ConceptDeclaration</p>
-<h3 id="properties-75">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.ConceptDeclaration</td>
-</tr>
-<tr>
-<td>isAbstract</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>identified</td>
-<td>any</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.identified">concerto.metamodel@0.4.0.Identified</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Identified</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.identifiedby">concerto.metamodel@0.4.0.IdentifiedBy</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IdentifiedBy</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>superType</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
-</tr>
-<tr>
-<td>properties</td>
-<td>[anyOf]</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.property">concerto.metamodel@0.4.0.Property</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Property</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.relationshipproperty">concerto.metamodel@0.4.0.RelationshipProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.RelationshipProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.objectproperty">concerto.metamodel@0.4.0.ObjectProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.ObjectProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.booleanproperty">concerto.metamodel@0.4.0.BooleanProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.BooleanProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.datetimeproperty">concerto.metamodel@0.4.0.DateTimeProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DateTimeProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.stringproperty">concerto.metamodel@0.4.0.StringProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.StringProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.doubleproperty">concerto.metamodel@0.4.0.DoubleProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DoubleProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.integerproperty">concerto.metamodel@0.4.0.IntegerProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IntegerProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.longproperty">concerto.metamodel@0.4.0.LongProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.LongProperty</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.AssetDeclaration">concerto.metamodel@0.4.0.AssetDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.assetdeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.AssetDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.assetdeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.assetdeclaration"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.AssetDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"isAbstract"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"identified"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"superType"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>AssetDeclaration</p>
-<h3 id="properties-76">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.AssetDeclaration</td>
-</tr>
-<tr>
-<td>isAbstract</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>identified</td>
-<td>any</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.identified">concerto.metamodel@0.4.0.Identified</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Identified</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.identifiedby">concerto.metamodel@0.4.0.IdentifiedBy</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IdentifiedBy</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>superType</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
-</tr>
-<tr>
-<td>properties</td>
-<td>[anyOf]</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.property">concerto.metamodel@0.4.0.Property</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Property</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.relationshipproperty">concerto.metamodel@0.4.0.RelationshipProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.RelationshipProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.objectproperty">concerto.metamodel@0.4.0.ObjectProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.ObjectProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.booleanproperty">concerto.metamodel@0.4.0.BooleanProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.BooleanProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.datetimeproperty">concerto.metamodel@0.4.0.DateTimeProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DateTimeProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.stringproperty">concerto.metamodel@0.4.0.StringProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.StringProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.doubleproperty">concerto.metamodel@0.4.0.DoubleProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DoubleProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.integerproperty">concerto.metamodel@0.4.0.IntegerProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IntegerProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.longproperty">concerto.metamodel@0.4.0.LongProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.LongProperty</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.ParticipantDeclaration">concerto.metamodel@0.4.0.ParticipantDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.participantdeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.ParticipantDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.participantdeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.participantdeclaration"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.ParticipantDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"isAbstract"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"identified"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"superType"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>ParticipantDeclaration</p>
-<h3 id="properties-77">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.ParticipantDeclaration</td>
-</tr>
-<tr>
-<td>isAbstract</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>identified</td>
-<td>any</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.identified">concerto.metamodel@0.4.0.Identified</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Identified</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.identifiedby">concerto.metamodel@0.4.0.IdentifiedBy</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IdentifiedBy</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>superType</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
-</tr>
-<tr>
-<td>properties</td>
-<td>[anyOf]</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.property">concerto.metamodel@0.4.0.Property</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Property</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.relationshipproperty">concerto.metamodel@0.4.0.RelationshipProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.RelationshipProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.objectproperty">concerto.metamodel@0.4.0.ObjectProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.ObjectProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.booleanproperty">concerto.metamodel@0.4.0.BooleanProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.BooleanProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.datetimeproperty">concerto.metamodel@0.4.0.DateTimeProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DateTimeProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.stringproperty">concerto.metamodel@0.4.0.StringProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.StringProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.doubleproperty">concerto.metamodel@0.4.0.DoubleProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DoubleProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.integerproperty">concerto.metamodel@0.4.0.IntegerProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IntegerProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.longproperty">concerto.metamodel@0.4.0.LongProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.LongProperty</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.TransactionDeclaration">concerto.metamodel@0.4.0.TransactionDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.transactiondeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.TransactionDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.transactiondeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.transactiondeclaration"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TransactionDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"isAbstract"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"identified"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"superType"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>TransactionDeclaration</p>
-<h3 id="properties-78">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.TransactionDeclaration</td>
-</tr>
-<tr>
-<td>isAbstract</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>identified</td>
-<td>any</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.identified">concerto.metamodel@0.4.0.Identified</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Identified</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.identifiedby">concerto.metamodel@0.4.0.IdentifiedBy</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IdentifiedBy</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>superType</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
-</tr>
-<tr>
-<td>properties</td>
-<td>[anyOf]</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.property">concerto.metamodel@0.4.0.Property</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Property</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.relationshipproperty">concerto.metamodel@0.4.0.RelationshipProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.RelationshipProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.objectproperty">concerto.metamodel@0.4.0.ObjectProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.ObjectProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.booleanproperty">concerto.metamodel@0.4.0.BooleanProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.BooleanProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.datetimeproperty">concerto.metamodel@0.4.0.DateTimeProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DateTimeProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.stringproperty">concerto.metamodel@0.4.0.StringProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.StringProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.doubleproperty">concerto.metamodel@0.4.0.DoubleProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DoubleProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.integerproperty">concerto.metamodel@0.4.0.IntegerProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IntegerProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.longproperty">concerto.metamodel@0.4.0.LongProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.LongProperty</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.EventDeclaration">concerto.metamodel@0.4.0.EventDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.eventdeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.EventDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.eventdeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.eventdeclaration"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.EventDeclaration"</span><span class="token punctuation">,</span><br>  <span class="token property">"isAbstract"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"identified"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Identified"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"superType"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"properties"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>EventDeclaration</p>
-<h3 id="properties-79">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.EventDeclaration</td>
-</tr>
-<tr>
-<td>isAbstract</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>identified</td>
-<td>any</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.identified">concerto.metamodel@0.4.0.Identified</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Identified</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.identifiedby">concerto.metamodel@0.4.0.IdentifiedBy</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IdentifiedBy</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>superType</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
-</tr>
-<tr>
-<td>properties</td>
-<td>[anyOf]</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.property">concerto.metamodel@0.4.0.Property</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Property</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.relationshipproperty">concerto.metamodel@0.4.0.RelationshipProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.RelationshipProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.objectproperty">concerto.metamodel@0.4.0.ObjectProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.ObjectProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.booleanproperty">concerto.metamodel@0.4.0.BooleanProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.BooleanProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.datetimeproperty">concerto.metamodel@0.4.0.DateTimeProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DateTimeProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.stringproperty">concerto.metamodel@0.4.0.StringProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.StringProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.doubleproperty">concerto.metamodel@0.4.0.DoubleProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DoubleProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.integerproperty">concerto.metamodel@0.4.0.IntegerProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IntegerProperty</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.longproperty">concerto.metamodel@0.4.0.LongProperty</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.LongProperty</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.Property">concerto.metamodel@0.4.0.Property</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.property"></a>
-<a id="schema_concerto.metamodel@0.4.0.Property"></a>
-<a id="tocSconcerto.metamodel@0.4.0.property"></a>
-<a id="tocsconcerto.metamodel@0.4.0.property"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Property"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>Property</p>
-<h3 id="properties-80">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.Property</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isArray</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isOptional</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.RelationshipProperty">concerto.metamodel@0.4.0.RelationshipProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.relationshipproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.RelationshipProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.relationshipproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.relationshipproperty"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.RelationshipProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"type"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>RelationshipProperty</p>
-<h3 id="properties-81">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.RelationshipProperty</td>
-</tr>
-<tr>
-<td>type</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
-<td>true</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isArray</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isOptional</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.ObjectProperty">concerto.metamodel@0.4.0.ObjectProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.objectproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.ObjectProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.objectproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.objectproperty"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.ObjectProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"type"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.TypeIdentifier"</span><span class="token punctuation">,</span><br>    <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>ObjectProperty</p>
-<h3 id="properties-82">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.ObjectProperty</td>
-</tr>
-<tr>
-<td>defaultValue</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>type</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.typeidentifier">concerto.metamodel@0.4.0.TypeIdentifier</a></td>
-<td>true</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.TypeIdentifier</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isArray</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isOptional</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.BooleanProperty">concerto.metamodel@0.4.0.BooleanProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.booleanproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.BooleanProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.booleanproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.booleanproperty"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.BooleanProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token boolean">true</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>BooleanProperty</p>
-<h3 id="properties-83">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.BooleanProperty</td>
-</tr>
-<tr>
-<td>defaultValue</td>
-<td>boolean</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isArray</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isOptional</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.DateTimeProperty">concerto.metamodel@0.4.0.DateTimeProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.datetimeproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.DateTimeProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.datetimeproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.datetimeproperty"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DateTimeProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>DateTimeProperty</p>
-<h3 id="properties-84">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.DateTimeProperty</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isArray</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isOptional</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.StringProperty">concerto.metamodel@0.4.0.StringProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.stringproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.StringProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.stringproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.stringproperty"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.StringProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"validator"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.StringRegexValidator"</span><span class="token punctuation">,</span><br>    <span class="token property">"pattern"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>    <span class="token property">"flags"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>StringProperty</p>
-<h3 id="properties-85">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.StringProperty</td>
-</tr>
-<tr>
-<td>defaultValue</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>validator</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.stringregexvalidator">concerto.metamodel@0.4.0.StringRegexValidator</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.StringRegexValidator</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isArray</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isOptional</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.StringRegexValidator">concerto.metamodel@0.4.0.StringRegexValidator</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.stringregexvalidator"></a>
-<a id="schema_concerto.metamodel@0.4.0.StringRegexValidator"></a>
-<a id="tocSconcerto.metamodel@0.4.0.stringregexvalidator"></a>
-<a id="tocsconcerto.metamodel@0.4.0.stringregexvalidator"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.StringRegexValidator"</span><span class="token punctuation">,</span><br>  <span class="token property">"pattern"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"flags"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>StringRegexValidator</p>
-<h3 id="properties-86">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.StringRegexValidator</td>
-</tr>
-<tr>
-<td>pattern</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>flags</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.DoubleProperty">concerto.metamodel@0.4.0.DoubleProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.doubleproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.DoubleProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.doubleproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.doubleproperty"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DoubleProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"validator"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DoubleDomainValidator"</span><span class="token punctuation">,</span><br>    <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>DoubleProperty</p>
-<h3 id="properties-87">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.DoubleProperty</td>
-</tr>
-<tr>
-<td>defaultValue</td>
-<td>number</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>validator</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.doubledomainvalidator">concerto.metamodel@0.4.0.DoubleDomainValidator</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.DoubleDomainValidator</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isArray</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isOptional</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.DoubleDomainValidator">concerto.metamodel@0.4.0.DoubleDomainValidator</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
-<a id="schema_concerto.metamodel@0.4.0.DoubleDomainValidator"></a>
-<a id="tocSconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
-<a id="tocsconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DoubleDomainValidator"</span><span class="token punctuation">,</span><br>  <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>DoubleDomainValidator</p>
-<h3 id="properties-88">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.DoubleDomainValidator</td>
-</tr>
-<tr>
-<td>lower</td>
-<td>number</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>upper</td>
-<td>number</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.IntegerProperty">concerto.metamodel@0.4.0.IntegerProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.integerproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.IntegerProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.integerproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.integerproperty"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.IntegerProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"validator"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.IntegerDomainValidator"</span><span class="token punctuation">,</span><br>    <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>IntegerProperty</p>
-<h3 id="properties-89">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.IntegerProperty</td>
-</tr>
-<tr>
-<td>defaultValue</td>
-<td>integer</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>validator</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.integerdomainvalidator">concerto.metamodel@0.4.0.IntegerDomainValidator</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.IntegerDomainValidator</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isArray</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isOptional</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.IntegerDomainValidator">concerto.metamodel@0.4.0.IntegerDomainValidator</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
-<a id="schema_concerto.metamodel@0.4.0.IntegerDomainValidator"></a>
-<a id="tocSconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
-<a id="tocsconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.IntegerDomainValidator"</span><span class="token punctuation">,</span><br>  <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>IntegerDomainValidator</p>
-<h3 id="properties-90">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.IntegerDomainValidator</td>
-</tr>
-<tr>
-<td>lower</td>
-<td>integer</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>upper</td>
-<td>integer</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.LongProperty">concerto.metamodel@0.4.0.LongProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.longproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.LongProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.longproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.longproperty"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.LongProperty"</span><span class="token punctuation">,</span><br>  <span class="token property">"defaultValue"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"validator"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.LongDomainValidator"</span><span class="token punctuation">,</span><br>    <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>    <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br>  <span class="token punctuation">}</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"isArray"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"isOptional"</span><span class="token operator">:</span> <span class="token boolean">false</span><span class="token punctuation">,</span><br>  <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>      <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>      <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>    <span class="token punctuation">}</span><span class="token punctuation">,</span><br>    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>  <span class="token punctuation">}</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>LongProperty</p>
-<h3 id="properties-91">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.LongProperty</td>
-</tr>
-<tr>
-<td>defaultValue</td>
-<td>integer</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>validator</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.longdomainvalidator">concerto.metamodel@0.4.0.LongDomainValidator</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.LongDomainValidator</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isArray</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>isOptional</td>
-<td>boolean</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>decorators</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.decorator">concerto.metamodel@0.4.0.Decorator</a>]</td>
-<td>false</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Decorator]</td>
-</tr>
-<tr>
-<td>location</td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.range">concerto.metamodel@0.4.0.Range</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Range</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.LongDomainValidator">concerto.metamodel@0.4.0.LongDomainValidator</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.longdomainvalidator"></a>
-<a id="schema_concerto.metamodel@0.4.0.LongDomainValidator"></a>
-<a id="tocSconcerto.metamodel@0.4.0.longdomainvalidator"></a>
-<a id="tocsconcerto.metamodel@0.4.0.longdomainvalidator"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.LongDomainValidator"</span><span class="token punctuation">,</span><br>  <span class="token property">"lower"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>  <span class="token property">"upper"</span><span class="token operator">:</span> <span class="token number">0</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>LongDomainValidator</p>
-<h3 id="properties-92">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.LongDomainValidator</td>
-</tr>
-<tr>
-<td>lower</td>
-<td>integer</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>upper</td>
-<td>integer</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.Import">concerto.metamodel@0.4.0.Import</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.import"></a>
-<a id="schema_concerto.metamodel@0.4.0.Import"></a>
-<a id="tocSconcerto.metamodel@0.4.0.import"></a>
-<a id="tocsconcerto.metamodel@0.4.0.import"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Import"</span><span class="token punctuation">,</span><br>  <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"uri"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>Import</p>
-<h3 id="properties-93">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.Import</td>
-</tr>
-<tr>
-<td>namespace</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>uri</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.ImportAll">concerto.metamodel@0.4.0.ImportAll</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.importall"></a>
-<a id="schema_concerto.metamodel@0.4.0.ImportAll"></a>
-<a id="tocSconcerto.metamodel@0.4.0.importall"></a>
-<a id="tocsconcerto.metamodel@0.4.0.importall"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.ImportAll"</span><span class="token punctuation">,</span><br>  <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"uri"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>ImportAll</p>
-<h3 id="properties-94">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.ImportAll</td>
-</tr>
-<tr>
-<td>namespace</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>uri</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.ImportType">concerto.metamodel@0.4.0.ImportType</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.importtype"></a>
-<a id="schema_concerto.metamodel@0.4.0.ImportType"></a>
-<a id="tocSconcerto.metamodel@0.4.0.importtype"></a>
-<a id="tocsconcerto.metamodel@0.4.0.importtype"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.ImportType"</span><span class="token punctuation">,</span><br>  <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"uri"</span><span class="token operator">:</span> <span class="token string">"string"</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>ImportType</p>
-<h3 id="properties-95">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.ImportType</td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>namespace</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>uri</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.Model">concerto.metamodel@0.4.0.Model</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.model"></a>
-<a id="schema_concerto.metamodel@0.4.0.Model"></a>
-<a id="tocSconcerto.metamodel@0.4.0.model"></a>
-<a id="tocsconcerto.metamodel@0.4.0.model"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Model"</span><span class="token punctuation">,</span><br>  <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"sourceUri"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"concertoVersion"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>  <span class="token property">"imports"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Import"</span><span class="token punctuation">,</span><br>      <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"uri"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><span class="token punctuation">,</span><br>  <span class="token property">"declarations"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Declaration"</span><span class="token punctuation">,</span><br>      <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>        <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>        <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>          <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>          <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>        <span class="token punctuation">}</span><span class="token punctuation">,</span><br>        <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>      <span class="token punctuation">}</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>Model</p>
-<h3 id="properties-96">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.Model</td>
-</tr>
-<tr>
-<td>namespace</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>sourceUri</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>concertoVersion</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-<tr>
-<td>imports</td>
-<td>[anyOf]</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.import">concerto.metamodel@0.4.0.Import</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Import</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.importall">concerto.metamodel@0.4.0.ImportAll</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.ImportAll</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.importtype">concerto.metamodel@0.4.0.ImportType</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.ImportType</td>
-</tr>
-</tbody>
-</table>
-<p>continued</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>declarations</td>
-<td>[anyOf]</td>
-<td>false</td>
-<td>none</td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
-<p>anyOf</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.declaration">concerto.metamodel@0.4.0.Declaration</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.Declaration</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.enumdeclaration">concerto.metamodel@0.4.0.EnumDeclaration</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.EnumDeclaration</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.conceptdeclaration">concerto.metamodel@0.4.0.ConceptDeclaration</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.ConceptDeclaration</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.assetdeclaration">concerto.metamodel@0.4.0.AssetDeclaration</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.AssetDeclaration</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.participantdeclaration">concerto.metamodel@0.4.0.ParticipantDeclaration</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.ParticipantDeclaration</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.transactiondeclaration">concerto.metamodel@0.4.0.TransactionDeclaration</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.TransactionDeclaration</td>
-</tr>
-</tbody>
-</table>
-<p>or</p>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>» <em>anonymous</em></td>
-<td><a href="#schemaconcerto.metamodel@0.4.0.eventdeclaration">concerto.metamodel@0.4.0.EventDeclaration</a></td>
-<td>false</td>
-<td>none</td>
-<td>An instance of concerto.metamodel@0.4.0.EventDeclaration</td>
-</tr>
-</tbody>
-</table>
-<h2 id="tocS_concerto.metamodel@0.4.0.Models">concerto.metamodel@0.4.0.Models</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.models"></a>
-<a id="schema_concerto.metamodel@0.4.0.Models"></a>
-<a id="tocSconcerto.metamodel@0.4.0.models"></a>
-<a id="tocsconcerto.metamodel@0.4.0.models"></a>
-<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span><br>  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Models"</span><span class="token punctuation">,</span><br>  <span class="token property">"models"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>    <span class="token punctuation">{</span><br>      <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Model"</span><span class="token punctuation">,</span><br>      <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"sourceUri"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"concertoVersion"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>      <span class="token property">"imports"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Import"</span><span class="token punctuation">,</span><br>          <span class="token property">"namespace"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"uri"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><span class="token punctuation">,</span><br>      <span class="token property">"declarations"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>        <span class="token punctuation">{</span><br>          <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Declaration"</span><span class="token punctuation">,</span><br>          <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>          <span class="token property">"decorators"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>            <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Decorator"</span><span class="token punctuation">,</span><br>              <span class="token property">"name"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span><br>              <span class="token property">"arguments"</span><span class="token operator">:</span> <span class="token punctuation">[</span><br>                <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.DecoratorLiteral"</span><span class="token punctuation">,</span><br>                  <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                    <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                    <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">,</span><br>                    <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">,</span><br>                    <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>                  <span class="token punctuation">}</span><br>                <span class="token punctuation">}</span><br>              <span class="token punctuation">]</span><span class="token punctuation">,</span><br>              <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>                <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>                  <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>                  <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>                  <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>                <span class="token punctuation">}</span><span class="token punctuation">,</span><br>                <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>              <span class="token punctuation">}</span><br>            <span class="token punctuation">}</span><br>          <span class="token punctuation">]</span><span class="token punctuation">,</span><br>          <span class="token property">"location"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>            <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Range"</span><span class="token punctuation">,</span><br>            <span class="token property">"start"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"end"</span><span class="token operator">:</span> <span class="token punctuation">{</span><br>              <span class="token property">"$class"</span><span class="token operator">:</span> <span class="token string">"concerto.metamodel@0.4.0.Position"</span><span class="token punctuation">,</span><br>              <span class="token property">"line"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"column"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span><br>              <span class="token property">"offset"</span><span class="token operator">:</span> <span class="token number">0</span><br>            <span class="token punctuation">}</span><span class="token punctuation">,</span><br>            <span class="token property">"source"</span><span class="token operator">:</span> <span class="token string">"string"</span><br>          <span class="token punctuation">}</span><br>        <span class="token punctuation">}</span><br>      <span class="token punctuation">]</span><br>    <span class="token punctuation">}</span><br>  <span class="token punctuation">]</span><br><span class="token punctuation">}</span><br></code></pre>
-<p>Models</p>
-<h3 id="properties-97">Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Type</th>
-<th>Required</th>
-<th>Restrictions</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>$class</td>
-<td>string</td>
-<td>true</td>
-<td>none</td>
-<td>The class identifier for concerto.metamodel@0.4.0.Models</td>
-</tr>
-<tr>
-<td>models</td>
-<td>[<a href="#schemaconcerto.metamodel@0.4.0.model">concerto.metamodel@0.4.0.Model</a>]</td>
-<td>true</td>
-<td>none</td>
-<td>[An instance of concerto.metamodel@0.4.0.Model]</td>
 </tr>
 </tbody>
 </table>

--- a/client/typescript/apap.ts
+++ b/client/typescript/apap.ts
@@ -3,1839 +3,2163 @@
  * Do not make direct changes to the file.
  */
 
-
 export interface paths {
-  "/sharedmodels": {
-    /**
-     * List All Sharedmodels 
-     * @description Gets a list of all `sharedmodel` entities.
-     */
-    get: operations["listSharedmodels"];
-    /**
-     * Create a Sharedmodel 
-     * @description Creates a new instance of a `sharedmodel`.
-     */
-    post: operations["createSharedmodel"];
-  };
-  "/sharedmodels/{uri}": {
-    /**
-     * Get a sharedmodel 
-     * @description Gets the details of a single instance of a `sharedmodel`.
-     */
-    get: operations["getSharedmodel"];
-    /**
-     * Update a sharedmodel 
-     * @description Updates an existing `sharedmodel`.
-     */
-    put: operations["replaceSharedmodel"];
-    /**
-     * Delete a sharedmodel 
-     * @description Deletes an existing `sharedmodel`.
-     */
-    delete: operations["deleteSharedmodel"];
-    parameters: {
-        /** @description A unique identifier for a `SharedModel`. */
-      path: {
-        uri: string;
-      };
+    "/sharedmodels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List All Sharedmodels
+         * @description Gets a list of all `sharedmodel` entities.
+         */
+        get: operations["listSharedmodels"];
+        put?: never;
+        /**
+         * Create a Sharedmodel
+         * @description Creates a new instance of a `sharedmodel`.
+         */
+        post: operations["createSharedmodel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-  };
-  "/templates": {
-    /**
-     * List All Templates 
-     * @description Gets a list of all `template` entities.
-     */
-    get: operations["listTemplates"];
-    /**
-     * Create a Template 
-     * @description Creates a new instance of a `template`.
-     */
-    post: operations["createTemplate"];
-  };
-  "/templates/{uri}": {
-    /**
-     * Get a template 
-     * @description Gets the details of a single instance of a `template`.
-     */
-    get: operations["getTemplate"];
-    /**
-     * Update a template 
-     * @description Updates an existing `template`.
-     */
-    put: operations["replaceTemplate"];
-    /**
-     * Delete a template 
-     * @description Deletes an existing `template`.
-     */
-    delete: operations["deleteTemplate"];
-    parameters: {
-        /** @description A unique identifier for a `Template`. */
-      path: {
-        uri: string;
-      };
+    "/sharedmodels/{uri}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `SharedModel`. */
+                uri: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Get a sharedmodel
+         * @description Gets the details of a single instance of a `sharedmodel`.
+         */
+        get: operations["getSharedmodel"];
+        /**
+         * Update a sharedmodel
+         * @description Updates an existing `sharedmodel`.
+         */
+        put: operations["replaceSharedmodel"];
+        post?: never;
+        /**
+         * Delete a sharedmodel
+         * @description Deletes an existing `sharedmodel`.
+         */
+        delete: operations["deleteSharedmodel"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-  };
-  "/agreements": {
-    /**
-     * List All Agreements 
-     * @description Gets a list of all `agreement` entities.
-     */
-    get: operations["listAgreements"];
-    /**
-     * Create a Agreement 
-     * @description Creates a new instance of a `agreement`.
-     */
-    post: operations["createAgreement"];
-  };
-  "/agreements/{uri}": {
-    /**
-     * Get a agreement 
-     * @description Gets the details of a single instance of a `agreement`.
-     */
-    get: operations["getAgreement"];
-    /**
-     * Update a agreement 
-     * @description Updates an existing `agreement`.
-     */
-    put: operations["replaceAgreement"];
-    /**
-     * Delete a agreement 
-     * @description Deletes an existing `agreement`.
-     */
-    delete: operations["deleteAgreement"];
-    parameters: {
-        /** @description A unique identifier for a `Agreement`. */
-      path: {
-        uri: string;
-      };
+    "/templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List All Templates
+         * @description Gets a list of all `template` entities.
+         */
+        get: operations["listTemplates"];
+        put?: never;
+        /**
+         * Create a Template
+         * @description Creates a new instance of a `template`.
+         */
+        post: operations["createTemplate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-  };
-  "/agreements/{agreementId}/convert/html": {
-    /**
-     * Convert agreement to HTML 
-     * @description Converts an existing `agreement` to HTML.
-     */
-    post: operations["convertAgreementHtml"];
-    parameters: {
-        /** @description A unique identifier for a `Agreement`. */
-      path: {
-        agreementId: string;
-      };
+    "/templates/{uri}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Template`. */
+                uri: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Get a template
+         * @description Gets the details of a single instance of a `template`.
+         */
+        get: operations["getTemplate"];
+        /**
+         * Update a template
+         * @description Updates an existing `template`.
+         */
+        put: operations["replaceTemplate"];
+        post?: never;
+        /**
+         * Delete a template
+         * @description Deletes an existing `template`.
+         */
+        delete: operations["deleteTemplate"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-  };
-  "/agreements/{agreementId}/trigger": {
-    /**
-     * Trigger an agreement 
-     * @description Sends data to an existing agreement.
-     */
-    post: operations["triggerAgreement"];
-    parameters: {
-        /** @description A unique identifier for a `Agreement`. */
-      path: {
-        agreementId: string;
-      };
+    "/agreements": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List All Agreements
+         * @description Gets a list of all `agreement` entities.
+         */
+        get: operations["listAgreements"];
+        put?: never;
+        /**
+         * Create a Agreement
+         * @description Creates a new instance of a `agreement`.
+         */
+        post: operations["createAgreement"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-  };
-  "/capabilities": {
-    /**
-     * Get server capabilities 
-     * @description Retrieve the supported features of the server.
-     */
-    get: operations["getCapabilities"];
-  };
+    "/agreements/{uri}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Agreement`. */
+                uri: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Get a agreement
+         * @description Gets the details of a single instance of a `agreement`.
+         */
+        get: operations["getAgreement"];
+        /**
+         * Update a agreement
+         * @description Updates an existing `agreement`.
+         */
+        put: operations["replaceAgreement"];
+        post?: never;
+        /**
+         * Delete a agreement
+         * @description Deletes an existing `agreement`.
+         */
+        delete: operations["deleteAgreement"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agreements/{agreementId}/convert/html": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Agreement`. */
+                agreementId: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Convert agreement to HTML
+         * @description Converts an existing `agreement` to HTML.
+         */
+        post: operations["convertAgreementHtml"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agreements/{agreementId}/trigger": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Agreement`. */
+                agreementId: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger an agreement
+         * @description Sends data to an existing agreement.
+         */
+        post: operations["triggerAgreement"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/capabilities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get server capabilities
+         * @description Retrieve the supported features of the server.
+         */
+        get: operations["getCapabilities"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
-
 export type webhooks = Record<string, never>;
-
 export interface components {
-  schemas: {
-    "org.accordproject.protocol@1.0.0.URI": string;
-    "org.accordproject.protocol@1.0.0.JSON": string;
-    "org.accordproject.protocol@1.0.0.FullyQualifiedTypeName": string;
-    /**
-     * Blob 
-     * @description An instance of org.accordproject.protocol@1.0.0.Blob
-     */
-    "org.accordproject.protocol@1.0.0.Blob": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.Blob 
-       * @default org.accordproject.protocol@1.0.0.Blob
-       */
-      $class: string;
-      base64: string;
-      mimeType: string;
-    };
-    /**
-     * Text 
-     * @description An instance of org.accordproject.protocol@1.0.0.Text
-     */
-    "org.accordproject.protocol@1.0.0.Text": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.Text 
-       * @default org.accordproject.protocol@1.0.0.Text
-       */
-      $class: string;
-      templateMark?: components["schemas"]["org.accordproject.commonmark@0.5.0.Document"];
-      templateText?: string;
-    };
-    /**
-     * DomainModel 
-     * @description An instance of org.accordproject.protocol@1.0.0.DomainModel
-     */
-    "org.accordproject.protocol@1.0.0.DomainModel": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.DomainModel 
-       * @default org.accordproject.protocol@1.0.0.DomainModel
-       */
-      $class: string;
-    };
-    /**
-     * CtoFile 
-     * @description An instance of org.accordproject.protocol@1.0.0.CtoFile
-     */
-    "org.accordproject.protocol@1.0.0.CtoFile": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.CtoFile 
-       * @default org.accordproject.protocol@1.0.0.CtoFile
-       */
-      $class: string;
-      contents: string;
-      filename: string;
-    };
-    /**
-     * CtoModel 
-     * @description An instance of org.accordproject.protocol@1.0.0.CtoModel
-     */
-    "org.accordproject.protocol@1.0.0.CtoModel": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.CtoModel 
-       * @default org.accordproject.protocol@1.0.0.CtoModel
-       */
-      $class: string;
-      ctoFiles: (components["schemas"]["org.accordproject.protocol@1.0.0.CtoFile"])[];
-    };
-    /**
-     * JsonModel 
-     * @description An instance of org.accordproject.protocol@1.0.0.JsonModel
-     */
-    "org.accordproject.protocol@1.0.0.JsonModel": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.JsonModel 
-       * @default org.accordproject.protocol@1.0.0.JsonModel
-       */
-      $class: string;
-      model?: components["schemas"]["concerto.metamodel@0.4.0.Model"];
-    };
-    /**
-     * TemplateModel 
-     * @description An instance of org.accordproject.protocol@1.0.0.TemplateModel
-     */
-    "org.accordproject.protocol@1.0.0.TemplateModel": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.TemplateModel 
-       * @default org.accordproject.protocol@1.0.0.TemplateModel
-       */
-      $class: string;
-      typeName: string;
-      /** @description The identifier of an instance of org.accordproject.protocol@1.0.0.SharedModel */
-      sharedModel?: string;
-      model?: components["schemas"]["org.accordproject.protocol@1.0.0.DomainModel"] | components["schemas"]["org.accordproject.protocol@1.0.0.CtoModel"] | components["schemas"]["org.accordproject.protocol@1.0.0.JsonModel"];
-    };
-    /**
-     * SharedModel 
-     * @description An instance of org.accordproject.protocol@1.0.0.SharedModel
-     */
-    "org.accordproject.protocol@1.0.0.SharedModel": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.SharedModel 
-       * @default org.accordproject.protocol@1.0.0.SharedModel
-       */
-      $class: string;
-      /** @description The instance identifier for this type */
-      uri: string;
-      model: components["schemas"]["org.accordproject.protocol@1.0.0.DomainModel"] | components["schemas"]["org.accordproject.protocol@1.0.0.CtoModel"] | components["schemas"]["org.accordproject.protocol@1.0.0.JsonModel"];
-    };
-    /**
-     * CodeType 
-     * @description An instance of org.accordproject.protocol@1.0.0.CodeType 
-     * @enum {unknown}
-     */
-    "org.accordproject.protocol@1.0.0.CodeType": "ES2015" | "WASM_BYTES" | "TYPESCRIPT";
-    /**
-     * CodeEncodingType 
-     * @description An instance of org.accordproject.protocol@1.0.0.CodeEncodingType 
-     * @enum {unknown}
-     */
-    "org.accordproject.protocol@1.0.0.CodeEncodingType": "PLAIN_TEXT" | "BASE64";
-    /**
-     * Code 
-     * @description An instance of org.accordproject.protocol@1.0.0.Code
-     */
-    "org.accordproject.protocol@1.0.0.Code": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.Code 
-       * @default org.accordproject.protocol@1.0.0.Code
-       */
-      $class: string;
-      /** @description The instance identifier for this type */
-      id: string;
-      type: components["schemas"]["org.accordproject.protocol@1.0.0.CodeType"];
-      encoding: components["schemas"]["org.accordproject.protocol@1.0.0.CodeEncodingType"];
-      value: string;
-    };
-    /**
-     * Logic 
-     * @description An instance of org.accordproject.protocol@1.0.0.Logic
-     */
-    "org.accordproject.protocol@1.0.0.Logic": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.Logic 
-       * @default org.accordproject.protocol@1.0.0.Logic
-       */
-      $class: string;
-      stateType?: string;
-      codes: (components["schemas"]["org.accordproject.protocol@1.0.0.Code"])[];
-    };
-    /**
-     * TemplateMetadata 
-     * @description An instance of org.accordproject.protocol@1.0.0.TemplateMetadata
-     */
-    "org.accordproject.protocol@1.0.0.TemplateMetadata": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.TemplateMetadata 
-       * @default org.accordproject.protocol@1.0.0.TemplateMetadata
-       */
-      $class: string;
-      runtime: string;
-      template: string;
-      cicero: string;
-    };
-    /**
-     * Template 
-     * @description An instance of org.accordproject.protocol@1.0.0.Template
-     */
-    "org.accordproject.protocol@1.0.0.Template": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.Template 
-       * @default org.accordproject.protocol@1.0.0.Template
-       */
-      $class: string;
-      /** @description The instance identifier for this type */
-      uri: string;
-      author: string;
-      displayName?: string;
-      version: string;
-      description?: string;
-      license: string;
-      keywords?: (string)[];
-      metadata: components["schemas"]["org.accordproject.protocol@1.0.0.TemplateMetadata"];
-      logo?: components["schemas"]["org.accordproject.protocol@1.0.0.Blob"];
-      templateModel: components["schemas"]["org.accordproject.protocol@1.0.0.TemplateModel"];
-      text: components["schemas"]["org.accordproject.protocol@1.0.0.Text"];
-      logic?: components["schemas"]["org.accordproject.protocol@1.0.0.Logic"];
-      sampleRequest?: string;
-    };
-    /**
-     * KeyValue 
-     * @description An instance of org.accordproject.protocol@1.0.0.KeyValue
-     */
-    "org.accordproject.protocol@1.0.0.KeyValue": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.KeyValue 
-       * @default org.accordproject.protocol@1.0.0.KeyValue
-       */
-      $class: string;
-      key: string;
-      value: string;
-    };
-    /**
-     * Metadata 
-     * @description An instance of org.accordproject.protocol@1.0.0.Metadata
-     */
-    "org.accordproject.protocol@1.0.0.Metadata": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.Metadata 
-       * @default org.accordproject.protocol@1.0.0.Metadata
-       */
-      $class: string;
-      values: (components["schemas"]["org.accordproject.protocol@1.0.0.KeyValue"])[];
-    };
-    /**
-     * AgreementStatusType 
-     * @description An instance of org.accordproject.protocol@1.0.0.AgreementStatusType 
-     * @enum {unknown}
-     */
-    "org.accordproject.protocol@1.0.0.AgreementStatusType": "DRAFT" | "SIGNNG" | "COMPLETED" | "SUPERSEDED";
-    /**
-     * Agreement 
-     * @description An instance of org.accordproject.protocol@1.0.0.Agreement
-     */
-    "org.accordproject.protocol@1.0.0.Agreement": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.Agreement 
-       * @default org.accordproject.protocol@1.0.0.Agreement
-       */
-      $class: string;
-      /** @description The instance identifier for this type */
-      uri: string;
-      data: string;
-      /** @description The identifier of an instance of org.accordproject.protocol@1.0.0.Template */
-      template: string;
-      state?: string;
-      agreementStatus: components["schemas"]["org.accordproject.protocol@1.0.0.AgreementStatusType"];
-      agreementParties?: (components["schemas"]["org.accordproject.protocol@1.0.0.AgreementParty"])[];
-      signatures?: (components["schemas"]["org.accordproject.protocol@1.0.0.Signature"])[];
-      historyEntries?: (components["schemas"]["org.accordproject.protocol@1.0.0.HistoryEntry"])[];
-      attachments?: (components["schemas"]["org.accordproject.protocol@1.0.0.Blob"])[];
-      references?: (string)[];
-      metadata?: components["schemas"]["org.accordproject.protocol@1.0.0.Metadata"];
-    };
-    /**
-     * AgreementParty 
-     * @description An instance of org.accordproject.protocol@1.0.0.AgreementParty
-     */
-    "org.accordproject.protocol@1.0.0.AgreementParty": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.AgreementParty 
-       * @default org.accordproject.protocol@1.0.0.AgreementParty
-       */
-      $class: string;
-      name: string;
-      signatory: boolean;
-      role?: string;
-      email?: string;
-      phone?: string;
-      company?: string;
-      network?: string;
-      address?: components["schemas"]["org.accordproject.protocol@1.0.0.Address"];
-      /** @description The instance identifier for this type */
-      partyId: string;
-    };
-    /**
-     * Address 
-     * @description An instance of org.accordproject.protocol@1.0.0.Address
-     */
-    "org.accordproject.protocol@1.0.0.Address": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.Address 
-       * @default org.accordproject.protocol@1.0.0.Address
-       */
-      $class: string;
-      streetRoad: (string)[];
-      suburbTownCity?: string;
-      stateTerritoryRegion?: string;
-      postalCode?: string;
-      country?: string;
-    };
-    /**
-     * HistoryEntry 
-     * @description An instance of org.accordproject.protocol@1.0.0.HistoryEntry
-     */
-    "org.accordproject.protocol@1.0.0.HistoryEntry": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.HistoryEntry 
-       * @default org.accordproject.protocol@1.0.0.HistoryEntry
-       */
-      $class: string;
-      agreementStatus: components["schemas"]["org.accordproject.protocol@1.0.0.AgreementStatusType"];
-      data: string;
-      metadata: components["schemas"]["org.accordproject.protocol@1.0.0.Metadata"];
-    };
-    /**
-     * Signature 
-     * @description An instance of org.accordproject.protocol@1.0.0.Signature
-     */
-    "org.accordproject.protocol@1.0.0.Signature": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.Signature 
-       * @default org.accordproject.protocol@1.0.0.Signature
-       */
-      $class: string;
-      signatory: components["schemas"]["org.accordproject.protocol@1.0.0.AgreementParty"];
-      /** Format: date-time */
-      signedAt?: string;
-      metadata: components["schemas"]["org.accordproject.protocol@1.0.0.Metadata"];
-      signatureImage: (components["schemas"]["org.accordproject.protocol@1.0.0.Blob"])[];
-    };
-    /**
-     * ConversionOptions 
-     * @description An instance of org.accordproject.protocol@1.0.0.ConversionOptions
-     */
-    "org.accordproject.protocol@1.0.0.ConversionOptions": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.ConversionOptions 
-       * @default org.accordproject.protocol@1.0.0.ConversionOptions
-       */
-      $class: string;
-    };
-    /**
-     * HtmlConversionOptions 
-     * @description An instance of org.accordproject.protocol@1.0.0.HtmlConversionOptions
-     */
-    "org.accordproject.protocol@1.0.0.HtmlConversionOptions": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.HtmlConversionOptions 
-       * @default org.accordproject.protocol@1.0.0.HtmlConversionOptions
-       */
-      $class: string;
-    };
-    /**
-     * FeatureType 
-     * @description An instance of org.accordproject.protocol@1.0.0.FeatureType 
-     * @enum {unknown}
-     */
-    "org.accordproject.protocol@1.0.0.FeatureType": "TEMPLATE_MANAGE" | "TEMPLATE_VERIFY_SIGNATURES" | "TEMPLATE_LOGIC" | "TEMPLATE_STATEFUL" | "LOGIC_WASM" | "LOGIC_ES2015" | "LOGIC_TYPESCRIPT" | "AGREEMENT_MANAGE" | "AGREEMENT_TRIGGER" | "AGREEMENT_STATE" | "AGREEMENT_CONVERT_HTML" | "AGREEMENT_SIGNING" | "SHARED_MODEL_MANAGE";
-    /**
-     * Capabilities 
-     * @description An instance of org.accordproject.protocol@1.0.0.Capabilities
-     */
-    "org.accordproject.protocol@1.0.0.Capabilities": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.Capabilities 
-       * @default org.accordproject.protocol@1.0.0.Capabilities
-       */
-      $class: string;
-      features: (components["schemas"]["org.accordproject.protocol@1.0.0.FeatureType"])[];
-    };
-    /**
-     * TriggerRequest 
-     * @description An instance of org.accordproject.protocol@1.0.0.TriggerRequest
-     */
-    "org.accordproject.protocol@1.0.0.TriggerRequest": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.TriggerRequest 
-       * @default org.accordproject.protocol@1.0.0.TriggerRequest
-       */
-      $class: string;
-      payload: string;
-    };
-    /**
-     * TriggerResponse 
-     * @description An instance of org.accordproject.protocol@1.0.0.TriggerResponse
-     */
-    "org.accordproject.protocol@1.0.0.TriggerResponse": {
-      /**
-       * @description The class identifier for org.accordproject.protocol@1.0.0.TriggerResponse 
-       * @default org.accordproject.protocol@1.0.0.TriggerResponse
-       */
-      $class: string;
-      result?: string;
-      isError: boolean;
-      errorMessage?: string;
-      errorDetails?: string;
-    };
-    /**
-     * Node 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Node
-     */
-    "org.accordproject.commonmark@0.5.0.Node": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Node 
-       * @default org.accordproject.commonmark@0.5.0.Node
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Root 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Root
-     */
-    "org.accordproject.commonmark@0.5.0.Root": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Root 
-       * @default org.accordproject.commonmark@0.5.0.Root
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Child 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Child
-     */
-    "org.accordproject.commonmark@0.5.0.Child": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Child 
-       * @default org.accordproject.commonmark@0.5.0.Child
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Text 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Text
-     */
-    "org.accordproject.commonmark@0.5.0.Text": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Text 
-       * @default org.accordproject.commonmark@0.5.0.Text
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Attribute 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Attribute
-     */
-    "org.accordproject.commonmark@0.5.0.Attribute": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Attribute 
-       * @default org.accordproject.commonmark@0.5.0.Attribute
-       */
-      $class: string;
-      name: string;
-      value: string;
-    };
-    /**
-     * TagInfo 
-     * @description An instance of org.accordproject.commonmark@0.5.0.TagInfo
-     */
-    "org.accordproject.commonmark@0.5.0.TagInfo": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.TagInfo 
-       * @default org.accordproject.commonmark@0.5.0.TagInfo
-       */
-      $class: string;
-      tagName: string;
-      attributeString: string;
-      attributes: (components["schemas"]["org.accordproject.commonmark@0.5.0.Attribute"])[];
-      content: string;
-      closed: boolean;
-    };
-    /**
-     * CodeBlock 
-     * @description An instance of org.accordproject.commonmark@0.5.0.CodeBlock
-     */
-    "org.accordproject.commonmark@0.5.0.CodeBlock": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.CodeBlock 
-       * @default org.accordproject.commonmark@0.5.0.CodeBlock
-       */
-      $class: string;
-      info?: string;
-      tag?: components["schemas"]["org.accordproject.commonmark@0.5.0.TagInfo"];
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Code 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Code
-     */
-    "org.accordproject.commonmark@0.5.0.Code": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Code 
-       * @default org.accordproject.commonmark@0.5.0.Code
-       */
-      $class: string;
-      info?: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * HtmlInline 
-     * @description An instance of org.accordproject.commonmark@0.5.0.HtmlInline
-     */
-    "org.accordproject.commonmark@0.5.0.HtmlInline": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.HtmlInline 
-       * @default org.accordproject.commonmark@0.5.0.HtmlInline
-       */
-      $class: string;
-      tag?: components["schemas"]["org.accordproject.commonmark@0.5.0.TagInfo"];
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * HtmlBlock 
-     * @description An instance of org.accordproject.commonmark@0.5.0.HtmlBlock
-     */
-    "org.accordproject.commonmark@0.5.0.HtmlBlock": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.HtmlBlock 
-       * @default org.accordproject.commonmark@0.5.0.HtmlBlock
-       */
-      $class: string;
-      tag?: components["schemas"]["org.accordproject.commonmark@0.5.0.TagInfo"];
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Emph 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Emph
-     */
-    "org.accordproject.commonmark@0.5.0.Emph": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Emph 
-       * @default org.accordproject.commonmark@0.5.0.Emph
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Strong 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Strong
-     */
-    "org.accordproject.commonmark@0.5.0.Strong": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Strong 
-       * @default org.accordproject.commonmark@0.5.0.Strong
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * BlockQuote 
-     * @description An instance of org.accordproject.commonmark@0.5.0.BlockQuote
-     */
-    "org.accordproject.commonmark@0.5.0.BlockQuote": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.BlockQuote 
-       * @default org.accordproject.commonmark@0.5.0.BlockQuote
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Heading 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Heading
-     */
-    "org.accordproject.commonmark@0.5.0.Heading": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Heading 
-       * @default org.accordproject.commonmark@0.5.0.Heading
-       */
-      $class: string;
-      level: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * ThematicBreak 
-     * @description An instance of org.accordproject.commonmark@0.5.0.ThematicBreak
-     */
-    "org.accordproject.commonmark@0.5.0.ThematicBreak": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.ThematicBreak 
-       * @default org.accordproject.commonmark@0.5.0.ThematicBreak
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Softbreak 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Softbreak
-     */
-    "org.accordproject.commonmark@0.5.0.Softbreak": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Softbreak 
-       * @default org.accordproject.commonmark@0.5.0.Softbreak
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Linebreak 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Linebreak
-     */
-    "org.accordproject.commonmark@0.5.0.Linebreak": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Linebreak 
-       * @default org.accordproject.commonmark@0.5.0.Linebreak
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Link 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Link
-     */
-    "org.accordproject.commonmark@0.5.0.Link": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Link 
-       * @default org.accordproject.commonmark@0.5.0.Link
-       */
-      $class: string;
-      destination: string;
-      title: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Image 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Image
-     */
-    "org.accordproject.commonmark@0.5.0.Image": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Image 
-       * @default org.accordproject.commonmark@0.5.0.Image
-       */
-      $class: string;
-      destination: string;
-      title: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Paragraph 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Paragraph
-     */
-    "org.accordproject.commonmark@0.5.0.Paragraph": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Paragraph 
-       * @default org.accordproject.commonmark@0.5.0.Paragraph
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * List 
-     * @description An instance of org.accordproject.commonmark@0.5.0.List
-     */
-    "org.accordproject.commonmark@0.5.0.List": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.List 
-       * @default org.accordproject.commonmark@0.5.0.List
-       */
-      $class: string;
-      type: string;
-      start?: string;
-      tight: string;
-      delimiter?: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Item 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Item
-     */
-    "org.accordproject.commonmark@0.5.0.Item": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Item 
-       * @default org.accordproject.commonmark@0.5.0.Item
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Document 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Document
-     */
-    "org.accordproject.commonmark@0.5.0.Document": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Document 
-       * @default org.accordproject.commonmark@0.5.0.Document
-       */
-      $class: string;
-      xmlns: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Table 
-     * @description An instance of org.accordproject.commonmark@0.5.0.Table
-     */
-    "org.accordproject.commonmark@0.5.0.Table": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.Table 
-       * @default org.accordproject.commonmark@0.5.0.Table
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * TableHead 
-     * @description An instance of org.accordproject.commonmark@0.5.0.TableHead
-     */
-    "org.accordproject.commonmark@0.5.0.TableHead": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.TableHead 
-       * @default org.accordproject.commonmark@0.5.0.TableHead
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * TableBody 
-     * @description An instance of org.accordproject.commonmark@0.5.0.TableBody
-     */
-    "org.accordproject.commonmark@0.5.0.TableBody": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.TableBody 
-       * @default org.accordproject.commonmark@0.5.0.TableBody
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * TableRow 
-     * @description An instance of org.accordproject.commonmark@0.5.0.TableRow
-     */
-    "org.accordproject.commonmark@0.5.0.TableRow": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.TableRow 
-       * @default org.accordproject.commonmark@0.5.0.TableRow
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * HeaderCell 
-     * @description An instance of org.accordproject.commonmark@0.5.0.HeaderCell
-     */
-    "org.accordproject.commonmark@0.5.0.HeaderCell": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.HeaderCell 
-       * @default org.accordproject.commonmark@0.5.0.HeaderCell
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * TableCell 
-     * @description An instance of org.accordproject.commonmark@0.5.0.TableCell
-     */
-    "org.accordproject.commonmark@0.5.0.TableCell": {
-      /**
-       * @description The class identifier for org.accordproject.commonmark@0.5.0.TableCell 
-       * @default org.accordproject.commonmark@0.5.0.TableCell
-       */
-      $class: string;
-      text?: string;
-      nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
-      startLine?: number;
-      endLine?: number;
-    };
-    /**
-     * Party 
-     * @description An instance of org.accordproject.party@0.2.0.Party
-     */
-    "org.accordproject.party@0.2.0.Party": {
-      /**
-       * @description The class identifier for org.accordproject.party@0.2.0.Party 
-       * @default org.accordproject.party@0.2.0.Party
-       */
-      $class: string;
-      /** @description The instance identifier for this type */
-      partyId: string;
-    };
-    /**
-     * Position 
-     * @description An instance of concerto.metamodel@0.4.0.Position
-     */
-    "concerto.metamodel@0.4.0.Position": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.Position 
-       * @default concerto.metamodel@0.4.0.Position
-       */
-      $class: string;
-      line: number;
-      column: number;
-      offset: number;
-    };
-    /**
-     * Range 
-     * @description An instance of concerto.metamodel@0.4.0.Range
-     */
-    "concerto.metamodel@0.4.0.Range": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.Range 
-       * @default concerto.metamodel@0.4.0.Range
-       */
-      $class: string;
-      start: components["schemas"]["concerto.metamodel@0.4.0.Position"];
-      end: components["schemas"]["concerto.metamodel@0.4.0.Position"];
-      source?: string;
-    };
-    /**
-     * TypeIdentifier 
-     * @description An instance of concerto.metamodel@0.4.0.TypeIdentifier
-     */
-    "concerto.metamodel@0.4.0.TypeIdentifier": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.TypeIdentifier 
-       * @default concerto.metamodel@0.4.0.TypeIdentifier
-       */
-      $class: string;
-      name: string;
-      namespace?: string;
-    };
-    /**
-     * DecoratorLiteral 
-     * @description An instance of concerto.metamodel@0.4.0.DecoratorLiteral
-     */
-    "concerto.metamodel@0.4.0.DecoratorLiteral": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.DecoratorLiteral 
-       * @default concerto.metamodel@0.4.0.DecoratorLiteral
-       */
-      $class: string;
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * DecoratorString 
-     * @description An instance of concerto.metamodel@0.4.0.DecoratorString
-     */
-    "concerto.metamodel@0.4.0.DecoratorString": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.DecoratorString 
-       * @default concerto.metamodel@0.4.0.DecoratorString
-       */
-      $class: string;
-      value: string;
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * DecoratorNumber 
-     * @description An instance of concerto.metamodel@0.4.0.DecoratorNumber
-     */
-    "concerto.metamodel@0.4.0.DecoratorNumber": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.DecoratorNumber 
-       * @default concerto.metamodel@0.4.0.DecoratorNumber
-       */
-      $class: string;
-      value: number;
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * DecoratorBoolean 
-     * @description An instance of concerto.metamodel@0.4.0.DecoratorBoolean
-     */
-    "concerto.metamodel@0.4.0.DecoratorBoolean": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.DecoratorBoolean 
-       * @default concerto.metamodel@0.4.0.DecoratorBoolean
-       */
-      $class: string;
-      value: boolean;
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * DecoratorTypeReference 
-     * @description An instance of concerto.metamodel@0.4.0.DecoratorTypeReference
-     */
-    "concerto.metamodel@0.4.0.DecoratorTypeReference": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.DecoratorTypeReference 
-       * @default concerto.metamodel@0.4.0.DecoratorTypeReference
-       */
-      $class: string;
-      type: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
-      /** @default false */
-      isArray: boolean;
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * Decorator 
-     * @description An instance of concerto.metamodel@0.4.0.Decorator
-     */
-    "concerto.metamodel@0.4.0.Decorator": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.Decorator 
-       * @default concerto.metamodel@0.4.0.Decorator
-       */
-      $class: string;
-      name: string;
-      arguments?: (components["schemas"]["concerto.metamodel@0.4.0.DecoratorLiteral"] | components["schemas"]["concerto.metamodel@0.4.0.DecoratorString"] | components["schemas"]["concerto.metamodel@0.4.0.DecoratorNumber"] | components["schemas"]["concerto.metamodel@0.4.0.DecoratorBoolean"] | components["schemas"]["concerto.metamodel@0.4.0.DecoratorTypeReference"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * Identified 
-     * @description An instance of concerto.metamodel@0.4.0.Identified
-     */
-    "concerto.metamodel@0.4.0.Identified": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.Identified 
-       * @default concerto.metamodel@0.4.0.Identified
-       */
-      $class: string;
-    };
-    /**
-     * IdentifiedBy 
-     * @description An instance of concerto.metamodel@0.4.0.IdentifiedBy
-     */
-    "concerto.metamodel@0.4.0.IdentifiedBy": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.IdentifiedBy 
-       * @default concerto.metamodel@0.4.0.IdentifiedBy
-       */
-      $class: string;
-      name: string;
-    };
-    /**
-     * Declaration 
-     * @description An instance of concerto.metamodel@0.4.0.Declaration
-     */
-    "concerto.metamodel@0.4.0.Declaration": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.Declaration 
-       * @default concerto.metamodel@0.4.0.Declaration
-       */
-      $class: string;
-      name: string;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * EnumDeclaration 
-     * @description An instance of concerto.metamodel@0.4.0.EnumDeclaration
-     */
-    "concerto.metamodel@0.4.0.EnumDeclaration": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.EnumDeclaration 
-       * @default concerto.metamodel@0.4.0.EnumDeclaration
-       */
-      $class: string;
-      properties: (components["schemas"]["concerto.metamodel@0.4.0.EnumProperty"])[];
-      name: string;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * EnumProperty 
-     * @description An instance of concerto.metamodel@0.4.0.EnumProperty
-     */
-    "concerto.metamodel@0.4.0.EnumProperty": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.EnumProperty 
-       * @default concerto.metamodel@0.4.0.EnumProperty
-       */
-      $class: string;
-      name: string;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * ConceptDeclaration 
-     * @description An instance of concerto.metamodel@0.4.0.ConceptDeclaration
-     */
-    "concerto.metamodel@0.4.0.ConceptDeclaration": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.ConceptDeclaration 
-       * @default concerto.metamodel@0.4.0.ConceptDeclaration
-       */
-      $class: string;
-      /** @default false */
-      isAbstract: boolean;
-      identified?: components["schemas"]["concerto.metamodel@0.4.0.Identified"] | components["schemas"]["concerto.metamodel@0.4.0.IdentifiedBy"];
-      superType?: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
-      properties: (components["schemas"]["concerto.metamodel@0.4.0.Property"] | components["schemas"]["concerto.metamodel@0.4.0.RelationshipProperty"] | components["schemas"]["concerto.metamodel@0.4.0.ObjectProperty"] | components["schemas"]["concerto.metamodel@0.4.0.BooleanProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DateTimeProperty"] | components["schemas"]["concerto.metamodel@0.4.0.StringProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DoubleProperty"] | components["schemas"]["concerto.metamodel@0.4.0.IntegerProperty"] | components["schemas"]["concerto.metamodel@0.4.0.LongProperty"])[];
-      name: string;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * AssetDeclaration 
-     * @description An instance of concerto.metamodel@0.4.0.AssetDeclaration
-     */
-    "concerto.metamodel@0.4.0.AssetDeclaration": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.AssetDeclaration 
-       * @default concerto.metamodel@0.4.0.AssetDeclaration
-       */
-      $class: string;
-      /** @default false */
-      isAbstract: boolean;
-      identified?: components["schemas"]["concerto.metamodel@0.4.0.Identified"] | components["schemas"]["concerto.metamodel@0.4.0.IdentifiedBy"];
-      superType?: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
-      properties: (components["schemas"]["concerto.metamodel@0.4.0.Property"] | components["schemas"]["concerto.metamodel@0.4.0.RelationshipProperty"] | components["schemas"]["concerto.metamodel@0.4.0.ObjectProperty"] | components["schemas"]["concerto.metamodel@0.4.0.BooleanProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DateTimeProperty"] | components["schemas"]["concerto.metamodel@0.4.0.StringProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DoubleProperty"] | components["schemas"]["concerto.metamodel@0.4.0.IntegerProperty"] | components["schemas"]["concerto.metamodel@0.4.0.LongProperty"])[];
-      name: string;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * ParticipantDeclaration 
-     * @description An instance of concerto.metamodel@0.4.0.ParticipantDeclaration
-     */
-    "concerto.metamodel@0.4.0.ParticipantDeclaration": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.ParticipantDeclaration 
-       * @default concerto.metamodel@0.4.0.ParticipantDeclaration
-       */
-      $class: string;
-      /** @default false */
-      isAbstract: boolean;
-      identified?: components["schemas"]["concerto.metamodel@0.4.0.Identified"] | components["schemas"]["concerto.metamodel@0.4.0.IdentifiedBy"];
-      superType?: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
-      properties: (components["schemas"]["concerto.metamodel@0.4.0.Property"] | components["schemas"]["concerto.metamodel@0.4.0.RelationshipProperty"] | components["schemas"]["concerto.metamodel@0.4.0.ObjectProperty"] | components["schemas"]["concerto.metamodel@0.4.0.BooleanProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DateTimeProperty"] | components["schemas"]["concerto.metamodel@0.4.0.StringProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DoubleProperty"] | components["schemas"]["concerto.metamodel@0.4.0.IntegerProperty"] | components["schemas"]["concerto.metamodel@0.4.0.LongProperty"])[];
-      name: string;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * TransactionDeclaration 
-     * @description An instance of concerto.metamodel@0.4.0.TransactionDeclaration
-     */
-    "concerto.metamodel@0.4.0.TransactionDeclaration": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.TransactionDeclaration 
-       * @default concerto.metamodel@0.4.0.TransactionDeclaration
-       */
-      $class: string;
-      /** @default false */
-      isAbstract: boolean;
-      identified?: components["schemas"]["concerto.metamodel@0.4.0.Identified"] | components["schemas"]["concerto.metamodel@0.4.0.IdentifiedBy"];
-      superType?: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
-      properties: (components["schemas"]["concerto.metamodel@0.4.0.Property"] | components["schemas"]["concerto.metamodel@0.4.0.RelationshipProperty"] | components["schemas"]["concerto.metamodel@0.4.0.ObjectProperty"] | components["schemas"]["concerto.metamodel@0.4.0.BooleanProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DateTimeProperty"] | components["schemas"]["concerto.metamodel@0.4.0.StringProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DoubleProperty"] | components["schemas"]["concerto.metamodel@0.4.0.IntegerProperty"] | components["schemas"]["concerto.metamodel@0.4.0.LongProperty"])[];
-      name: string;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * EventDeclaration 
-     * @description An instance of concerto.metamodel@0.4.0.EventDeclaration
-     */
-    "concerto.metamodel@0.4.0.EventDeclaration": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.EventDeclaration 
-       * @default concerto.metamodel@0.4.0.EventDeclaration
-       */
-      $class: string;
-      /** @default false */
-      isAbstract: boolean;
-      identified?: components["schemas"]["concerto.metamodel@0.4.0.Identified"] | components["schemas"]["concerto.metamodel@0.4.0.IdentifiedBy"];
-      superType?: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
-      properties: (components["schemas"]["concerto.metamodel@0.4.0.Property"] | components["schemas"]["concerto.metamodel@0.4.0.RelationshipProperty"] | components["schemas"]["concerto.metamodel@0.4.0.ObjectProperty"] | components["schemas"]["concerto.metamodel@0.4.0.BooleanProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DateTimeProperty"] | components["schemas"]["concerto.metamodel@0.4.0.StringProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DoubleProperty"] | components["schemas"]["concerto.metamodel@0.4.0.IntegerProperty"] | components["schemas"]["concerto.metamodel@0.4.0.LongProperty"])[];
-      name: string;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * Property 
-     * @description An instance of concerto.metamodel@0.4.0.Property
-     */
-    "concerto.metamodel@0.4.0.Property": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.Property 
-       * @default concerto.metamodel@0.4.0.Property
-       */
-      $class: string;
-      name: string;
-      /** @default false */
-      isArray: boolean;
-      /** @default false */
-      isOptional: boolean;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * RelationshipProperty 
-     * @description An instance of concerto.metamodel@0.4.0.RelationshipProperty
-     */
-    "concerto.metamodel@0.4.0.RelationshipProperty": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.RelationshipProperty 
-       * @default concerto.metamodel@0.4.0.RelationshipProperty
-       */
-      $class: string;
-      type: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
-      name: string;
-      /** @default false */
-      isArray: boolean;
-      /** @default false */
-      isOptional: boolean;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * ObjectProperty 
-     * @description An instance of concerto.metamodel@0.4.0.ObjectProperty
-     */
-    "concerto.metamodel@0.4.0.ObjectProperty": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.ObjectProperty 
-       * @default concerto.metamodel@0.4.0.ObjectProperty
-       */
-      $class: string;
-      defaultValue?: string;
-      type: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
-      name: string;
-      /** @default false */
-      isArray: boolean;
-      /** @default false */
-      isOptional: boolean;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * BooleanProperty 
-     * @description An instance of concerto.metamodel@0.4.0.BooleanProperty
-     */
-    "concerto.metamodel@0.4.0.BooleanProperty": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.BooleanProperty 
-       * @default concerto.metamodel@0.4.0.BooleanProperty
-       */
-      $class: string;
-      defaultValue?: boolean;
-      name: string;
-      /** @default false */
-      isArray: boolean;
-      /** @default false */
-      isOptional: boolean;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * DateTimeProperty 
-     * @description An instance of concerto.metamodel@0.4.0.DateTimeProperty
-     */
-    "concerto.metamodel@0.4.0.DateTimeProperty": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.DateTimeProperty 
-       * @default concerto.metamodel@0.4.0.DateTimeProperty
-       */
-      $class: string;
-      name: string;
-      /** @default false */
-      isArray: boolean;
-      /** @default false */
-      isOptional: boolean;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * StringProperty 
-     * @description An instance of concerto.metamodel@0.4.0.StringProperty
-     */
-    "concerto.metamodel@0.4.0.StringProperty": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.StringProperty 
-       * @default concerto.metamodel@0.4.0.StringProperty
-       */
-      $class: string;
-      defaultValue?: string;
-      validator?: components["schemas"]["concerto.metamodel@0.4.0.StringRegexValidator"];
-      name: string;
-      /** @default false */
-      isArray: boolean;
-      /** @default false */
-      isOptional: boolean;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * StringRegexValidator 
-     * @description An instance of concerto.metamodel@0.4.0.StringRegexValidator
-     */
-    "concerto.metamodel@0.4.0.StringRegexValidator": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.StringRegexValidator 
-       * @default concerto.metamodel@0.4.0.StringRegexValidator
-       */
-      $class: string;
-      pattern: string;
-      flags: string;
-    };
-    /**
-     * DoubleProperty 
-     * @description An instance of concerto.metamodel@0.4.0.DoubleProperty
-     */
-    "concerto.metamodel@0.4.0.DoubleProperty": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.DoubleProperty 
-       * @default concerto.metamodel@0.4.0.DoubleProperty
-       */
-      $class: string;
-      defaultValue?: number;
-      validator?: components["schemas"]["concerto.metamodel@0.4.0.DoubleDomainValidator"];
-      name: string;
-      /** @default false */
-      isArray: boolean;
-      /** @default false */
-      isOptional: boolean;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * DoubleDomainValidator 
-     * @description An instance of concerto.metamodel@0.4.0.DoubleDomainValidator
-     */
-    "concerto.metamodel@0.4.0.DoubleDomainValidator": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.DoubleDomainValidator 
-       * @default concerto.metamodel@0.4.0.DoubleDomainValidator
-       */
-      $class: string;
-      lower?: number;
-      upper?: number;
-    };
-    /**
-     * IntegerProperty 
-     * @description An instance of concerto.metamodel@0.4.0.IntegerProperty
-     */
-    "concerto.metamodel@0.4.0.IntegerProperty": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.IntegerProperty 
-       * @default concerto.metamodel@0.4.0.IntegerProperty
-       */
-      $class: string;
-      defaultValue?: number;
-      validator?: components["schemas"]["concerto.metamodel@0.4.0.IntegerDomainValidator"];
-      name: string;
-      /** @default false */
-      isArray: boolean;
-      /** @default false */
-      isOptional: boolean;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * IntegerDomainValidator 
-     * @description An instance of concerto.metamodel@0.4.0.IntegerDomainValidator
-     */
-    "concerto.metamodel@0.4.0.IntegerDomainValidator": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.IntegerDomainValidator 
-       * @default concerto.metamodel@0.4.0.IntegerDomainValidator
-       */
-      $class: string;
-      lower?: number;
-      upper?: number;
-    };
-    /**
-     * LongProperty 
-     * @description An instance of concerto.metamodel@0.4.0.LongProperty
-     */
-    "concerto.metamodel@0.4.0.LongProperty": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.LongProperty 
-       * @default concerto.metamodel@0.4.0.LongProperty
-       */
-      $class: string;
-      defaultValue?: number;
-      validator?: components["schemas"]["concerto.metamodel@0.4.0.LongDomainValidator"];
-      name: string;
-      /** @default false */
-      isArray: boolean;
-      /** @default false */
-      isOptional: boolean;
-      decorators?: (components["schemas"]["concerto.metamodel@0.4.0.Decorator"])[];
-      location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
-    };
-    /**
-     * LongDomainValidator 
-     * @description An instance of concerto.metamodel@0.4.0.LongDomainValidator
-     */
-    "concerto.metamodel@0.4.0.LongDomainValidator": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.LongDomainValidator 
-       * @default concerto.metamodel@0.4.0.LongDomainValidator
-       */
-      $class: string;
-      lower?: number;
-      upper?: number;
-    };
-    /**
-     * Import 
-     * @description An instance of concerto.metamodel@0.4.0.Import
-     */
-    "concerto.metamodel@0.4.0.Import": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.Import 
-       * @default concerto.metamodel@0.4.0.Import
-       */
-      $class: string;
-      namespace: string;
-      uri?: string;
-    };
-    /**
-     * ImportAll 
-     * @description An instance of concerto.metamodel@0.4.0.ImportAll
-     */
-    "concerto.metamodel@0.4.0.ImportAll": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.ImportAll 
-       * @default concerto.metamodel@0.4.0.ImportAll
-       */
-      $class: string;
-      namespace: string;
-      uri?: string;
-    };
-    /**
-     * ImportType 
-     * @description An instance of concerto.metamodel@0.4.0.ImportType
-     */
-    "concerto.metamodel@0.4.0.ImportType": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.ImportType 
-       * @default concerto.metamodel@0.4.0.ImportType
-       */
-      $class: string;
-      name: string;
-      namespace: string;
-      uri?: string;
-    };
-    /**
-     * Model 
-     * @description An instance of concerto.metamodel@0.4.0.Model
-     */
-    "concerto.metamodel@0.4.0.Model": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.Model 
-       * @default concerto.metamodel@0.4.0.Model
-       */
-      $class: string;
-      namespace: string;
-      sourceUri?: string;
-      concertoVersion?: string;
-      imports?: (components["schemas"]["concerto.metamodel@0.4.0.Import"] | components["schemas"]["concerto.metamodel@0.4.0.ImportAll"] | components["schemas"]["concerto.metamodel@0.4.0.ImportType"])[];
-      declarations?: (components["schemas"]["concerto.metamodel@0.4.0.Declaration"] | components["schemas"]["concerto.metamodel@0.4.0.EnumDeclaration"] | components["schemas"]["concerto.metamodel@0.4.0.ConceptDeclaration"] | components["schemas"]["concerto.metamodel@0.4.0.AssetDeclaration"] | components["schemas"]["concerto.metamodel@0.4.0.ParticipantDeclaration"] | components["schemas"]["concerto.metamodel@0.4.0.TransactionDeclaration"] | components["schemas"]["concerto.metamodel@0.4.0.EventDeclaration"])[];
-    };
-    /**
-     * Models 
-     * @description An instance of concerto.metamodel@0.4.0.Models
-     */
-    "concerto.metamodel@0.4.0.Models": {
-      /**
-       * @description The class identifier for concerto.metamodel@0.4.0.Models 
-       * @default concerto.metamodel@0.4.0.Models
-       */
-      $class: string;
-      models: (components["schemas"]["concerto.metamodel@0.4.0.Model"])[];
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    schemas: {
+        "org.accordproject.protocol@1.0.0.URI": string;
+        "org.accordproject.protocol@1.0.0.JSON": string;
+        "org.accordproject.protocol@1.0.0.FullyQualifiedTypeName": string;
+        /**
+         * Blob
+         * @description An instance of org.accordproject.protocol@1.0.0.Blob
+         */
+        "org.accordproject.protocol@1.0.0.Blob": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.Blob
+             * @default org.accordproject.protocol@1.0.0.Blob
+             */
+            $class: string;
+            base64: string;
+            mimeType: string;
+        };
+        /**
+         * Text
+         * @description An instance of org.accordproject.protocol@1.0.0.Text
+         */
+        "org.accordproject.protocol@1.0.0.Text": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.Text
+             * @default org.accordproject.protocol@1.0.0.Text
+             */
+            $class: string;
+            templateMark?: components["schemas"]["org.accordproject.commonmark@0.5.0.Document"];
+            templateText?: string;
+        };
+        /**
+         * DomainModel
+         * @description An instance of org.accordproject.protocol@1.0.0.DomainModel
+         */
+        "org.accordproject.protocol@1.0.0.DomainModel": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.DomainModel
+             * @default org.accordproject.protocol@1.0.0.DomainModel
+             */
+            $class: string;
+        };
+        /**
+         * CtoFile
+         * @description An instance of org.accordproject.protocol@1.0.0.CtoFile
+         */
+        "org.accordproject.protocol@1.0.0.CtoFile": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.CtoFile
+             * @default org.accordproject.protocol@1.0.0.CtoFile
+             */
+            $class: string;
+            contents: string;
+            filename: string;
+        };
+        /**
+         * CtoModel
+         * @description An instance of org.accordproject.protocol@1.0.0.CtoModel
+         */
+        "org.accordproject.protocol@1.0.0.CtoModel": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.CtoModel
+             * @default org.accordproject.protocol@1.0.0.CtoModel
+             */
+            $class: string;
+            ctoFiles: components["schemas"]["org.accordproject.protocol@1.0.0.CtoFile"][];
+        };
+        /**
+         * JsonModel
+         * @description An instance of org.accordproject.protocol@1.0.0.JsonModel
+         */
+        "org.accordproject.protocol@1.0.0.JsonModel": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.JsonModel
+             * @default org.accordproject.protocol@1.0.0.JsonModel
+             */
+            $class: string;
+            model?: components["schemas"]["concerto.metamodel@0.4.0.Model"];
+        };
+        /**
+         * TemplateModel
+         * @description An instance of org.accordproject.protocol@1.0.0.TemplateModel
+         */
+        "org.accordproject.protocol@1.0.0.TemplateModel": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.TemplateModel
+             * @default org.accordproject.protocol@1.0.0.TemplateModel
+             */
+            $class: string;
+            typeName: string;
+            /** @description The identifier of an instance of org.accordproject.protocol@1.0.0.SharedModel */
+            sharedModel?: string;
+            model?: components["schemas"]["org.accordproject.protocol@1.0.0.DomainModel"] | components["schemas"]["org.accordproject.protocol@1.0.0.CtoModel"] | components["schemas"]["org.accordproject.protocol@1.0.0.JsonModel"];
+        };
+        /**
+         * SharedModel
+         * @description An instance of org.accordproject.protocol@1.0.0.SharedModel
+         */
+        "org.accordproject.protocol@1.0.0.SharedModel": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.SharedModel
+             * @default org.accordproject.protocol@1.0.0.SharedModel
+             */
+            $class: string;
+            /** @description The instance identifier for this type */
+            uri: string;
+            model: components["schemas"]["org.accordproject.protocol@1.0.0.DomainModel"] | components["schemas"]["org.accordproject.protocol@1.0.0.CtoModel"] | components["schemas"]["org.accordproject.protocol@1.0.0.JsonModel"];
+        };
+        /**
+         * CodeType
+         * @description An instance of org.accordproject.protocol@1.0.0.CodeType
+         * @enum {unknown}
+         */
+        "org.accordproject.protocol@1.0.0.CodeType": "ES2015" | "WASM_BYTES" | "TYPESCRIPT";
+        /**
+         * CodeEncodingType
+         * @description An instance of org.accordproject.protocol@1.0.0.CodeEncodingType
+         * @enum {unknown}
+         */
+        "org.accordproject.protocol@1.0.0.CodeEncodingType": "PLAIN_TEXT" | "BASE64";
+        /**
+         * Code
+         * @description An instance of org.accordproject.protocol@1.0.0.Code
+         */
+        "org.accordproject.protocol@1.0.0.Code": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.Code
+             * @default org.accordproject.protocol@1.0.0.Code
+             */
+            $class: string;
+            /** @description The instance identifier for this type */
+            id: string;
+            type: components["schemas"]["org.accordproject.protocol@1.0.0.CodeType"];
+            encoding: components["schemas"]["org.accordproject.protocol@1.0.0.CodeEncodingType"];
+            value: string;
+        };
+        /**
+         * Logic
+         * @description An instance of org.accordproject.protocol@1.0.0.Logic
+         */
+        "org.accordproject.protocol@1.0.0.Logic": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.Logic
+             * @default org.accordproject.protocol@1.0.0.Logic
+             */
+            $class: string;
+            stateType?: string;
+            codes: components["schemas"]["org.accordproject.protocol@1.0.0.Code"][];
+        };
+        /**
+         * TemplateMetadata
+         * @description An instance of org.accordproject.protocol@1.0.0.TemplateMetadata
+         */
+        "org.accordproject.protocol@1.0.0.TemplateMetadata": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.TemplateMetadata
+             * @default org.accordproject.protocol@1.0.0.TemplateMetadata
+             */
+            $class: string;
+            runtime: string;
+            template: string;
+            cicero: string;
+        };
+        /**
+         * Template
+         * @description An instance of org.accordproject.protocol@1.0.0.Template
+         */
+        "org.accordproject.protocol@1.0.0.Template": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.Template
+             * @default org.accordproject.protocol@1.0.0.Template
+             */
+            $class: string;
+            /** @description The instance identifier for this type */
+            uri: string;
+            author: string;
+            displayName?: string;
+            version: string;
+            description?: string;
+            license: string;
+            keywords?: string[];
+            metadata: components["schemas"]["org.accordproject.protocol@1.0.0.TemplateMetadata"];
+            logo?: components["schemas"]["org.accordproject.protocol@1.0.0.Blob"];
+            templateModel: components["schemas"]["org.accordproject.protocol@1.0.0.TemplateModel"];
+            text: components["schemas"]["org.accordproject.protocol@1.0.0.Text"];
+            logic?: components["schemas"]["org.accordproject.protocol@1.0.0.Logic"];
+            sampleRequest?: string;
+        };
+        /**
+         * KeyValue
+         * @description An instance of org.accordproject.protocol@1.0.0.KeyValue
+         */
+        "org.accordproject.protocol@1.0.0.KeyValue": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.KeyValue
+             * @default org.accordproject.protocol@1.0.0.KeyValue
+             */
+            $class: string;
+            key: string;
+            value: string;
+        };
+        /**
+         * Metadata
+         * @description An instance of org.accordproject.protocol@1.0.0.Metadata
+         */
+        "org.accordproject.protocol@1.0.0.Metadata": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.Metadata
+             * @default org.accordproject.protocol@1.0.0.Metadata
+             */
+            $class: string;
+            values: components["schemas"]["org.accordproject.protocol@1.0.0.KeyValue"][];
+        };
+        /**
+         * AgreementStatusType
+         * @description An instance of org.accordproject.protocol@1.0.0.AgreementStatusType
+         * @enum {unknown}
+         */
+        "org.accordproject.protocol@1.0.0.AgreementStatusType": "DRAFT" | "SIGNNG" | "COMPLETED" | "SUPERSEDED";
+        /**
+         * Agreement
+         * @description An instance of org.accordproject.protocol@1.0.0.Agreement
+         */
+        "org.accordproject.protocol@1.0.0.Agreement": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.Agreement
+             * @default org.accordproject.protocol@1.0.0.Agreement
+             */
+            $class: string;
+            /** @description The instance identifier for this type */
+            uri: string;
+            data: string;
+            /** @description The identifier of an instance of org.accordproject.protocol@1.0.0.Template */
+            template: string;
+            state?: string;
+            agreementStatus: components["schemas"]["org.accordproject.protocol@1.0.0.AgreementStatusType"];
+            agreementParties?: components["schemas"]["org.accordproject.protocol@1.0.0.AgreementParty"][];
+            signatures?: components["schemas"]["org.accordproject.protocol@1.0.0.Signature"][];
+            historyEntries?: components["schemas"]["org.accordproject.protocol@1.0.0.HistoryEntry"][];
+            attachments?: components["schemas"]["org.accordproject.protocol@1.0.0.Blob"][];
+            references?: string[];
+            metadata?: components["schemas"]["org.accordproject.protocol@1.0.0.Metadata"];
+        };
+        /**
+         * AgreementParty
+         * @description An instance of org.accordproject.protocol@1.0.0.AgreementParty
+         */
+        "org.accordproject.protocol@1.0.0.AgreementParty": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.AgreementParty
+             * @default org.accordproject.protocol@1.0.0.AgreementParty
+             */
+            $class: string;
+            name: string;
+            signatory: boolean;
+            role?: string;
+            email?: string;
+            phone?: string;
+            company?: string;
+            network?: string;
+            address?: components["schemas"]["org.accordproject.protocol@1.0.0.Address"];
+            /** @description The instance identifier for this type */
+            partyId: string;
+        };
+        /**
+         * Address
+         * @description An instance of org.accordproject.protocol@1.0.0.Address
+         */
+        "org.accordproject.protocol@1.0.0.Address": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.Address
+             * @default org.accordproject.protocol@1.0.0.Address
+             */
+            $class: string;
+            streetRoad: string[];
+            suburbTownCity?: string;
+            stateTerritoryRegion?: string;
+            postalCode?: string;
+            country?: string;
+        };
+        /**
+         * HistoryEntry
+         * @description An instance of org.accordproject.protocol@1.0.0.HistoryEntry
+         */
+        "org.accordproject.protocol@1.0.0.HistoryEntry": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.HistoryEntry
+             * @default org.accordproject.protocol@1.0.0.HistoryEntry
+             */
+            $class: string;
+            agreementStatus: components["schemas"]["org.accordproject.protocol@1.0.0.AgreementStatusType"];
+            data: string;
+            metadata: components["schemas"]["org.accordproject.protocol@1.0.0.Metadata"];
+        };
+        /**
+         * Signature
+         * @description An instance of org.accordproject.protocol@1.0.0.Signature
+         */
+        "org.accordproject.protocol@1.0.0.Signature": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.Signature
+             * @default org.accordproject.protocol@1.0.0.Signature
+             */
+            $class: string;
+            signatory: components["schemas"]["org.accordproject.protocol@1.0.0.AgreementParty"];
+            /** Format: date-time */
+            signedAt?: string;
+            metadata: components["schemas"]["org.accordproject.protocol@1.0.0.Metadata"];
+            signatureImage: components["schemas"]["org.accordproject.protocol@1.0.0.Blob"][];
+        };
+        /**
+         * ConversionOptions
+         * @description An instance of org.accordproject.protocol@1.0.0.ConversionOptions
+         */
+        "org.accordproject.protocol@1.0.0.ConversionOptions": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.ConversionOptions
+             * @default org.accordproject.protocol@1.0.0.ConversionOptions
+             */
+            $class: string;
+        };
+        /**
+         * HtmlConversionOptions
+         * @description An instance of org.accordproject.protocol@1.0.0.HtmlConversionOptions
+         */
+        "org.accordproject.protocol@1.0.0.HtmlConversionOptions": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.HtmlConversionOptions
+             * @default org.accordproject.protocol@1.0.0.HtmlConversionOptions
+             */
+            $class: string;
+        };
+        /**
+         * FeatureType
+         * @description An instance of org.accordproject.protocol@1.0.0.FeatureType
+         * @enum {unknown}
+         */
+        "org.accordproject.protocol@1.0.0.FeatureType": "TEMPLATE_MANAGE" | "TEMPLATE_VERIFY_SIGNATURES" | "TEMPLATE_LOGIC" | "TEMPLATE_STATEFUL" | "LOGIC_WASM" | "LOGIC_ES2015" | "LOGIC_TYPESCRIPT" | "AGREEMENT_MANAGE" | "AGREEMENT_TRIGGER" | "AGREEMENT_STATE" | "AGREEMENT_CONVERT_HTML" | "AGREEMENT_SIGNING" | "SHARED_MODEL_MANAGE";
+        /**
+         * Capabilities
+         * @description An instance of org.accordproject.protocol@1.0.0.Capabilities
+         */
+        "org.accordproject.protocol@1.0.0.Capabilities": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.Capabilities
+             * @default org.accordproject.protocol@1.0.0.Capabilities
+             */
+            $class: string;
+            features: components["schemas"]["org.accordproject.protocol@1.0.0.FeatureType"][];
+        };
+        /**
+         * TriggerRequest
+         * @description An instance of org.accordproject.protocol@1.0.0.TriggerRequest
+         */
+        "org.accordproject.protocol@1.0.0.TriggerRequest": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.TriggerRequest
+             * @default org.accordproject.protocol@1.0.0.TriggerRequest
+             */
+            $class: string;
+            payload: string;
+        };
+        /**
+         * TriggerResponse
+         * @description An instance of org.accordproject.protocol@1.0.0.TriggerResponse
+         */
+        "org.accordproject.protocol@1.0.0.TriggerResponse": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.TriggerResponse
+             * @default org.accordproject.protocol@1.0.0.TriggerResponse
+             */
+            $class: string;
+            result?: string;
+            obligations?: (components["schemas"]["org.accordproject.protocol@1.0.0.BaseObligation"] | components["schemas"]["org.accordproject.protocol@1.0.0.OwnershipTransferObligation"] | components["schemas"]["org.accordproject.protocol@1.0.0.PaymentObligation"] | components["schemas"]["org.accordproject.protocol@1.0.0.EscrowReleaseObligation"] | components["schemas"]["org.accordproject.protocol@1.0.0.AccessControlObligation"])[];
+            isError: boolean;
+            errorMessage?: string;
+            errorDetails?: string;
+        };
+        /**
+         * ObligationStatus
+         * @description An instance of org.accordproject.protocol@1.0.0.ObligationStatus
+         * @enum {unknown}
+         */
+        "org.accordproject.protocol@1.0.0.ObligationStatus": "ACTIVE" | "FULFILLED" | "VIOLATED" | "PARTIALLY_FULFILLED" | "DISPUTED" | "UNDER_REVIEW" | "RESOLVED_WITH_ADJUSTMENT" | "CANCELLED" | "SUPERSEDED" | "ERROR" | "OTHER";
+        /**
+         * BaseObligation
+         * @description An instance of org.accordproject.protocol@1.0.0.BaseObligation
+         */
+        "org.accordproject.protocol@1.0.0.BaseObligation": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.BaseObligation
+             * @default org.accordproject.protocol@1.0.0.BaseObligation
+             */
+            $class: string;
+            status: components["schemas"]["org.accordproject.protocol@1.0.0.ObligationStatus"];
+            description?: string;
+        };
+        /**
+         * OwnershipTransferObligation
+         * @description An instance of org.accordproject.protocol@1.0.0.OwnershipTransferObligation
+         */
+        "org.accordproject.protocol@1.0.0.OwnershipTransferObligation": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.OwnershipTransferObligation
+             * @default org.accordproject.protocol@1.0.0.OwnershipTransferObligation
+             */
+            $class: string;
+            assetIdentifier: string;
+            currentOwner: string;
+            newOwner: string;
+            status: components["schemas"]["org.accordproject.protocol@1.0.0.ObligationStatus"];
+            description?: string;
+        };
+        /**
+         * PaymentObligation
+         * @description An instance of org.accordproject.protocol@1.0.0.PaymentObligation
+         */
+        "org.accordproject.protocol@1.0.0.PaymentObligation": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.PaymentObligation
+             * @default org.accordproject.protocol@1.0.0.PaymentObligation
+             */
+            $class: string;
+            debtor: string;
+            creditor: string;
+            amount: number;
+            currency: string;
+            status: components["schemas"]["org.accordproject.protocol@1.0.0.ObligationStatus"];
+            description?: string;
+        };
+        /**
+         * EscrowReleaseObligation
+         * @description An instance of org.accordproject.protocol@1.0.0.EscrowReleaseObligation
+         */
+        "org.accordproject.protocol@1.0.0.EscrowReleaseObligation": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.EscrowReleaseObligation
+             * @default org.accordproject.protocol@1.0.0.EscrowReleaseObligation
+             */
+            $class: string;
+            escrowAgent: string;
+            beneficiary: string;
+            tokenIdentifier: string;
+            amount: number;
+            status: components["schemas"]["org.accordproject.protocol@1.0.0.ObligationStatus"];
+            description?: string;
+        };
+        /**
+         * AccessControlObligation
+         * @description An instance of org.accordproject.protocol@1.0.0.AccessControlObligation
+         */
+        "org.accordproject.protocol@1.0.0.AccessControlObligation": {
+            /**
+             * @description The class identifier for org.accordproject.protocol@1.0.0.AccessControlObligation
+             * @default org.accordproject.protocol@1.0.0.AccessControlObligation
+             */
+            $class: string;
+            grantee: string;
+            resourceIdentifier: string;
+            permission: string;
+            status: components["schemas"]["org.accordproject.protocol@1.0.0.ObligationStatus"];
+            description?: string;
+        };
+        /**
+         * Party
+         * @description An instance of org.accordproject.party@0.2.0.Party
+         */
+        "org.accordproject.party@0.2.0.Party": {
+            /**
+             * @description The class identifier for org.accordproject.party@0.2.0.Party
+             * @default org.accordproject.party@0.2.0.Party
+             */
+            $class: string;
+            /** @description The instance identifier for this type */
+            partyId: string;
+        };
+        /**
+         * Position
+         * @description An instance of concerto.metamodel@0.4.0.Position
+         */
+        "concerto.metamodel@0.4.0.Position": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.Position
+             * @default concerto.metamodel@0.4.0.Position
+             */
+            $class: string;
+            line: number;
+            column: number;
+            offset: number;
+        };
+        /**
+         * Range
+         * @description An instance of concerto.metamodel@0.4.0.Range
+         */
+        "concerto.metamodel@0.4.0.Range": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.Range
+             * @default concerto.metamodel@0.4.0.Range
+             */
+            $class: string;
+            start: components["schemas"]["concerto.metamodel@0.4.0.Position"];
+            end: components["schemas"]["concerto.metamodel@0.4.0.Position"];
+            source?: string;
+        };
+        /**
+         * TypeIdentifier
+         * @description An instance of concerto.metamodel@0.4.0.TypeIdentifier
+         */
+        "concerto.metamodel@0.4.0.TypeIdentifier": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.TypeIdentifier
+             * @default concerto.metamodel@0.4.0.TypeIdentifier
+             */
+            $class: string;
+            name: string;
+            namespace?: string;
+        };
+        /**
+         * DecoratorLiteral
+         * @description An instance of concerto.metamodel@0.4.0.DecoratorLiteral
+         */
+        "concerto.metamodel@0.4.0.DecoratorLiteral": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.DecoratorLiteral
+             * @default concerto.metamodel@0.4.0.DecoratorLiteral
+             */
+            $class: string;
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * DecoratorString
+         * @description An instance of concerto.metamodel@0.4.0.DecoratorString
+         */
+        "concerto.metamodel@0.4.0.DecoratorString": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.DecoratorString
+             * @default concerto.metamodel@0.4.0.DecoratorString
+             */
+            $class: string;
+            value: string;
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * DecoratorNumber
+         * @description An instance of concerto.metamodel@0.4.0.DecoratorNumber
+         */
+        "concerto.metamodel@0.4.0.DecoratorNumber": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.DecoratorNumber
+             * @default concerto.metamodel@0.4.0.DecoratorNumber
+             */
+            $class: string;
+            value: number;
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * DecoratorBoolean
+         * @description An instance of concerto.metamodel@0.4.0.DecoratorBoolean
+         */
+        "concerto.metamodel@0.4.0.DecoratorBoolean": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.DecoratorBoolean
+             * @default concerto.metamodel@0.4.0.DecoratorBoolean
+             */
+            $class: string;
+            value: boolean;
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * DecoratorTypeReference
+         * @description An instance of concerto.metamodel@0.4.0.DecoratorTypeReference
+         */
+        "concerto.metamodel@0.4.0.DecoratorTypeReference": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.DecoratorTypeReference
+             * @default concerto.metamodel@0.4.0.DecoratorTypeReference
+             */
+            $class: string;
+            type: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
+            /** @default false */
+            isArray: boolean;
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * Decorator
+         * @description An instance of concerto.metamodel@0.4.0.Decorator
+         */
+        "concerto.metamodel@0.4.0.Decorator": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.Decorator
+             * @default concerto.metamodel@0.4.0.Decorator
+             */
+            $class: string;
+            name: string;
+            arguments?: (components["schemas"]["concerto.metamodel@0.4.0.DecoratorLiteral"] | components["schemas"]["concerto.metamodel@0.4.0.DecoratorString"] | components["schemas"]["concerto.metamodel@0.4.0.DecoratorNumber"] | components["schemas"]["concerto.metamodel@0.4.0.DecoratorBoolean"] | components["schemas"]["concerto.metamodel@0.4.0.DecoratorTypeReference"])[];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * Identified
+         * @description An instance of concerto.metamodel@0.4.0.Identified
+         */
+        "concerto.metamodel@0.4.0.Identified": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.Identified
+             * @default concerto.metamodel@0.4.0.Identified
+             */
+            $class: string;
+        };
+        /**
+         * IdentifiedBy
+         * @description An instance of concerto.metamodel@0.4.0.IdentifiedBy
+         */
+        "concerto.metamodel@0.4.0.IdentifiedBy": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.IdentifiedBy
+             * @default concerto.metamodel@0.4.0.IdentifiedBy
+             */
+            $class: string;
+            name: string;
+        };
+        /**
+         * Declaration
+         * @description An instance of concerto.metamodel@0.4.0.Declaration
+         */
+        "concerto.metamodel@0.4.0.Declaration": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.Declaration
+             * @default concerto.metamodel@0.4.0.Declaration
+             */
+            $class: string;
+            name: string;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * EnumDeclaration
+         * @description An instance of concerto.metamodel@0.4.0.EnumDeclaration
+         */
+        "concerto.metamodel@0.4.0.EnumDeclaration": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.EnumDeclaration
+             * @default concerto.metamodel@0.4.0.EnumDeclaration
+             */
+            $class: string;
+            properties: components["schemas"]["concerto.metamodel@0.4.0.EnumProperty"][];
+            name: string;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * EnumProperty
+         * @description An instance of concerto.metamodel@0.4.0.EnumProperty
+         */
+        "concerto.metamodel@0.4.0.EnumProperty": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.EnumProperty
+             * @default concerto.metamodel@0.4.0.EnumProperty
+             */
+            $class: string;
+            name: string;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * ConceptDeclaration
+         * @description An instance of concerto.metamodel@0.4.0.ConceptDeclaration
+         */
+        "concerto.metamodel@0.4.0.ConceptDeclaration": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.ConceptDeclaration
+             * @default concerto.metamodel@0.4.0.ConceptDeclaration
+             */
+            $class: string;
+            /** @default false */
+            isAbstract: boolean;
+            identified?: components["schemas"]["concerto.metamodel@0.4.0.Identified"] | components["schemas"]["concerto.metamodel@0.4.0.IdentifiedBy"];
+            superType?: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
+            properties: (components["schemas"]["concerto.metamodel@0.4.0.Property"] | components["schemas"]["concerto.metamodel@0.4.0.RelationshipProperty"] | components["schemas"]["concerto.metamodel@0.4.0.ObjectProperty"] | components["schemas"]["concerto.metamodel@0.4.0.BooleanProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DateTimeProperty"] | components["schemas"]["concerto.metamodel@0.4.0.StringProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DoubleProperty"] | components["schemas"]["concerto.metamodel@0.4.0.IntegerProperty"] | components["schemas"]["concerto.metamodel@0.4.0.LongProperty"])[];
+            name: string;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * AssetDeclaration
+         * @description An instance of concerto.metamodel@0.4.0.AssetDeclaration
+         */
+        "concerto.metamodel@0.4.0.AssetDeclaration": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.AssetDeclaration
+             * @default concerto.metamodel@0.4.0.AssetDeclaration
+             */
+            $class: string;
+            /** @default false */
+            isAbstract: boolean;
+            identified?: components["schemas"]["concerto.metamodel@0.4.0.Identified"] | components["schemas"]["concerto.metamodel@0.4.0.IdentifiedBy"];
+            superType?: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
+            properties: (components["schemas"]["concerto.metamodel@0.4.0.Property"] | components["schemas"]["concerto.metamodel@0.4.0.RelationshipProperty"] | components["schemas"]["concerto.metamodel@0.4.0.ObjectProperty"] | components["schemas"]["concerto.metamodel@0.4.0.BooleanProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DateTimeProperty"] | components["schemas"]["concerto.metamodel@0.4.0.StringProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DoubleProperty"] | components["schemas"]["concerto.metamodel@0.4.0.IntegerProperty"] | components["schemas"]["concerto.metamodel@0.4.0.LongProperty"])[];
+            name: string;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * ParticipantDeclaration
+         * @description An instance of concerto.metamodel@0.4.0.ParticipantDeclaration
+         */
+        "concerto.metamodel@0.4.0.ParticipantDeclaration": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.ParticipantDeclaration
+             * @default concerto.metamodel@0.4.0.ParticipantDeclaration
+             */
+            $class: string;
+            /** @default false */
+            isAbstract: boolean;
+            identified?: components["schemas"]["concerto.metamodel@0.4.0.Identified"] | components["schemas"]["concerto.metamodel@0.4.0.IdentifiedBy"];
+            superType?: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
+            properties: (components["schemas"]["concerto.metamodel@0.4.0.Property"] | components["schemas"]["concerto.metamodel@0.4.0.RelationshipProperty"] | components["schemas"]["concerto.metamodel@0.4.0.ObjectProperty"] | components["schemas"]["concerto.metamodel@0.4.0.BooleanProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DateTimeProperty"] | components["schemas"]["concerto.metamodel@0.4.0.StringProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DoubleProperty"] | components["schemas"]["concerto.metamodel@0.4.0.IntegerProperty"] | components["schemas"]["concerto.metamodel@0.4.0.LongProperty"])[];
+            name: string;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * TransactionDeclaration
+         * @description An instance of concerto.metamodel@0.4.0.TransactionDeclaration
+         */
+        "concerto.metamodel@0.4.0.TransactionDeclaration": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.TransactionDeclaration
+             * @default concerto.metamodel@0.4.0.TransactionDeclaration
+             */
+            $class: string;
+            /** @default false */
+            isAbstract: boolean;
+            identified?: components["schemas"]["concerto.metamodel@0.4.0.Identified"] | components["schemas"]["concerto.metamodel@0.4.0.IdentifiedBy"];
+            superType?: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
+            properties: (components["schemas"]["concerto.metamodel@0.4.0.Property"] | components["schemas"]["concerto.metamodel@0.4.0.RelationshipProperty"] | components["schemas"]["concerto.metamodel@0.4.0.ObjectProperty"] | components["schemas"]["concerto.metamodel@0.4.0.BooleanProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DateTimeProperty"] | components["schemas"]["concerto.metamodel@0.4.0.StringProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DoubleProperty"] | components["schemas"]["concerto.metamodel@0.4.0.IntegerProperty"] | components["schemas"]["concerto.metamodel@0.4.0.LongProperty"])[];
+            name: string;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * EventDeclaration
+         * @description An instance of concerto.metamodel@0.4.0.EventDeclaration
+         */
+        "concerto.metamodel@0.4.0.EventDeclaration": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.EventDeclaration
+             * @default concerto.metamodel@0.4.0.EventDeclaration
+             */
+            $class: string;
+            /** @default false */
+            isAbstract: boolean;
+            identified?: components["schemas"]["concerto.metamodel@0.4.0.Identified"] | components["schemas"]["concerto.metamodel@0.4.0.IdentifiedBy"];
+            superType?: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
+            properties: (components["schemas"]["concerto.metamodel@0.4.0.Property"] | components["schemas"]["concerto.metamodel@0.4.0.RelationshipProperty"] | components["schemas"]["concerto.metamodel@0.4.0.ObjectProperty"] | components["schemas"]["concerto.metamodel@0.4.0.BooleanProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DateTimeProperty"] | components["schemas"]["concerto.metamodel@0.4.0.StringProperty"] | components["schemas"]["concerto.metamodel@0.4.0.DoubleProperty"] | components["schemas"]["concerto.metamodel@0.4.0.IntegerProperty"] | components["schemas"]["concerto.metamodel@0.4.0.LongProperty"])[];
+            name: string;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * Property
+         * @description An instance of concerto.metamodel@0.4.0.Property
+         */
+        "concerto.metamodel@0.4.0.Property": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.Property
+             * @default concerto.metamodel@0.4.0.Property
+             */
+            $class: string;
+            name: string;
+            /** @default false */
+            isArray: boolean;
+            /** @default false */
+            isOptional: boolean;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * RelationshipProperty
+         * @description An instance of concerto.metamodel@0.4.0.RelationshipProperty
+         */
+        "concerto.metamodel@0.4.0.RelationshipProperty": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.RelationshipProperty
+             * @default concerto.metamodel@0.4.0.RelationshipProperty
+             */
+            $class: string;
+            type: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
+            name: string;
+            /** @default false */
+            isArray: boolean;
+            /** @default false */
+            isOptional: boolean;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * ObjectProperty
+         * @description An instance of concerto.metamodel@0.4.0.ObjectProperty
+         */
+        "concerto.metamodel@0.4.0.ObjectProperty": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.ObjectProperty
+             * @default concerto.metamodel@0.4.0.ObjectProperty
+             */
+            $class: string;
+            defaultValue?: string;
+            type: components["schemas"]["concerto.metamodel@0.4.0.TypeIdentifier"];
+            name: string;
+            /** @default false */
+            isArray: boolean;
+            /** @default false */
+            isOptional: boolean;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * BooleanProperty
+         * @description An instance of concerto.metamodel@0.4.0.BooleanProperty
+         */
+        "concerto.metamodel@0.4.0.BooleanProperty": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.BooleanProperty
+             * @default concerto.metamodel@0.4.0.BooleanProperty
+             */
+            $class: string;
+            defaultValue?: boolean;
+            name: string;
+            /** @default false */
+            isArray: boolean;
+            /** @default false */
+            isOptional: boolean;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * DateTimeProperty
+         * @description An instance of concerto.metamodel@0.4.0.DateTimeProperty
+         */
+        "concerto.metamodel@0.4.0.DateTimeProperty": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.DateTimeProperty
+             * @default concerto.metamodel@0.4.0.DateTimeProperty
+             */
+            $class: string;
+            name: string;
+            /** @default false */
+            isArray: boolean;
+            /** @default false */
+            isOptional: boolean;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * StringProperty
+         * @description An instance of concerto.metamodel@0.4.0.StringProperty
+         */
+        "concerto.metamodel@0.4.0.StringProperty": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.StringProperty
+             * @default concerto.metamodel@0.4.0.StringProperty
+             */
+            $class: string;
+            defaultValue?: string;
+            validator?: components["schemas"]["concerto.metamodel@0.4.0.StringRegexValidator"];
+            name: string;
+            /** @default false */
+            isArray: boolean;
+            /** @default false */
+            isOptional: boolean;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * StringRegexValidator
+         * @description An instance of concerto.metamodel@0.4.0.StringRegexValidator
+         */
+        "concerto.metamodel@0.4.0.StringRegexValidator": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.StringRegexValidator
+             * @default concerto.metamodel@0.4.0.StringRegexValidator
+             */
+            $class: string;
+            pattern: string;
+            flags: string;
+        };
+        /**
+         * DoubleProperty
+         * @description An instance of concerto.metamodel@0.4.0.DoubleProperty
+         */
+        "concerto.metamodel@0.4.0.DoubleProperty": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.DoubleProperty
+             * @default concerto.metamodel@0.4.0.DoubleProperty
+             */
+            $class: string;
+            defaultValue?: number;
+            validator?: components["schemas"]["concerto.metamodel@0.4.0.DoubleDomainValidator"];
+            name: string;
+            /** @default false */
+            isArray: boolean;
+            /** @default false */
+            isOptional: boolean;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * DoubleDomainValidator
+         * @description An instance of concerto.metamodel@0.4.0.DoubleDomainValidator
+         */
+        "concerto.metamodel@0.4.0.DoubleDomainValidator": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.DoubleDomainValidator
+             * @default concerto.metamodel@0.4.0.DoubleDomainValidator
+             */
+            $class: string;
+            lower?: number;
+            upper?: number;
+        };
+        /**
+         * IntegerProperty
+         * @description An instance of concerto.metamodel@0.4.0.IntegerProperty
+         */
+        "concerto.metamodel@0.4.0.IntegerProperty": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.IntegerProperty
+             * @default concerto.metamodel@0.4.0.IntegerProperty
+             */
+            $class: string;
+            defaultValue?: number;
+            validator?: components["schemas"]["concerto.metamodel@0.4.0.IntegerDomainValidator"];
+            name: string;
+            /** @default false */
+            isArray: boolean;
+            /** @default false */
+            isOptional: boolean;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * IntegerDomainValidator
+         * @description An instance of concerto.metamodel@0.4.0.IntegerDomainValidator
+         */
+        "concerto.metamodel@0.4.0.IntegerDomainValidator": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.IntegerDomainValidator
+             * @default concerto.metamodel@0.4.0.IntegerDomainValidator
+             */
+            $class: string;
+            lower?: number;
+            upper?: number;
+        };
+        /**
+         * LongProperty
+         * @description An instance of concerto.metamodel@0.4.0.LongProperty
+         */
+        "concerto.metamodel@0.4.0.LongProperty": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.LongProperty
+             * @default concerto.metamodel@0.4.0.LongProperty
+             */
+            $class: string;
+            defaultValue?: number;
+            validator?: components["schemas"]["concerto.metamodel@0.4.0.LongDomainValidator"];
+            name: string;
+            /** @default false */
+            isArray: boolean;
+            /** @default false */
+            isOptional: boolean;
+            decorators?: components["schemas"]["concerto.metamodel@0.4.0.Decorator"][];
+            location?: components["schemas"]["concerto.metamodel@0.4.0.Range"];
+        };
+        /**
+         * LongDomainValidator
+         * @description An instance of concerto.metamodel@0.4.0.LongDomainValidator
+         */
+        "concerto.metamodel@0.4.0.LongDomainValidator": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.LongDomainValidator
+             * @default concerto.metamodel@0.4.0.LongDomainValidator
+             */
+            $class: string;
+            lower?: number;
+            upper?: number;
+        };
+        /**
+         * Import
+         * @description An instance of concerto.metamodel@0.4.0.Import
+         */
+        "concerto.metamodel@0.4.0.Import": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.Import
+             * @default concerto.metamodel@0.4.0.Import
+             */
+            $class: string;
+            namespace: string;
+            uri?: string;
+        };
+        /**
+         * ImportAll
+         * @description An instance of concerto.metamodel@0.4.0.ImportAll
+         */
+        "concerto.metamodel@0.4.0.ImportAll": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.ImportAll
+             * @default concerto.metamodel@0.4.0.ImportAll
+             */
+            $class: string;
+            namespace: string;
+            uri?: string;
+        };
+        /**
+         * ImportType
+         * @description An instance of concerto.metamodel@0.4.0.ImportType
+         */
+        "concerto.metamodel@0.4.0.ImportType": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.ImportType
+             * @default concerto.metamodel@0.4.0.ImportType
+             */
+            $class: string;
+            name: string;
+            namespace: string;
+            uri?: string;
+        };
+        /**
+         * Model
+         * @description An instance of concerto.metamodel@0.4.0.Model
+         */
+        "concerto.metamodel@0.4.0.Model": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.Model
+             * @default concerto.metamodel@0.4.0.Model
+             */
+            $class: string;
+            namespace: string;
+            sourceUri?: string;
+            concertoVersion?: string;
+            imports?: (components["schemas"]["concerto.metamodel@0.4.0.Import"] | components["schemas"]["concerto.metamodel@0.4.0.ImportAll"] | components["schemas"]["concerto.metamodel@0.4.0.ImportType"])[];
+            declarations?: (components["schemas"]["concerto.metamodel@0.4.0.Declaration"] | components["schemas"]["concerto.metamodel@0.4.0.EnumDeclaration"] | components["schemas"]["concerto.metamodel@0.4.0.ConceptDeclaration"] | components["schemas"]["concerto.metamodel@0.4.0.AssetDeclaration"] | components["schemas"]["concerto.metamodel@0.4.0.ParticipantDeclaration"] | components["schemas"]["concerto.metamodel@0.4.0.TransactionDeclaration"] | components["schemas"]["concerto.metamodel@0.4.0.EventDeclaration"])[];
+        };
+        /**
+         * Models
+         * @description An instance of concerto.metamodel@0.4.0.Models
+         */
+        "concerto.metamodel@0.4.0.Models": {
+            /**
+             * @description The class identifier for concerto.metamodel@0.4.0.Models
+             * @default concerto.metamodel@0.4.0.Models
+             */
+            $class: string;
+            models: components["schemas"]["concerto.metamodel@0.4.0.Model"][];
+        };
+        /**
+         * Node
+         * @description An instance of org.accordproject.commonmark@0.5.0.Node
+         */
+        "org.accordproject.commonmark@0.5.0.Node": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Node
+             * @default org.accordproject.commonmark@0.5.0.Node
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Root
+         * @description An instance of org.accordproject.commonmark@0.5.0.Root
+         */
+        "org.accordproject.commonmark@0.5.0.Root": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Root
+             * @default org.accordproject.commonmark@0.5.0.Root
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Child
+         * @description An instance of org.accordproject.commonmark@0.5.0.Child
+         */
+        "org.accordproject.commonmark@0.5.0.Child": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Child
+             * @default org.accordproject.commonmark@0.5.0.Child
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Text
+         * @description An instance of org.accordproject.commonmark@0.5.0.Text
+         */
+        "org.accordproject.commonmark@0.5.0.Text": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Text
+             * @default org.accordproject.commonmark@0.5.0.Text
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Attribute
+         * @description An instance of org.accordproject.commonmark@0.5.0.Attribute
+         */
+        "org.accordproject.commonmark@0.5.0.Attribute": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Attribute
+             * @default org.accordproject.commonmark@0.5.0.Attribute
+             */
+            $class: string;
+            name: string;
+            value: string;
+        };
+        /**
+         * TagInfo
+         * @description An instance of org.accordproject.commonmark@0.5.0.TagInfo
+         */
+        "org.accordproject.commonmark@0.5.0.TagInfo": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.TagInfo
+             * @default org.accordproject.commonmark@0.5.0.TagInfo
+             */
+            $class: string;
+            tagName: string;
+            attributeString: string;
+            attributes: components["schemas"]["org.accordproject.commonmark@0.5.0.Attribute"][];
+            content: string;
+            closed: boolean;
+        };
+        /**
+         * CodeBlock
+         * @description An instance of org.accordproject.commonmark@0.5.0.CodeBlock
+         */
+        "org.accordproject.commonmark@0.5.0.CodeBlock": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.CodeBlock
+             * @default org.accordproject.commonmark@0.5.0.CodeBlock
+             */
+            $class: string;
+            info?: string;
+            tag?: components["schemas"]["org.accordproject.commonmark@0.5.0.TagInfo"];
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Code
+         * @description An instance of org.accordproject.commonmark@0.5.0.Code
+         */
+        "org.accordproject.commonmark@0.5.0.Code": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Code
+             * @default org.accordproject.commonmark@0.5.0.Code
+             */
+            $class: string;
+            info?: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * HtmlInline
+         * @description An instance of org.accordproject.commonmark@0.5.0.HtmlInline
+         */
+        "org.accordproject.commonmark@0.5.0.HtmlInline": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.HtmlInline
+             * @default org.accordproject.commonmark@0.5.0.HtmlInline
+             */
+            $class: string;
+            tag?: components["schemas"]["org.accordproject.commonmark@0.5.0.TagInfo"];
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * HtmlBlock
+         * @description An instance of org.accordproject.commonmark@0.5.0.HtmlBlock
+         */
+        "org.accordproject.commonmark@0.5.0.HtmlBlock": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.HtmlBlock
+             * @default org.accordproject.commonmark@0.5.0.HtmlBlock
+             */
+            $class: string;
+            tag?: components["schemas"]["org.accordproject.commonmark@0.5.0.TagInfo"];
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Emph
+         * @description An instance of org.accordproject.commonmark@0.5.0.Emph
+         */
+        "org.accordproject.commonmark@0.5.0.Emph": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Emph
+             * @default org.accordproject.commonmark@0.5.0.Emph
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Strong
+         * @description An instance of org.accordproject.commonmark@0.5.0.Strong
+         */
+        "org.accordproject.commonmark@0.5.0.Strong": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Strong
+             * @default org.accordproject.commonmark@0.5.0.Strong
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * BlockQuote
+         * @description An instance of org.accordproject.commonmark@0.5.0.BlockQuote
+         */
+        "org.accordproject.commonmark@0.5.0.BlockQuote": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.BlockQuote
+             * @default org.accordproject.commonmark@0.5.0.BlockQuote
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Heading
+         * @description An instance of org.accordproject.commonmark@0.5.0.Heading
+         */
+        "org.accordproject.commonmark@0.5.0.Heading": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Heading
+             * @default org.accordproject.commonmark@0.5.0.Heading
+             */
+            $class: string;
+            level: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * ThematicBreak
+         * @description An instance of org.accordproject.commonmark@0.5.0.ThematicBreak
+         */
+        "org.accordproject.commonmark@0.5.0.ThematicBreak": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.ThematicBreak
+             * @default org.accordproject.commonmark@0.5.0.ThematicBreak
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Softbreak
+         * @description An instance of org.accordproject.commonmark@0.5.0.Softbreak
+         */
+        "org.accordproject.commonmark@0.5.0.Softbreak": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Softbreak
+             * @default org.accordproject.commonmark@0.5.0.Softbreak
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Linebreak
+         * @description An instance of org.accordproject.commonmark@0.5.0.Linebreak
+         */
+        "org.accordproject.commonmark@0.5.0.Linebreak": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Linebreak
+             * @default org.accordproject.commonmark@0.5.0.Linebreak
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Link
+         * @description An instance of org.accordproject.commonmark@0.5.0.Link
+         */
+        "org.accordproject.commonmark@0.5.0.Link": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Link
+             * @default org.accordproject.commonmark@0.5.0.Link
+             */
+            $class: string;
+            destination: string;
+            title: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Image
+         * @description An instance of org.accordproject.commonmark@0.5.0.Image
+         */
+        "org.accordproject.commonmark@0.5.0.Image": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Image
+             * @default org.accordproject.commonmark@0.5.0.Image
+             */
+            $class: string;
+            destination: string;
+            title: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Paragraph
+         * @description An instance of org.accordproject.commonmark@0.5.0.Paragraph
+         */
+        "org.accordproject.commonmark@0.5.0.Paragraph": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Paragraph
+             * @default org.accordproject.commonmark@0.5.0.Paragraph
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * List
+         * @description An instance of org.accordproject.commonmark@0.5.0.List
+         */
+        "org.accordproject.commonmark@0.5.0.List": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.List
+             * @default org.accordproject.commonmark@0.5.0.List
+             */
+            $class: string;
+            type: string;
+            start?: string;
+            tight: string;
+            delimiter?: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Item
+         * @description An instance of org.accordproject.commonmark@0.5.0.Item
+         */
+        "org.accordproject.commonmark@0.5.0.Item": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Item
+             * @default org.accordproject.commonmark@0.5.0.Item
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Document
+         * @description An instance of org.accordproject.commonmark@0.5.0.Document
+         */
+        "org.accordproject.commonmark@0.5.0.Document": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Document
+             * @default org.accordproject.commonmark@0.5.0.Document
+             */
+            $class: string;
+            xmlns: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * Table
+         * @description An instance of org.accordproject.commonmark@0.5.0.Table
+         */
+        "org.accordproject.commonmark@0.5.0.Table": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.Table
+             * @default org.accordproject.commonmark@0.5.0.Table
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * TableHead
+         * @description An instance of org.accordproject.commonmark@0.5.0.TableHead
+         */
+        "org.accordproject.commonmark@0.5.0.TableHead": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.TableHead
+             * @default org.accordproject.commonmark@0.5.0.TableHead
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * TableBody
+         * @description An instance of org.accordproject.commonmark@0.5.0.TableBody
+         */
+        "org.accordproject.commonmark@0.5.0.TableBody": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.TableBody
+             * @default org.accordproject.commonmark@0.5.0.TableBody
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * TableRow
+         * @description An instance of org.accordproject.commonmark@0.5.0.TableRow
+         */
+        "org.accordproject.commonmark@0.5.0.TableRow": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.TableRow
+             * @default org.accordproject.commonmark@0.5.0.TableRow
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * HeaderCell
+         * @description An instance of org.accordproject.commonmark@0.5.0.HeaderCell
+         */
+        "org.accordproject.commonmark@0.5.0.HeaderCell": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.HeaderCell
+             * @default org.accordproject.commonmark@0.5.0.HeaderCell
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+        /**
+         * TableCell
+         * @description An instance of org.accordproject.commonmark@0.5.0.TableCell
+         */
+        "org.accordproject.commonmark@0.5.0.TableCell": {
+            /**
+             * @description The class identifier for org.accordproject.commonmark@0.5.0.TableCell
+             * @default org.accordproject.commonmark@0.5.0.TableCell
+             */
+            $class: string;
+            text?: string;
+            nodes?: (components["schemas"]["org.accordproject.commonmark@0.5.0.Node"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Root"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Document"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Child"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Text"] | components["schemas"]["org.accordproject.commonmark@0.5.0.CodeBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Code"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlInline"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HtmlBlock"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Emph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Strong"] | components["schemas"]["org.accordproject.commonmark@0.5.0.BlockQuote"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Heading"] | components["schemas"]["org.accordproject.commonmark@0.5.0.ThematicBreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Softbreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Linebreak"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Link"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Image"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Paragraph"] | components["schemas"]["org.accordproject.commonmark@0.5.0.List"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Item"] | components["schemas"]["org.accordproject.commonmark@0.5.0.Table"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableHead"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableBody"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableRow"] | components["schemas"]["org.accordproject.commonmark@0.5.0.HeaderCell"] | components["schemas"]["org.accordproject.commonmark@0.5.0.TableCell"])[];
+            startLine?: number;
+            endLine?: number;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
-
-export type external = Record<string, never>;
-
+export type $defs = Record<string, never>;
 export interface operations {
-
-  listSharedmodels: {
-    /**
-     * List All Sharedmodels 
-     * @description Gets a list of all `sharedmodel` entities.
-     */
-    responses: {
-      /** @description Successful response - returns an array of `sharedmodel` entities. */
-      200: {
-        content: {
-          "application/json": (components["schemas"]["org.accordproject.protocol@1.0.0.SharedModel"])[];
+    listSharedmodels: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-  };
-  createSharedmodel: {
-    /**
-     * Create a Sharedmodel 
-     * @description Creates a new instance of a `sharedmodel`.
-     */
-    /** @description A new `sharedmodel` to be created. */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.SharedModel"];
-      };
-    };
-    responses: {
-      /** @description Successful response. */
-      201: never;
-    };
-  };
-  getSharedmodel: {
-    /**
-     * Get a sharedmodel 
-     * @description Gets the details of a single instance of a `sharedmodel`.
-     */
-    responses: {
-      /** @description Successful response - returns a single `sharedmodel`. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.SharedModel"];
+        requestBody?: never;
+        responses: {
+            /** @description Successful response - returns an array of `sharedmodel` entities. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.SharedModel"][];
+                };
+            };
         };
-      };
     };
-  };
-  replaceSharedmodel: {
-    /**
-     * Update a sharedmodel 
-     * @description Updates an existing `sharedmodel`.
-     */
-    /** @description Updated `sharedmodel` information. */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.SharedModel"];
-      };
-    };
-    responses: {
-      /** @description Successful response. */
-      202: never;
-    };
-  };
-  deleteSharedmodel: {
-    /**
-     * Delete a sharedmodel 
-     * @description Deletes an existing `sharedmodel`.
-     */
-    responses: {
-      /** @description Successful response. */
-      204: never;
-    };
-  };
-  listTemplates: {
-    /**
-     * List All Templates 
-     * @description Gets a list of all `template` entities.
-     */
-    responses: {
-      /** @description Successful response - returns an array of `template` entities. */
-      200: {
-        content: {
-          "application/json": (components["schemas"]["org.accordproject.protocol@1.0.0.Template"])[];
+    createSharedmodel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-  };
-  createTemplate: {
-    /**
-     * Create a Template 
-     * @description Creates a new instance of a `template`.
-     */
-    /** @description A new `template` to be created. */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Template"];
-      };
-    };
-    responses: {
-      /** @description Successful response. */
-      201: never;
-    };
-  };
-  getTemplate: {
-    /**
-     * Get a template 
-     * @description Gets the details of a single instance of a `template`.
-     */
-    responses: {
-      /** @description Successful response - returns a single `template`. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Template"];
+        /** @description A new `sharedmodel` to be created. */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.SharedModel"];
+            };
         };
-      };
-    };
-  };
-  replaceTemplate: {
-    /**
-     * Update a template 
-     * @description Updates an existing `template`.
-     */
-    /** @description Updated `template` information. */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Template"];
-      };
-    };
-    responses: {
-      /** @description Successful response. */
-      202: never;
-    };
-  };
-  deleteTemplate: {
-    /**
-     * Delete a template 
-     * @description Deletes an existing `template`.
-     */
-    responses: {
-      /** @description Successful response. */
-      204: never;
-    };
-  };
-  listAgreements: {
-    /**
-     * List All Agreements 
-     * @description Gets a list of all `agreement` entities.
-     */
-    responses: {
-      /** @description Successful response - returns an array of `agreement` entities. */
-      200: {
-        content: {
-          "application/json": (components["schemas"]["org.accordproject.protocol@1.0.0.Agreement"])[];
+        responses: {
+            /** @description Successful response. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
-      };
     };
-  };
-  createAgreement: {
-    /**
-     * Create a Agreement 
-     * @description Creates a new instance of a `agreement`.
-     */
-    /** @description A new `agreement` to be created. */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Agreement"];
-      };
-    };
-    responses: {
-      /** @description Successful response. */
-      201: never;
-    };
-  };
-  getAgreement: {
-    /**
-     * Get a agreement 
-     * @description Gets the details of a single instance of a `agreement`.
-     */
-    responses: {
-      /** @description Successful response - returns a single `agreement`. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Agreement"];
+    getSharedmodel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `SharedModel`. */
+                uri: string;
+            };
+            cookie?: never;
         };
-      };
-    };
-  };
-  replaceAgreement: {
-    /**
-     * Update a agreement 
-     * @description Updates an existing `agreement`.
-     */
-    /** @description Updated `agreement` information. */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Agreement"];
-      };
-    };
-    responses: {
-      /** @description Successful response. */
-      202: never;
-    };
-  };
-  deleteAgreement: {
-    /**
-     * Delete a agreement 
-     * @description Deletes an existing `agreement`.
-     */
-    responses: {
-      /** @description Successful response. */
-      204: never;
-    };
-  };
-  convertAgreementHtml: {
-    /**
-     * Convert agreement to HTML 
-     * @description Converts an existing `agreement` to HTML.
-     */
-    /** @description HTML conversion options. */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.HtmlConversionOptions"];
-      };
-    };
-    responses: {
-      /** @description A HTML file */
-      202: {
-        content: {
-          "application/pdf:": string;
+        requestBody?: never;
+        responses: {
+            /** @description Successful response - returns a single `sharedmodel`. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.SharedModel"];
+                };
+            };
         };
-      };
     };
-  };
-  triggerAgreement: {
-    /**
-     * Trigger an agreement 
-     * @description Sends data to an existing agreement.
-     */
-    /** @description Incoming data — a JSON serialized Concerto type */
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.TriggerRequest"];
-      };
-    };
-    responses: {
-      /** @description Successful response - returns the result of calling a function. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.TriggerResponse"];
+    replaceSharedmodel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `SharedModel`. */
+                uri: string;
+            };
+            cookie?: never;
         };
-      };
-    };
-  };
-  getCapabilities: {
-    /**
-     * Get server capabilities 
-     * @description Retrieve the supported features of the server.
-     */
-    responses: {
-      /** @description Successful response - returns `capabilities` for the server. */
-      200: {
-        content: {
-          "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Capabilities"];
+        /** @description Updated `sharedmodel` information. */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.SharedModel"];
+            };
         };
-      };
+        responses: {
+            /** @description Successful response. */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-  };
+    deleteSharedmodel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `SharedModel`. */
+                uri: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listTemplates: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response - returns an array of `template` entities. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Template"][];
+                };
+            };
+        };
+    };
+    createTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description A new `template` to be created. */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Template"];
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Template`. */
+                uri: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response - returns a single `template`. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Template"];
+                };
+            };
+        };
+    };
+    replaceTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Template`. */
+                uri: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updated `template` information. */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Template"];
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Template`. */
+                uri: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listAgreements: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response - returns an array of `agreement` entities. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Agreement"][];
+                };
+            };
+        };
+    };
+    createAgreement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description A new `agreement` to be created. */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Agreement"];
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getAgreement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Agreement`. */
+                uri: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response - returns a single `agreement`. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Agreement"];
+                };
+            };
+        };
+    };
+    replaceAgreement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Agreement`. */
+                uri: string;
+            };
+            cookie?: never;
+        };
+        /** @description Updated `agreement` information. */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Agreement"];
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteAgreement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Agreement`. */
+                uri: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    convertAgreementHtml: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Agreement`. */
+                agreementId: string;
+            };
+            cookie?: never;
+        };
+        /** @description HTML conversion options. */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.HtmlConversionOptions"];
+            };
+        };
+        responses: {
+            /** @description A HTML file */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/pdf:": string;
+                };
+            };
+        };
+    };
+    triggerAgreement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique identifier for a `Agreement`. */
+                agreementId: string;
+            };
+            cookie?: never;
+        };
+        /** @description Incoming data — a JSON serialized Concerto type */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.TriggerRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful response - returns the result of calling a function. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.TriggerResponse"];
+                };
+            };
+        };
+    };
+    getCapabilities: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response - returns `capabilities` for the server. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["org.accordproject.protocol@1.0.0.Capabilities"];
+                };
+            };
+        };
+    };
 }

--- a/index.md
+++ b/index.md
@@ -10366,6 +10366,13 @@ Sends data to an existing agreement.
 {
   "$class": "org.accordproject.protocol@1.0.0.TriggerResponse",
   "result": "string",
+  "obligations": [
+    {
+      "$class": "org.accordproject.protocol@1.0.0.BaseObligation",
+      "status": "ACTIVE",
+      "description": "string"
+    }
+  ],
   "isError": true,
   "errorMessage": "string",
   "errorDetails": "string"
@@ -11765,6 +11772,13 @@ TriggerRequest
 {
   "$class": "org.accordproject.protocol@1.0.0.TriggerResponse",
   "result": "string",
+  "obligations": [
+    {
+      "$class": "org.accordproject.protocol@1.0.0.BaseObligation",
+      "status": "ACTIVE",
+      "description": "string"
+    }
+  ],
   "isError": true,
   "errorMessage": "string",
   "errorDetails": "string"
@@ -11780,9 +11794,3527 @@ TriggerResponse
 |---|---|---|---|---|
 |$class|string|true|none|The class identifier for org.accordproject.protocol@1.0.0.TriggerResponse|
 |result|string|false|none|none|
+|obligations|[anyOf]|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[org.accordproject.protocol@1.0.0.BaseObligation](#schemaorg.accordproject.protocol@1.0.0.baseobligation)|false|none|An instance of org.accordproject.protocol@1.0.0.BaseObligation|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[org.accordproject.protocol@1.0.0.OwnershipTransferObligation](#schemaorg.accordproject.protocol@1.0.0.ownershiptransferobligation)|false|none|An instance of org.accordproject.protocol@1.0.0.OwnershipTransferObligation|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[org.accordproject.protocol@1.0.0.PaymentObligation](#schemaorg.accordproject.protocol@1.0.0.paymentobligation)|false|none|An instance of org.accordproject.protocol@1.0.0.PaymentObligation|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[org.accordproject.protocol@1.0.0.EscrowReleaseObligation](#schemaorg.accordproject.protocol@1.0.0.escrowreleaseobligation)|false|none|An instance of org.accordproject.protocol@1.0.0.EscrowReleaseObligation|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[org.accordproject.protocol@1.0.0.AccessControlObligation](#schemaorg.accordproject.protocol@1.0.0.accesscontrolobligation)|false|none|An instance of org.accordproject.protocol@1.0.0.AccessControlObligation|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
 |isError|boolean|true|none|none|
 |errorMessage|string|false|none|none|
 |errorDetails|string|false|none|none|
+
+<h2 id="tocS_org.accordproject.protocol@1.0.0.ObligationStatus">org.accordproject.protocol@1.0.0.ObligationStatus</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.obligationstatus"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.ObligationStatus"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.obligationstatus"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.obligationstatus"></a>
+
+```json
+"ACTIVE"
+
+```
+
+ObligationStatus
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|ObligationStatus|any|false|none|An instance of org.accordproject.protocol@1.0.0.ObligationStatus|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|ObligationStatus|ACTIVE|
+|ObligationStatus|FULFILLED|
+|ObligationStatus|VIOLATED|
+|ObligationStatus|PARTIALLY_FULFILLED|
+|ObligationStatus|DISPUTED|
+|ObligationStatus|UNDER_REVIEW|
+|ObligationStatus|RESOLVED_WITH_ADJUSTMENT|
+|ObligationStatus|CANCELLED|
+|ObligationStatus|SUPERSEDED|
+|ObligationStatus|ERROR|
+|ObligationStatus|OTHER|
+
+<h2 id="tocS_org.accordproject.protocol@1.0.0.BaseObligation">org.accordproject.protocol@1.0.0.BaseObligation</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.baseobligation"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.BaseObligation"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.baseobligation"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.baseobligation"></a>
+
+```json
+{
+  "$class": "org.accordproject.protocol@1.0.0.BaseObligation",
+  "status": "ACTIVE",
+  "description": "string"
+}
+
+```
+
+BaseObligation
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for org.accordproject.protocol@1.0.0.BaseObligation|
+|status|[org.accordproject.protocol@1.0.0.ObligationStatus](#schemaorg.accordproject.protocol@1.0.0.obligationstatus)|true|none|An instance of org.accordproject.protocol@1.0.0.ObligationStatus|
+|description|string|false|none|none|
+
+<h2 id="tocS_org.accordproject.protocol@1.0.0.OwnershipTransferObligation">org.accordproject.protocol@1.0.0.OwnershipTransferObligation</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.ownershiptransferobligation"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.OwnershipTransferObligation"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.ownershiptransferobligation"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.ownershiptransferobligation"></a>
+
+```json
+{
+  "$class": "org.accordproject.protocol@1.0.0.OwnershipTransferObligation",
+  "assetIdentifier": "string",
+  "currentOwner": "string",
+  "newOwner": "string",
+  "status": "ACTIVE",
+  "description": "string"
+}
+
+```
+
+OwnershipTransferObligation
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for org.accordproject.protocol@1.0.0.OwnershipTransferObligation|
+|assetIdentifier|string|true|none|none|
+|currentOwner|string|true|none|none|
+|newOwner|string|true|none|none|
+|status|[org.accordproject.protocol@1.0.0.ObligationStatus](#schemaorg.accordproject.protocol@1.0.0.obligationstatus)|true|none|An instance of org.accordproject.protocol@1.0.0.ObligationStatus|
+|description|string|false|none|none|
+
+<h2 id="tocS_org.accordproject.protocol@1.0.0.PaymentObligation">org.accordproject.protocol@1.0.0.PaymentObligation</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.paymentobligation"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.PaymentObligation"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.paymentobligation"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.paymentobligation"></a>
+
+```json
+{
+  "$class": "org.accordproject.protocol@1.0.0.PaymentObligation",
+  "debtor": "string",
+  "creditor": "string",
+  "amount": 0,
+  "currency": "string",
+  "status": "ACTIVE",
+  "description": "string"
+}
+
+```
+
+PaymentObligation
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for org.accordproject.protocol@1.0.0.PaymentObligation|
+|debtor|string|true|none|none|
+|creditor|string|true|none|none|
+|amount|number|true|none|none|
+|currency|string|true|none|none|
+|status|[org.accordproject.protocol@1.0.0.ObligationStatus](#schemaorg.accordproject.protocol@1.0.0.obligationstatus)|true|none|An instance of org.accordproject.protocol@1.0.0.ObligationStatus|
+|description|string|false|none|none|
+
+<h2 id="tocS_org.accordproject.protocol@1.0.0.EscrowReleaseObligation">org.accordproject.protocol@1.0.0.EscrowReleaseObligation</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.escrowreleaseobligation"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.EscrowReleaseObligation"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.escrowreleaseobligation"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.escrowreleaseobligation"></a>
+
+```json
+{
+  "$class": "org.accordproject.protocol@1.0.0.EscrowReleaseObligation",
+  "escrowAgent": "string",
+  "beneficiary": "string",
+  "tokenIdentifier": "string",
+  "amount": 0,
+  "status": "ACTIVE",
+  "description": "string"
+}
+
+```
+
+EscrowReleaseObligation
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for org.accordproject.protocol@1.0.0.EscrowReleaseObligation|
+|escrowAgent|string|true|none|none|
+|beneficiary|string|true|none|none|
+|tokenIdentifier|string|true|none|none|
+|amount|number|true|none|none|
+|status|[org.accordproject.protocol@1.0.0.ObligationStatus](#schemaorg.accordproject.protocol@1.0.0.obligationstatus)|true|none|An instance of org.accordproject.protocol@1.0.0.ObligationStatus|
+|description|string|false|none|none|
+
+<h2 id="tocS_org.accordproject.protocol@1.0.0.AccessControlObligation">org.accordproject.protocol@1.0.0.AccessControlObligation</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.protocol@1.0.0.accesscontrolobligation"></a>
+<a id="schema_org.accordproject.protocol@1.0.0.AccessControlObligation"></a>
+<a id="tocSorg.accordproject.protocol@1.0.0.accesscontrolobligation"></a>
+<a id="tocsorg.accordproject.protocol@1.0.0.accesscontrolobligation"></a>
+
+```json
+{
+  "$class": "org.accordproject.protocol@1.0.0.AccessControlObligation",
+  "grantee": "string",
+  "resourceIdentifier": "string",
+  "permission": "string",
+  "status": "ACTIVE",
+  "description": "string"
+}
+
+```
+
+AccessControlObligation
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for org.accordproject.protocol@1.0.0.AccessControlObligation|
+|grantee|string|true|none|none|
+|resourceIdentifier|string|true|none|none|
+|permission|string|true|none|none|
+|status|[org.accordproject.protocol@1.0.0.ObligationStatus](#schemaorg.accordproject.protocol@1.0.0.obligationstatus)|true|none|An instance of org.accordproject.protocol@1.0.0.ObligationStatus|
+|description|string|false|none|none|
+
+<h2 id="tocS_org.accordproject.party@0.2.0.Party">org.accordproject.party@0.2.0.Party</h2>
+<!-- backwards compatibility -->
+<a id="schemaorg.accordproject.party@0.2.0.party"></a>
+<a id="schema_org.accordproject.party@0.2.0.Party"></a>
+<a id="tocSorg.accordproject.party@0.2.0.party"></a>
+<a id="tocsorg.accordproject.party@0.2.0.party"></a>
+
+```json
+{
+  "$class": "org.accordproject.party@0.2.0.Party",
+  "partyId": "string"
+}
+
+```
+
+Party
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for org.accordproject.party@0.2.0.Party|
+|partyId|string|true|none|The instance identifier for this type|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.Position">concerto.metamodel@0.4.0.Position</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.position"></a>
+<a id="schema_concerto.metamodel@0.4.0.Position"></a>
+<a id="tocSconcerto.metamodel@0.4.0.position"></a>
+<a id="tocsconcerto.metamodel@0.4.0.position"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.Position",
+  "line": 0,
+  "column": 0,
+  "offset": 0
+}
+
+```
+
+Position
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Position|
+|line|integer|true|none|none|
+|column|integer|true|none|none|
+|offset|integer|true|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.Range">concerto.metamodel@0.4.0.Range</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.range"></a>
+<a id="schema_concerto.metamodel@0.4.0.Range"></a>
+<a id="tocSconcerto.metamodel@0.4.0.range"></a>
+<a id="tocsconcerto.metamodel@0.4.0.range"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.Range",
+  "start": {
+    "$class": "concerto.metamodel@0.4.0.Position",
+    "line": 0,
+    "column": 0,
+    "offset": 0
+  },
+  "end": {
+    "$class": "concerto.metamodel@0.4.0.Position",
+    "line": 0,
+    "column": 0,
+    "offset": 0
+  },
+  "source": "string"
+}
+
+```
+
+Range
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Range|
+|start|[concerto.metamodel@0.4.0.Position](#schemaconcerto.metamodel@0.4.0.position)|true|none|An instance of concerto.metamodel@0.4.0.Position|
+|end|[concerto.metamodel@0.4.0.Position](#schemaconcerto.metamodel@0.4.0.position)|true|none|An instance of concerto.metamodel@0.4.0.Position|
+|source|string|false|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.TypeIdentifier">concerto.metamodel@0.4.0.TypeIdentifier</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.typeidentifier"></a>
+<a id="schema_concerto.metamodel@0.4.0.TypeIdentifier"></a>
+<a id="tocSconcerto.metamodel@0.4.0.typeidentifier"></a>
+<a id="tocsconcerto.metamodel@0.4.0.typeidentifier"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
+  "name": "string",
+  "namespace": "string"
+}
+
+```
+
+TypeIdentifier
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.TypeIdentifier|
+|name|string|true|none|none|
+|namespace|string|false|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorLiteral">concerto.metamodel@0.4.0.DecoratorLiteral</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decoratorliteral"></a>
+<a id="schema_concerto.metamodel@0.4.0.DecoratorLiteral"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decoratorliteral"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decoratorliteral"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+DecoratorLiteral
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DecoratorLiteral|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorString">concerto.metamodel@0.4.0.DecoratorString</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decoratorstring"></a>
+<a id="schema_concerto.metamodel@0.4.0.DecoratorString"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decoratorstring"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decoratorstring"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.DecoratorString",
+  "value": "string",
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+DecoratorString
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DecoratorString|
+|value|string|true|none|none|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorNumber">concerto.metamodel@0.4.0.DecoratorNumber</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decoratornumber"></a>
+<a id="schema_concerto.metamodel@0.4.0.DecoratorNumber"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decoratornumber"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decoratornumber"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.DecoratorNumber",
+  "value": 0,
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+DecoratorNumber
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DecoratorNumber|
+|value|number|true|none|none|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorBoolean">concerto.metamodel@0.4.0.DecoratorBoolean</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decoratorboolean"></a>
+<a id="schema_concerto.metamodel@0.4.0.DecoratorBoolean"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decoratorboolean"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decoratorboolean"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.DecoratorBoolean",
+  "value": true,
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+DecoratorBoolean
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DecoratorBoolean|
+|value|boolean|true|none|none|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorTypeReference">concerto.metamodel@0.4.0.DecoratorTypeReference</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decoratortypereference"></a>
+<a id="schema_concerto.metamodel@0.4.0.DecoratorTypeReference"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decoratortypereference"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decoratortypereference"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.DecoratorTypeReference",
+  "type": {
+    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
+    "name": "string",
+    "namespace": "string"
+  },
+  "isArray": false,
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+DecoratorTypeReference
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DecoratorTypeReference|
+|type|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|true|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
+|isArray|boolean|true|none|none|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.Decorator">concerto.metamodel@0.4.0.Decorator</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.decorator"></a>
+<a id="schema_concerto.metamodel@0.4.0.Decorator"></a>
+<a id="tocSconcerto.metamodel@0.4.0.decorator"></a>
+<a id="tocsconcerto.metamodel@0.4.0.decorator"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.Decorator",
+  "name": "string",
+  "arguments": [
+    {
+      "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+Decorator
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Decorator|
+|name|string|true|none|none|
+|arguments|[anyOf]|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DecoratorLiteral](#schemaconcerto.metamodel@0.4.0.decoratorliteral)|false|none|An instance of concerto.metamodel@0.4.0.DecoratorLiteral|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DecoratorString](#schemaconcerto.metamodel@0.4.0.decoratorstring)|false|none|An instance of concerto.metamodel@0.4.0.DecoratorString|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DecoratorNumber](#schemaconcerto.metamodel@0.4.0.decoratornumber)|false|none|An instance of concerto.metamodel@0.4.0.DecoratorNumber|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DecoratorBoolean](#schemaconcerto.metamodel@0.4.0.decoratorboolean)|false|none|An instance of concerto.metamodel@0.4.0.DecoratorBoolean|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DecoratorTypeReference](#schemaconcerto.metamodel@0.4.0.decoratortypereference)|false|none|An instance of concerto.metamodel@0.4.0.DecoratorTypeReference|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.Identified">concerto.metamodel@0.4.0.Identified</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.identified"></a>
+<a id="schema_concerto.metamodel@0.4.0.Identified"></a>
+<a id="tocSconcerto.metamodel@0.4.0.identified"></a>
+<a id="tocsconcerto.metamodel@0.4.0.identified"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.Identified"
+}
+
+```
+
+Identified
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Identified|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.IdentifiedBy">concerto.metamodel@0.4.0.IdentifiedBy</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.identifiedby"></a>
+<a id="schema_concerto.metamodel@0.4.0.IdentifiedBy"></a>
+<a id="tocSconcerto.metamodel@0.4.0.identifiedby"></a>
+<a id="tocsconcerto.metamodel@0.4.0.identifiedby"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.IdentifiedBy",
+  "name": "string"
+}
+
+```
+
+IdentifiedBy
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.IdentifiedBy|
+|name|string|true|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.Declaration">concerto.metamodel@0.4.0.Declaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.declaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.Declaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.declaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.declaration"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.Declaration",
+  "name": "string",
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+Declaration
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Declaration|
+|name|string|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.EnumDeclaration">concerto.metamodel@0.4.0.EnumDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.enumdeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.EnumDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.enumdeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.enumdeclaration"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.EnumDeclaration",
+  "properties": [
+    {
+      "$class": "concerto.metamodel@0.4.0.EnumProperty",
+      "name": "string",
+      "decorators": [
+        {
+          "$class": "concerto.metamodel@0.4.0.Decorator",
+          "name": "string",
+          "arguments": [
+            {
+              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+              "location": {
+                "$class": "concerto.metamodel@0.4.0.Range",
+                "start": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "end": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "source": "string"
+              }
+            }
+          ],
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "name": "string",
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+EnumDeclaration
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.EnumDeclaration|
+|properties|[[concerto.metamodel@0.4.0.EnumProperty](#schemaconcerto.metamodel@0.4.0.enumproperty)]|true|none|[An instance of concerto.metamodel@0.4.0.EnumProperty]|
+|name|string|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.EnumProperty">concerto.metamodel@0.4.0.EnumProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.enumproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.EnumProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.enumproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.enumproperty"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.EnumProperty",
+  "name": "string",
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+EnumProperty
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.EnumProperty|
+|name|string|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.ConceptDeclaration">concerto.metamodel@0.4.0.ConceptDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.conceptdeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.ConceptDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.conceptdeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.conceptdeclaration"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.ConceptDeclaration",
+  "isAbstract": false,
+  "identified": {
+    "$class": "concerto.metamodel@0.4.0.Identified"
+  },
+  "superType": {
+    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
+    "name": "string",
+    "namespace": "string"
+  },
+  "properties": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Property",
+      "name": "string",
+      "isArray": false,
+      "isOptional": false,
+      "decorators": [
+        {
+          "$class": "concerto.metamodel@0.4.0.Decorator",
+          "name": "string",
+          "arguments": [
+            {
+              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+              "location": {
+                "$class": "concerto.metamodel@0.4.0.Range",
+                "start": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "end": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "source": "string"
+              }
+            }
+          ],
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "name": "string",
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+ConceptDeclaration
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.ConceptDeclaration|
+|isAbstract|boolean|true|none|none|
+|identified|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Identified](#schemaconcerto.metamodel@0.4.0.identified)|false|none|An instance of concerto.metamodel@0.4.0.Identified|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.IdentifiedBy](#schemaconcerto.metamodel@0.4.0.identifiedby)|false|none|An instance of concerto.metamodel@0.4.0.IdentifiedBy|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|superType|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|false|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
+|properties|[anyOf]|true|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Property](#schemaconcerto.metamodel@0.4.0.property)|false|none|An instance of concerto.metamodel@0.4.0.Property|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.RelationshipProperty](#schemaconcerto.metamodel@0.4.0.relationshipproperty)|false|none|An instance of concerto.metamodel@0.4.0.RelationshipProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.ObjectProperty](#schemaconcerto.metamodel@0.4.0.objectproperty)|false|none|An instance of concerto.metamodel@0.4.0.ObjectProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.BooleanProperty](#schemaconcerto.metamodel@0.4.0.booleanproperty)|false|none|An instance of concerto.metamodel@0.4.0.BooleanProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DateTimeProperty](#schemaconcerto.metamodel@0.4.0.datetimeproperty)|false|none|An instance of concerto.metamodel@0.4.0.DateTimeProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.StringProperty](#schemaconcerto.metamodel@0.4.0.stringproperty)|false|none|An instance of concerto.metamodel@0.4.0.StringProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DoubleProperty](#schemaconcerto.metamodel@0.4.0.doubleproperty)|false|none|An instance of concerto.metamodel@0.4.0.DoubleProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.IntegerProperty](#schemaconcerto.metamodel@0.4.0.integerproperty)|false|none|An instance of concerto.metamodel@0.4.0.IntegerProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.LongProperty](#schemaconcerto.metamodel@0.4.0.longproperty)|false|none|An instance of concerto.metamodel@0.4.0.LongProperty|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.AssetDeclaration">concerto.metamodel@0.4.0.AssetDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.assetdeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.AssetDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.assetdeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.assetdeclaration"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.AssetDeclaration",
+  "isAbstract": false,
+  "identified": {
+    "$class": "concerto.metamodel@0.4.0.Identified"
+  },
+  "superType": {
+    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
+    "name": "string",
+    "namespace": "string"
+  },
+  "properties": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Property",
+      "name": "string",
+      "isArray": false,
+      "isOptional": false,
+      "decorators": [
+        {
+          "$class": "concerto.metamodel@0.4.0.Decorator",
+          "name": "string",
+          "arguments": [
+            {
+              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+              "location": {
+                "$class": "concerto.metamodel@0.4.0.Range",
+                "start": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "end": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "source": "string"
+              }
+            }
+          ],
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "name": "string",
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+AssetDeclaration
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.AssetDeclaration|
+|isAbstract|boolean|true|none|none|
+|identified|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Identified](#schemaconcerto.metamodel@0.4.0.identified)|false|none|An instance of concerto.metamodel@0.4.0.Identified|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.IdentifiedBy](#schemaconcerto.metamodel@0.4.0.identifiedby)|false|none|An instance of concerto.metamodel@0.4.0.IdentifiedBy|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|superType|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|false|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
+|properties|[anyOf]|true|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Property](#schemaconcerto.metamodel@0.4.0.property)|false|none|An instance of concerto.metamodel@0.4.0.Property|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.RelationshipProperty](#schemaconcerto.metamodel@0.4.0.relationshipproperty)|false|none|An instance of concerto.metamodel@0.4.0.RelationshipProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.ObjectProperty](#schemaconcerto.metamodel@0.4.0.objectproperty)|false|none|An instance of concerto.metamodel@0.4.0.ObjectProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.BooleanProperty](#schemaconcerto.metamodel@0.4.0.booleanproperty)|false|none|An instance of concerto.metamodel@0.4.0.BooleanProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DateTimeProperty](#schemaconcerto.metamodel@0.4.0.datetimeproperty)|false|none|An instance of concerto.metamodel@0.4.0.DateTimeProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.StringProperty](#schemaconcerto.metamodel@0.4.0.stringproperty)|false|none|An instance of concerto.metamodel@0.4.0.StringProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DoubleProperty](#schemaconcerto.metamodel@0.4.0.doubleproperty)|false|none|An instance of concerto.metamodel@0.4.0.DoubleProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.IntegerProperty](#schemaconcerto.metamodel@0.4.0.integerproperty)|false|none|An instance of concerto.metamodel@0.4.0.IntegerProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.LongProperty](#schemaconcerto.metamodel@0.4.0.longproperty)|false|none|An instance of concerto.metamodel@0.4.0.LongProperty|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.ParticipantDeclaration">concerto.metamodel@0.4.0.ParticipantDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.participantdeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.ParticipantDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.participantdeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.participantdeclaration"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.ParticipantDeclaration",
+  "isAbstract": false,
+  "identified": {
+    "$class": "concerto.metamodel@0.4.0.Identified"
+  },
+  "superType": {
+    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
+    "name": "string",
+    "namespace": "string"
+  },
+  "properties": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Property",
+      "name": "string",
+      "isArray": false,
+      "isOptional": false,
+      "decorators": [
+        {
+          "$class": "concerto.metamodel@0.4.0.Decorator",
+          "name": "string",
+          "arguments": [
+            {
+              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+              "location": {
+                "$class": "concerto.metamodel@0.4.0.Range",
+                "start": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "end": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "source": "string"
+              }
+            }
+          ],
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "name": "string",
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+ParticipantDeclaration
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.ParticipantDeclaration|
+|isAbstract|boolean|true|none|none|
+|identified|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Identified](#schemaconcerto.metamodel@0.4.0.identified)|false|none|An instance of concerto.metamodel@0.4.0.Identified|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.IdentifiedBy](#schemaconcerto.metamodel@0.4.0.identifiedby)|false|none|An instance of concerto.metamodel@0.4.0.IdentifiedBy|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|superType|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|false|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
+|properties|[anyOf]|true|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Property](#schemaconcerto.metamodel@0.4.0.property)|false|none|An instance of concerto.metamodel@0.4.0.Property|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.RelationshipProperty](#schemaconcerto.metamodel@0.4.0.relationshipproperty)|false|none|An instance of concerto.metamodel@0.4.0.RelationshipProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.ObjectProperty](#schemaconcerto.metamodel@0.4.0.objectproperty)|false|none|An instance of concerto.metamodel@0.4.0.ObjectProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.BooleanProperty](#schemaconcerto.metamodel@0.4.0.booleanproperty)|false|none|An instance of concerto.metamodel@0.4.0.BooleanProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DateTimeProperty](#schemaconcerto.metamodel@0.4.0.datetimeproperty)|false|none|An instance of concerto.metamodel@0.4.0.DateTimeProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.StringProperty](#schemaconcerto.metamodel@0.4.0.stringproperty)|false|none|An instance of concerto.metamodel@0.4.0.StringProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DoubleProperty](#schemaconcerto.metamodel@0.4.0.doubleproperty)|false|none|An instance of concerto.metamodel@0.4.0.DoubleProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.IntegerProperty](#schemaconcerto.metamodel@0.4.0.integerproperty)|false|none|An instance of concerto.metamodel@0.4.0.IntegerProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.LongProperty](#schemaconcerto.metamodel@0.4.0.longproperty)|false|none|An instance of concerto.metamodel@0.4.0.LongProperty|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.TransactionDeclaration">concerto.metamodel@0.4.0.TransactionDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.transactiondeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.TransactionDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.transactiondeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.transactiondeclaration"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.TransactionDeclaration",
+  "isAbstract": false,
+  "identified": {
+    "$class": "concerto.metamodel@0.4.0.Identified"
+  },
+  "superType": {
+    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
+    "name": "string",
+    "namespace": "string"
+  },
+  "properties": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Property",
+      "name": "string",
+      "isArray": false,
+      "isOptional": false,
+      "decorators": [
+        {
+          "$class": "concerto.metamodel@0.4.0.Decorator",
+          "name": "string",
+          "arguments": [
+            {
+              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+              "location": {
+                "$class": "concerto.metamodel@0.4.0.Range",
+                "start": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "end": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "source": "string"
+              }
+            }
+          ],
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "name": "string",
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+TransactionDeclaration
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.TransactionDeclaration|
+|isAbstract|boolean|true|none|none|
+|identified|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Identified](#schemaconcerto.metamodel@0.4.0.identified)|false|none|An instance of concerto.metamodel@0.4.0.Identified|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.IdentifiedBy](#schemaconcerto.metamodel@0.4.0.identifiedby)|false|none|An instance of concerto.metamodel@0.4.0.IdentifiedBy|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|superType|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|false|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
+|properties|[anyOf]|true|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Property](#schemaconcerto.metamodel@0.4.0.property)|false|none|An instance of concerto.metamodel@0.4.0.Property|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.RelationshipProperty](#schemaconcerto.metamodel@0.4.0.relationshipproperty)|false|none|An instance of concerto.metamodel@0.4.0.RelationshipProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.ObjectProperty](#schemaconcerto.metamodel@0.4.0.objectproperty)|false|none|An instance of concerto.metamodel@0.4.0.ObjectProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.BooleanProperty](#schemaconcerto.metamodel@0.4.0.booleanproperty)|false|none|An instance of concerto.metamodel@0.4.0.BooleanProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DateTimeProperty](#schemaconcerto.metamodel@0.4.0.datetimeproperty)|false|none|An instance of concerto.metamodel@0.4.0.DateTimeProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.StringProperty](#schemaconcerto.metamodel@0.4.0.stringproperty)|false|none|An instance of concerto.metamodel@0.4.0.StringProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DoubleProperty](#schemaconcerto.metamodel@0.4.0.doubleproperty)|false|none|An instance of concerto.metamodel@0.4.0.DoubleProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.IntegerProperty](#schemaconcerto.metamodel@0.4.0.integerproperty)|false|none|An instance of concerto.metamodel@0.4.0.IntegerProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.LongProperty](#schemaconcerto.metamodel@0.4.0.longproperty)|false|none|An instance of concerto.metamodel@0.4.0.LongProperty|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.EventDeclaration">concerto.metamodel@0.4.0.EventDeclaration</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.eventdeclaration"></a>
+<a id="schema_concerto.metamodel@0.4.0.EventDeclaration"></a>
+<a id="tocSconcerto.metamodel@0.4.0.eventdeclaration"></a>
+<a id="tocsconcerto.metamodel@0.4.0.eventdeclaration"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.EventDeclaration",
+  "isAbstract": false,
+  "identified": {
+    "$class": "concerto.metamodel@0.4.0.Identified"
+  },
+  "superType": {
+    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
+    "name": "string",
+    "namespace": "string"
+  },
+  "properties": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Property",
+      "name": "string",
+      "isArray": false,
+      "isOptional": false,
+      "decorators": [
+        {
+          "$class": "concerto.metamodel@0.4.0.Decorator",
+          "name": "string",
+          "arguments": [
+            {
+              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+              "location": {
+                "$class": "concerto.metamodel@0.4.0.Range",
+                "start": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "end": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "source": "string"
+              }
+            }
+          ],
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "name": "string",
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+EventDeclaration
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.EventDeclaration|
+|isAbstract|boolean|true|none|none|
+|identified|any|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Identified](#schemaconcerto.metamodel@0.4.0.identified)|false|none|An instance of concerto.metamodel@0.4.0.Identified|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.IdentifiedBy](#schemaconcerto.metamodel@0.4.0.identifiedby)|false|none|An instance of concerto.metamodel@0.4.0.IdentifiedBy|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|superType|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|false|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
+|properties|[anyOf]|true|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Property](#schemaconcerto.metamodel@0.4.0.property)|false|none|An instance of concerto.metamodel@0.4.0.Property|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.RelationshipProperty](#schemaconcerto.metamodel@0.4.0.relationshipproperty)|false|none|An instance of concerto.metamodel@0.4.0.RelationshipProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.ObjectProperty](#schemaconcerto.metamodel@0.4.0.objectproperty)|false|none|An instance of concerto.metamodel@0.4.0.ObjectProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.BooleanProperty](#schemaconcerto.metamodel@0.4.0.booleanproperty)|false|none|An instance of concerto.metamodel@0.4.0.BooleanProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DateTimeProperty](#schemaconcerto.metamodel@0.4.0.datetimeproperty)|false|none|An instance of concerto.metamodel@0.4.0.DateTimeProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.StringProperty](#schemaconcerto.metamodel@0.4.0.stringproperty)|false|none|An instance of concerto.metamodel@0.4.0.StringProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.DoubleProperty](#schemaconcerto.metamodel@0.4.0.doubleproperty)|false|none|An instance of concerto.metamodel@0.4.0.DoubleProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.IntegerProperty](#schemaconcerto.metamodel@0.4.0.integerproperty)|false|none|An instance of concerto.metamodel@0.4.0.IntegerProperty|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.LongProperty](#schemaconcerto.metamodel@0.4.0.longproperty)|false|none|An instance of concerto.metamodel@0.4.0.LongProperty|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.Property">concerto.metamodel@0.4.0.Property</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.property"></a>
+<a id="schema_concerto.metamodel@0.4.0.Property"></a>
+<a id="tocSconcerto.metamodel@0.4.0.property"></a>
+<a id="tocsconcerto.metamodel@0.4.0.property"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.Property",
+  "name": "string",
+  "isArray": false,
+  "isOptional": false,
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+Property
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Property|
+|name|string|true|none|none|
+|isArray|boolean|true|none|none|
+|isOptional|boolean|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.RelationshipProperty">concerto.metamodel@0.4.0.RelationshipProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.relationshipproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.RelationshipProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.relationshipproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.relationshipproperty"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.RelationshipProperty",
+  "type": {
+    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
+    "name": "string",
+    "namespace": "string"
+  },
+  "name": "string",
+  "isArray": false,
+  "isOptional": false,
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+RelationshipProperty
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.RelationshipProperty|
+|type|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|true|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
+|name|string|true|none|none|
+|isArray|boolean|true|none|none|
+|isOptional|boolean|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.ObjectProperty">concerto.metamodel@0.4.0.ObjectProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.objectproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.ObjectProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.objectproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.objectproperty"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.ObjectProperty",
+  "defaultValue": "string",
+  "type": {
+    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
+    "name": "string",
+    "namespace": "string"
+  },
+  "name": "string",
+  "isArray": false,
+  "isOptional": false,
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+ObjectProperty
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.ObjectProperty|
+|defaultValue|string|false|none|none|
+|type|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|true|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
+|name|string|true|none|none|
+|isArray|boolean|true|none|none|
+|isOptional|boolean|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.BooleanProperty">concerto.metamodel@0.4.0.BooleanProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.booleanproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.BooleanProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.booleanproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.booleanproperty"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.BooleanProperty",
+  "defaultValue": true,
+  "name": "string",
+  "isArray": false,
+  "isOptional": false,
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+BooleanProperty
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.BooleanProperty|
+|defaultValue|boolean|false|none|none|
+|name|string|true|none|none|
+|isArray|boolean|true|none|none|
+|isOptional|boolean|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.DateTimeProperty">concerto.metamodel@0.4.0.DateTimeProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.datetimeproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.DateTimeProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.datetimeproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.datetimeproperty"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.DateTimeProperty",
+  "name": "string",
+  "isArray": false,
+  "isOptional": false,
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+DateTimeProperty
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DateTimeProperty|
+|name|string|true|none|none|
+|isArray|boolean|true|none|none|
+|isOptional|boolean|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.StringProperty">concerto.metamodel@0.4.0.StringProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.stringproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.StringProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.stringproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.stringproperty"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.StringProperty",
+  "defaultValue": "string",
+  "validator": {
+    "$class": "concerto.metamodel@0.4.0.StringRegexValidator",
+    "pattern": "string",
+    "flags": "string"
+  },
+  "name": "string",
+  "isArray": false,
+  "isOptional": false,
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+StringProperty
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.StringProperty|
+|defaultValue|string|false|none|none|
+|validator|[concerto.metamodel@0.4.0.StringRegexValidator](#schemaconcerto.metamodel@0.4.0.stringregexvalidator)|false|none|An instance of concerto.metamodel@0.4.0.StringRegexValidator|
+|name|string|true|none|none|
+|isArray|boolean|true|none|none|
+|isOptional|boolean|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.StringRegexValidator">concerto.metamodel@0.4.0.StringRegexValidator</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.stringregexvalidator"></a>
+<a id="schema_concerto.metamodel@0.4.0.StringRegexValidator"></a>
+<a id="tocSconcerto.metamodel@0.4.0.stringregexvalidator"></a>
+<a id="tocsconcerto.metamodel@0.4.0.stringregexvalidator"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.StringRegexValidator",
+  "pattern": "string",
+  "flags": "string"
+}
+
+```
+
+StringRegexValidator
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.StringRegexValidator|
+|pattern|string|true|none|none|
+|flags|string|true|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.DoubleProperty">concerto.metamodel@0.4.0.DoubleProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.doubleproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.DoubleProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.doubleproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.doubleproperty"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.DoubleProperty",
+  "defaultValue": 0,
+  "validator": {
+    "$class": "concerto.metamodel@0.4.0.DoubleDomainValidator",
+    "lower": 0,
+    "upper": 0
+  },
+  "name": "string",
+  "isArray": false,
+  "isOptional": false,
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+DoubleProperty
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DoubleProperty|
+|defaultValue|number|false|none|none|
+|validator|[concerto.metamodel@0.4.0.DoubleDomainValidator](#schemaconcerto.metamodel@0.4.0.doubledomainvalidator)|false|none|An instance of concerto.metamodel@0.4.0.DoubleDomainValidator|
+|name|string|true|none|none|
+|isArray|boolean|true|none|none|
+|isOptional|boolean|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.DoubleDomainValidator">concerto.metamodel@0.4.0.DoubleDomainValidator</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
+<a id="schema_concerto.metamodel@0.4.0.DoubleDomainValidator"></a>
+<a id="tocSconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
+<a id="tocsconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.DoubleDomainValidator",
+  "lower": 0,
+  "upper": 0
+}
+
+```
+
+DoubleDomainValidator
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DoubleDomainValidator|
+|lower|number|false|none|none|
+|upper|number|false|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.IntegerProperty">concerto.metamodel@0.4.0.IntegerProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.integerproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.IntegerProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.integerproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.integerproperty"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.IntegerProperty",
+  "defaultValue": 0,
+  "validator": {
+    "$class": "concerto.metamodel@0.4.0.IntegerDomainValidator",
+    "lower": 0,
+    "upper": 0
+  },
+  "name": "string",
+  "isArray": false,
+  "isOptional": false,
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+IntegerProperty
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.IntegerProperty|
+|defaultValue|integer|false|none|none|
+|validator|[concerto.metamodel@0.4.0.IntegerDomainValidator](#schemaconcerto.metamodel@0.4.0.integerdomainvalidator)|false|none|An instance of concerto.metamodel@0.4.0.IntegerDomainValidator|
+|name|string|true|none|none|
+|isArray|boolean|true|none|none|
+|isOptional|boolean|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.IntegerDomainValidator">concerto.metamodel@0.4.0.IntegerDomainValidator</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
+<a id="schema_concerto.metamodel@0.4.0.IntegerDomainValidator"></a>
+<a id="tocSconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
+<a id="tocsconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.IntegerDomainValidator",
+  "lower": 0,
+  "upper": 0
+}
+
+```
+
+IntegerDomainValidator
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.IntegerDomainValidator|
+|lower|integer|false|none|none|
+|upper|integer|false|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.LongProperty">concerto.metamodel@0.4.0.LongProperty</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.longproperty"></a>
+<a id="schema_concerto.metamodel@0.4.0.LongProperty"></a>
+<a id="tocSconcerto.metamodel@0.4.0.longproperty"></a>
+<a id="tocsconcerto.metamodel@0.4.0.longproperty"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.LongProperty",
+  "defaultValue": 0,
+  "validator": {
+    "$class": "concerto.metamodel@0.4.0.LongDomainValidator",
+    "lower": 0,
+    "upper": 0
+  },
+  "name": "string",
+  "isArray": false,
+  "isOptional": false,
+  "decorators": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Decorator",
+      "name": "string",
+      "arguments": [
+        {
+          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ],
+  "location": {
+    "$class": "concerto.metamodel@0.4.0.Range",
+    "start": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "end": {
+      "$class": "concerto.metamodel@0.4.0.Position",
+      "line": 0,
+      "column": 0,
+      "offset": 0
+    },
+    "source": "string"
+  }
+}
+
+```
+
+LongProperty
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.LongProperty|
+|defaultValue|integer|false|none|none|
+|validator|[concerto.metamodel@0.4.0.LongDomainValidator](#schemaconcerto.metamodel@0.4.0.longdomainvalidator)|false|none|An instance of concerto.metamodel@0.4.0.LongDomainValidator|
+|name|string|true|none|none|
+|isArray|boolean|true|none|none|
+|isOptional|boolean|true|none|none|
+|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
+|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.LongDomainValidator">concerto.metamodel@0.4.0.LongDomainValidator</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.longdomainvalidator"></a>
+<a id="schema_concerto.metamodel@0.4.0.LongDomainValidator"></a>
+<a id="tocSconcerto.metamodel@0.4.0.longdomainvalidator"></a>
+<a id="tocsconcerto.metamodel@0.4.0.longdomainvalidator"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.LongDomainValidator",
+  "lower": 0,
+  "upper": 0
+}
+
+```
+
+LongDomainValidator
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.LongDomainValidator|
+|lower|integer|false|none|none|
+|upper|integer|false|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.Import">concerto.metamodel@0.4.0.Import</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.import"></a>
+<a id="schema_concerto.metamodel@0.4.0.Import"></a>
+<a id="tocSconcerto.metamodel@0.4.0.import"></a>
+<a id="tocsconcerto.metamodel@0.4.0.import"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.Import",
+  "namespace": "string",
+  "uri": "string"
+}
+
+```
+
+Import
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Import|
+|namespace|string|true|none|none|
+|uri|string|false|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.ImportAll">concerto.metamodel@0.4.0.ImportAll</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.importall"></a>
+<a id="schema_concerto.metamodel@0.4.0.ImportAll"></a>
+<a id="tocSconcerto.metamodel@0.4.0.importall"></a>
+<a id="tocsconcerto.metamodel@0.4.0.importall"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.ImportAll",
+  "namespace": "string",
+  "uri": "string"
+}
+
+```
+
+ImportAll
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.ImportAll|
+|namespace|string|true|none|none|
+|uri|string|false|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.ImportType">concerto.metamodel@0.4.0.ImportType</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.importtype"></a>
+<a id="schema_concerto.metamodel@0.4.0.ImportType"></a>
+<a id="tocSconcerto.metamodel@0.4.0.importtype"></a>
+<a id="tocsconcerto.metamodel@0.4.0.importtype"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.ImportType",
+  "name": "string",
+  "namespace": "string",
+  "uri": "string"
+}
+
+```
+
+ImportType
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.ImportType|
+|name|string|true|none|none|
+|namespace|string|true|none|none|
+|uri|string|false|none|none|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.Model">concerto.metamodel@0.4.0.Model</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.model"></a>
+<a id="schema_concerto.metamodel@0.4.0.Model"></a>
+<a id="tocSconcerto.metamodel@0.4.0.model"></a>
+<a id="tocsconcerto.metamodel@0.4.0.model"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.Model",
+  "namespace": "string",
+  "sourceUri": "string",
+  "concertoVersion": "string",
+  "imports": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Import",
+      "namespace": "string",
+      "uri": "string"
+    }
+  ],
+  "declarations": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Declaration",
+      "name": "string",
+      "decorators": [
+        {
+          "$class": "concerto.metamodel@0.4.0.Decorator",
+          "name": "string",
+          "arguments": [
+            {
+              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+              "location": {
+                "$class": "concerto.metamodel@0.4.0.Range",
+                "start": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "end": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "source": "string"
+              }
+            }
+          ],
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ],
+      "location": {
+        "$class": "concerto.metamodel@0.4.0.Range",
+        "start": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "$class": "concerto.metamodel@0.4.0.Position",
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "source": "string"
+      }
+    }
+  ]
+}
+
+```
+
+Model
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Model|
+|namespace|string|true|none|none|
+|sourceUri|string|false|none|none|
+|concertoVersion|string|false|none|none|
+|imports|[anyOf]|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Import](#schemaconcerto.metamodel@0.4.0.import)|false|none|An instance of concerto.metamodel@0.4.0.Import|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.ImportAll](#schemaconcerto.metamodel@0.4.0.importall)|false|none|An instance of concerto.metamodel@0.4.0.ImportAll|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.ImportType](#schemaconcerto.metamodel@0.4.0.importtype)|false|none|An instance of concerto.metamodel@0.4.0.ImportType|
+
+continued
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|declarations|[anyOf]|false|none|none|
+
+anyOf
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.Declaration](#schemaconcerto.metamodel@0.4.0.declaration)|false|none|An instance of concerto.metamodel@0.4.0.Declaration|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.EnumDeclaration](#schemaconcerto.metamodel@0.4.0.enumdeclaration)|false|none|An instance of concerto.metamodel@0.4.0.EnumDeclaration|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.ConceptDeclaration](#schemaconcerto.metamodel@0.4.0.conceptdeclaration)|false|none|An instance of concerto.metamodel@0.4.0.ConceptDeclaration|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.AssetDeclaration](#schemaconcerto.metamodel@0.4.0.assetdeclaration)|false|none|An instance of concerto.metamodel@0.4.0.AssetDeclaration|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.ParticipantDeclaration](#schemaconcerto.metamodel@0.4.0.participantdeclaration)|false|none|An instance of concerto.metamodel@0.4.0.ParticipantDeclaration|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.TransactionDeclaration](#schemaconcerto.metamodel@0.4.0.transactiondeclaration)|false|none|An instance of concerto.metamodel@0.4.0.TransactionDeclaration|
+
+or
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» *anonymous*|[concerto.metamodel@0.4.0.EventDeclaration](#schemaconcerto.metamodel@0.4.0.eventdeclaration)|false|none|An instance of concerto.metamodel@0.4.0.EventDeclaration|
+
+<h2 id="tocS_concerto.metamodel@0.4.0.Models">concerto.metamodel@0.4.0.Models</h2>
+<!-- backwards compatibility -->
+<a id="schemaconcerto.metamodel@0.4.0.models"></a>
+<a id="schema_concerto.metamodel@0.4.0.Models"></a>
+<a id="tocSconcerto.metamodel@0.4.0.models"></a>
+<a id="tocsconcerto.metamodel@0.4.0.models"></a>
+
+```json
+{
+  "$class": "concerto.metamodel@0.4.0.Models",
+  "models": [
+    {
+      "$class": "concerto.metamodel@0.4.0.Model",
+      "namespace": "string",
+      "sourceUri": "string",
+      "concertoVersion": "string",
+      "imports": [
+        {
+          "$class": "concerto.metamodel@0.4.0.Import",
+          "namespace": "string",
+          "uri": "string"
+        }
+      ],
+      "declarations": [
+        {
+          "$class": "concerto.metamodel@0.4.0.Declaration",
+          "name": "string",
+          "decorators": [
+            {
+              "$class": "concerto.metamodel@0.4.0.Decorator",
+              "name": "string",
+              "arguments": [
+                {
+                  "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
+                  "location": {
+                    "$class": "concerto.metamodel@0.4.0.Range",
+                    "start": {},
+                    "end": {},
+                    "source": "string"
+                  }
+                }
+              ],
+              "location": {
+                "$class": "concerto.metamodel@0.4.0.Range",
+                "start": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "end": {
+                  "$class": "concerto.metamodel@0.4.0.Position",
+                  "line": 0,
+                  "column": 0,
+                  "offset": 0
+                },
+                "source": "string"
+              }
+            }
+          ],
+          "location": {
+            "$class": "concerto.metamodel@0.4.0.Range",
+            "start": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "end": {
+              "$class": "concerto.metamodel@0.4.0.Position",
+              "line": 0,
+              "column": 0,
+              "offset": 0
+            },
+            "source": "string"
+          }
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+Models
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Models|
+|models|[[concerto.metamodel@0.4.0.Model](#schemaconcerto.metamodel@0.4.0.model)]|true|none|[An instance of concerto.metamodel@0.4.0.Model]|
 
 <h2 id="tocS_org.accordproject.commonmark@0.5.0.Node">org.accordproject.commonmark@0.5.0.Node</h2>
 <!-- backwards compatibility -->
@@ -17659,3292 +21191,4 @@ continued
 |---|---|---|---|---|
 |startLine|integer|false|none|none|
 |endLine|integer|false|none|none|
-
-<h2 id="tocS_org.accordproject.party@0.2.0.Party">org.accordproject.party@0.2.0.Party</h2>
-<!-- backwards compatibility -->
-<a id="schemaorg.accordproject.party@0.2.0.party"></a>
-<a id="schema_org.accordproject.party@0.2.0.Party"></a>
-<a id="tocSorg.accordproject.party@0.2.0.party"></a>
-<a id="tocsorg.accordproject.party@0.2.0.party"></a>
-
-```json
-{
-  "$class": "org.accordproject.party@0.2.0.Party",
-  "partyId": "string"
-}
-
-```
-
-Party
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for org.accordproject.party@0.2.0.Party|
-|partyId|string|true|none|The instance identifier for this type|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.Position">concerto.metamodel@0.4.0.Position</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.position"></a>
-<a id="schema_concerto.metamodel@0.4.0.Position"></a>
-<a id="tocSconcerto.metamodel@0.4.0.position"></a>
-<a id="tocsconcerto.metamodel@0.4.0.position"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.Position",
-  "line": 0,
-  "column": 0,
-  "offset": 0
-}
-
-```
-
-Position
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Position|
-|line|integer|true|none|none|
-|column|integer|true|none|none|
-|offset|integer|true|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.Range">concerto.metamodel@0.4.0.Range</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.range"></a>
-<a id="schema_concerto.metamodel@0.4.0.Range"></a>
-<a id="tocSconcerto.metamodel@0.4.0.range"></a>
-<a id="tocsconcerto.metamodel@0.4.0.range"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.Range",
-  "start": {
-    "$class": "concerto.metamodel@0.4.0.Position",
-    "line": 0,
-    "column": 0,
-    "offset": 0
-  },
-  "end": {
-    "$class": "concerto.metamodel@0.4.0.Position",
-    "line": 0,
-    "column": 0,
-    "offset": 0
-  },
-  "source": "string"
-}
-
-```
-
-Range
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Range|
-|start|[concerto.metamodel@0.4.0.Position](#schemaconcerto.metamodel@0.4.0.position)|true|none|An instance of concerto.metamodel@0.4.0.Position|
-|end|[concerto.metamodel@0.4.0.Position](#schemaconcerto.metamodel@0.4.0.position)|true|none|An instance of concerto.metamodel@0.4.0.Position|
-|source|string|false|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.TypeIdentifier">concerto.metamodel@0.4.0.TypeIdentifier</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.typeidentifier"></a>
-<a id="schema_concerto.metamodel@0.4.0.TypeIdentifier"></a>
-<a id="tocSconcerto.metamodel@0.4.0.typeidentifier"></a>
-<a id="tocsconcerto.metamodel@0.4.0.typeidentifier"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
-  "name": "string",
-  "namespace": "string"
-}
-
-```
-
-TypeIdentifier
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.TypeIdentifier|
-|name|string|true|none|none|
-|namespace|string|false|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorLiteral">concerto.metamodel@0.4.0.DecoratorLiteral</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decoratorliteral"></a>
-<a id="schema_concerto.metamodel@0.4.0.DecoratorLiteral"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decoratorliteral"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decoratorliteral"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-DecoratorLiteral
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DecoratorLiteral|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorString">concerto.metamodel@0.4.0.DecoratorString</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decoratorstring"></a>
-<a id="schema_concerto.metamodel@0.4.0.DecoratorString"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decoratorstring"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decoratorstring"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.DecoratorString",
-  "value": "string",
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-DecoratorString
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DecoratorString|
-|value|string|true|none|none|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorNumber">concerto.metamodel@0.4.0.DecoratorNumber</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decoratornumber"></a>
-<a id="schema_concerto.metamodel@0.4.0.DecoratorNumber"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decoratornumber"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decoratornumber"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.DecoratorNumber",
-  "value": 0,
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-DecoratorNumber
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DecoratorNumber|
-|value|number|true|none|none|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorBoolean">concerto.metamodel@0.4.0.DecoratorBoolean</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decoratorboolean"></a>
-<a id="schema_concerto.metamodel@0.4.0.DecoratorBoolean"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decoratorboolean"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decoratorboolean"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.DecoratorBoolean",
-  "value": true,
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-DecoratorBoolean
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DecoratorBoolean|
-|value|boolean|true|none|none|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.DecoratorTypeReference">concerto.metamodel@0.4.0.DecoratorTypeReference</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decoratortypereference"></a>
-<a id="schema_concerto.metamodel@0.4.0.DecoratorTypeReference"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decoratortypereference"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decoratortypereference"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.DecoratorTypeReference",
-  "type": {
-    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
-    "name": "string",
-    "namespace": "string"
-  },
-  "isArray": false,
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-DecoratorTypeReference
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DecoratorTypeReference|
-|type|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|true|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
-|isArray|boolean|true|none|none|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.Decorator">concerto.metamodel@0.4.0.Decorator</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.decorator"></a>
-<a id="schema_concerto.metamodel@0.4.0.Decorator"></a>
-<a id="tocSconcerto.metamodel@0.4.0.decorator"></a>
-<a id="tocsconcerto.metamodel@0.4.0.decorator"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.Decorator",
-  "name": "string",
-  "arguments": [
-    {
-      "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-Decorator
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Decorator|
-|name|string|true|none|none|
-|arguments|[anyOf]|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DecoratorLiteral](#schemaconcerto.metamodel@0.4.0.decoratorliteral)|false|none|An instance of concerto.metamodel@0.4.0.DecoratorLiteral|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DecoratorString](#schemaconcerto.metamodel@0.4.0.decoratorstring)|false|none|An instance of concerto.metamodel@0.4.0.DecoratorString|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DecoratorNumber](#schemaconcerto.metamodel@0.4.0.decoratornumber)|false|none|An instance of concerto.metamodel@0.4.0.DecoratorNumber|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DecoratorBoolean](#schemaconcerto.metamodel@0.4.0.decoratorboolean)|false|none|An instance of concerto.metamodel@0.4.0.DecoratorBoolean|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DecoratorTypeReference](#schemaconcerto.metamodel@0.4.0.decoratortypereference)|false|none|An instance of concerto.metamodel@0.4.0.DecoratorTypeReference|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.Identified">concerto.metamodel@0.4.0.Identified</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.identified"></a>
-<a id="schema_concerto.metamodel@0.4.0.Identified"></a>
-<a id="tocSconcerto.metamodel@0.4.0.identified"></a>
-<a id="tocsconcerto.metamodel@0.4.0.identified"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.Identified"
-}
-
-```
-
-Identified
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Identified|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.IdentifiedBy">concerto.metamodel@0.4.0.IdentifiedBy</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.identifiedby"></a>
-<a id="schema_concerto.metamodel@0.4.0.IdentifiedBy"></a>
-<a id="tocSconcerto.metamodel@0.4.0.identifiedby"></a>
-<a id="tocsconcerto.metamodel@0.4.0.identifiedby"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.IdentifiedBy",
-  "name": "string"
-}
-
-```
-
-IdentifiedBy
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.IdentifiedBy|
-|name|string|true|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.Declaration">concerto.metamodel@0.4.0.Declaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.declaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.Declaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.declaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.declaration"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.Declaration",
-  "name": "string",
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-Declaration
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Declaration|
-|name|string|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.EnumDeclaration">concerto.metamodel@0.4.0.EnumDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.enumdeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.EnumDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.enumdeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.enumdeclaration"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.EnumDeclaration",
-  "properties": [
-    {
-      "$class": "concerto.metamodel@0.4.0.EnumProperty",
-      "name": "string",
-      "decorators": [
-        {
-          "$class": "concerto.metamodel@0.4.0.Decorator",
-          "name": "string",
-          "arguments": [
-            {
-              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-              "location": {
-                "$class": "concerto.metamodel@0.4.0.Range",
-                "start": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "end": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "source": "string"
-              }
-            }
-          ],
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "name": "string",
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-EnumDeclaration
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.EnumDeclaration|
-|properties|[[concerto.metamodel@0.4.0.EnumProperty](#schemaconcerto.metamodel@0.4.0.enumproperty)]|true|none|[An instance of concerto.metamodel@0.4.0.EnumProperty]|
-|name|string|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.EnumProperty">concerto.metamodel@0.4.0.EnumProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.enumproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.EnumProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.enumproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.enumproperty"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.EnumProperty",
-  "name": "string",
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-EnumProperty
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.EnumProperty|
-|name|string|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.ConceptDeclaration">concerto.metamodel@0.4.0.ConceptDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.conceptdeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.ConceptDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.conceptdeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.conceptdeclaration"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.ConceptDeclaration",
-  "isAbstract": false,
-  "identified": {
-    "$class": "concerto.metamodel@0.4.0.Identified"
-  },
-  "superType": {
-    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
-    "name": "string",
-    "namespace": "string"
-  },
-  "properties": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Property",
-      "name": "string",
-      "isArray": false,
-      "isOptional": false,
-      "decorators": [
-        {
-          "$class": "concerto.metamodel@0.4.0.Decorator",
-          "name": "string",
-          "arguments": [
-            {
-              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-              "location": {
-                "$class": "concerto.metamodel@0.4.0.Range",
-                "start": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "end": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "source": "string"
-              }
-            }
-          ],
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "name": "string",
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-ConceptDeclaration
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.ConceptDeclaration|
-|isAbstract|boolean|true|none|none|
-|identified|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Identified](#schemaconcerto.metamodel@0.4.0.identified)|false|none|An instance of concerto.metamodel@0.4.0.Identified|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.IdentifiedBy](#schemaconcerto.metamodel@0.4.0.identifiedby)|false|none|An instance of concerto.metamodel@0.4.0.IdentifiedBy|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|superType|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|false|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
-|properties|[anyOf]|true|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Property](#schemaconcerto.metamodel@0.4.0.property)|false|none|An instance of concerto.metamodel@0.4.0.Property|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.RelationshipProperty](#schemaconcerto.metamodel@0.4.0.relationshipproperty)|false|none|An instance of concerto.metamodel@0.4.0.RelationshipProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.ObjectProperty](#schemaconcerto.metamodel@0.4.0.objectproperty)|false|none|An instance of concerto.metamodel@0.4.0.ObjectProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.BooleanProperty](#schemaconcerto.metamodel@0.4.0.booleanproperty)|false|none|An instance of concerto.metamodel@0.4.0.BooleanProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DateTimeProperty](#schemaconcerto.metamodel@0.4.0.datetimeproperty)|false|none|An instance of concerto.metamodel@0.4.0.DateTimeProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.StringProperty](#schemaconcerto.metamodel@0.4.0.stringproperty)|false|none|An instance of concerto.metamodel@0.4.0.StringProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DoubleProperty](#schemaconcerto.metamodel@0.4.0.doubleproperty)|false|none|An instance of concerto.metamodel@0.4.0.DoubleProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.IntegerProperty](#schemaconcerto.metamodel@0.4.0.integerproperty)|false|none|An instance of concerto.metamodel@0.4.0.IntegerProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.LongProperty](#schemaconcerto.metamodel@0.4.0.longproperty)|false|none|An instance of concerto.metamodel@0.4.0.LongProperty|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|name|string|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.AssetDeclaration">concerto.metamodel@0.4.0.AssetDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.assetdeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.AssetDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.assetdeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.assetdeclaration"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.AssetDeclaration",
-  "isAbstract": false,
-  "identified": {
-    "$class": "concerto.metamodel@0.4.0.Identified"
-  },
-  "superType": {
-    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
-    "name": "string",
-    "namespace": "string"
-  },
-  "properties": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Property",
-      "name": "string",
-      "isArray": false,
-      "isOptional": false,
-      "decorators": [
-        {
-          "$class": "concerto.metamodel@0.4.0.Decorator",
-          "name": "string",
-          "arguments": [
-            {
-              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-              "location": {
-                "$class": "concerto.metamodel@0.4.0.Range",
-                "start": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "end": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "source": "string"
-              }
-            }
-          ],
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "name": "string",
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-AssetDeclaration
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.AssetDeclaration|
-|isAbstract|boolean|true|none|none|
-|identified|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Identified](#schemaconcerto.metamodel@0.4.0.identified)|false|none|An instance of concerto.metamodel@0.4.0.Identified|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.IdentifiedBy](#schemaconcerto.metamodel@0.4.0.identifiedby)|false|none|An instance of concerto.metamodel@0.4.0.IdentifiedBy|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|superType|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|false|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
-|properties|[anyOf]|true|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Property](#schemaconcerto.metamodel@0.4.0.property)|false|none|An instance of concerto.metamodel@0.4.0.Property|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.RelationshipProperty](#schemaconcerto.metamodel@0.4.0.relationshipproperty)|false|none|An instance of concerto.metamodel@0.4.0.RelationshipProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.ObjectProperty](#schemaconcerto.metamodel@0.4.0.objectproperty)|false|none|An instance of concerto.metamodel@0.4.0.ObjectProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.BooleanProperty](#schemaconcerto.metamodel@0.4.0.booleanproperty)|false|none|An instance of concerto.metamodel@0.4.0.BooleanProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DateTimeProperty](#schemaconcerto.metamodel@0.4.0.datetimeproperty)|false|none|An instance of concerto.metamodel@0.4.0.DateTimeProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.StringProperty](#schemaconcerto.metamodel@0.4.0.stringproperty)|false|none|An instance of concerto.metamodel@0.4.0.StringProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DoubleProperty](#schemaconcerto.metamodel@0.4.0.doubleproperty)|false|none|An instance of concerto.metamodel@0.4.0.DoubleProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.IntegerProperty](#schemaconcerto.metamodel@0.4.0.integerproperty)|false|none|An instance of concerto.metamodel@0.4.0.IntegerProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.LongProperty](#schemaconcerto.metamodel@0.4.0.longproperty)|false|none|An instance of concerto.metamodel@0.4.0.LongProperty|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|name|string|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.ParticipantDeclaration">concerto.metamodel@0.4.0.ParticipantDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.participantdeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.ParticipantDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.participantdeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.participantdeclaration"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.ParticipantDeclaration",
-  "isAbstract": false,
-  "identified": {
-    "$class": "concerto.metamodel@0.4.0.Identified"
-  },
-  "superType": {
-    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
-    "name": "string",
-    "namespace": "string"
-  },
-  "properties": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Property",
-      "name": "string",
-      "isArray": false,
-      "isOptional": false,
-      "decorators": [
-        {
-          "$class": "concerto.metamodel@0.4.0.Decorator",
-          "name": "string",
-          "arguments": [
-            {
-              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-              "location": {
-                "$class": "concerto.metamodel@0.4.0.Range",
-                "start": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "end": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "source": "string"
-              }
-            }
-          ],
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "name": "string",
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-ParticipantDeclaration
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.ParticipantDeclaration|
-|isAbstract|boolean|true|none|none|
-|identified|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Identified](#schemaconcerto.metamodel@0.4.0.identified)|false|none|An instance of concerto.metamodel@0.4.0.Identified|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.IdentifiedBy](#schemaconcerto.metamodel@0.4.0.identifiedby)|false|none|An instance of concerto.metamodel@0.4.0.IdentifiedBy|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|superType|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|false|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
-|properties|[anyOf]|true|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Property](#schemaconcerto.metamodel@0.4.0.property)|false|none|An instance of concerto.metamodel@0.4.0.Property|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.RelationshipProperty](#schemaconcerto.metamodel@0.4.0.relationshipproperty)|false|none|An instance of concerto.metamodel@0.4.0.RelationshipProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.ObjectProperty](#schemaconcerto.metamodel@0.4.0.objectproperty)|false|none|An instance of concerto.metamodel@0.4.0.ObjectProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.BooleanProperty](#schemaconcerto.metamodel@0.4.0.booleanproperty)|false|none|An instance of concerto.metamodel@0.4.0.BooleanProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DateTimeProperty](#schemaconcerto.metamodel@0.4.0.datetimeproperty)|false|none|An instance of concerto.metamodel@0.4.0.DateTimeProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.StringProperty](#schemaconcerto.metamodel@0.4.0.stringproperty)|false|none|An instance of concerto.metamodel@0.4.0.StringProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DoubleProperty](#schemaconcerto.metamodel@0.4.0.doubleproperty)|false|none|An instance of concerto.metamodel@0.4.0.DoubleProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.IntegerProperty](#schemaconcerto.metamodel@0.4.0.integerproperty)|false|none|An instance of concerto.metamodel@0.4.0.IntegerProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.LongProperty](#schemaconcerto.metamodel@0.4.0.longproperty)|false|none|An instance of concerto.metamodel@0.4.0.LongProperty|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|name|string|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.TransactionDeclaration">concerto.metamodel@0.4.0.TransactionDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.transactiondeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.TransactionDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.transactiondeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.transactiondeclaration"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.TransactionDeclaration",
-  "isAbstract": false,
-  "identified": {
-    "$class": "concerto.metamodel@0.4.0.Identified"
-  },
-  "superType": {
-    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
-    "name": "string",
-    "namespace": "string"
-  },
-  "properties": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Property",
-      "name": "string",
-      "isArray": false,
-      "isOptional": false,
-      "decorators": [
-        {
-          "$class": "concerto.metamodel@0.4.0.Decorator",
-          "name": "string",
-          "arguments": [
-            {
-              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-              "location": {
-                "$class": "concerto.metamodel@0.4.0.Range",
-                "start": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "end": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "source": "string"
-              }
-            }
-          ],
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "name": "string",
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-TransactionDeclaration
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.TransactionDeclaration|
-|isAbstract|boolean|true|none|none|
-|identified|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Identified](#schemaconcerto.metamodel@0.4.0.identified)|false|none|An instance of concerto.metamodel@0.4.0.Identified|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.IdentifiedBy](#schemaconcerto.metamodel@0.4.0.identifiedby)|false|none|An instance of concerto.metamodel@0.4.0.IdentifiedBy|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|superType|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|false|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
-|properties|[anyOf]|true|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Property](#schemaconcerto.metamodel@0.4.0.property)|false|none|An instance of concerto.metamodel@0.4.0.Property|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.RelationshipProperty](#schemaconcerto.metamodel@0.4.0.relationshipproperty)|false|none|An instance of concerto.metamodel@0.4.0.RelationshipProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.ObjectProperty](#schemaconcerto.metamodel@0.4.0.objectproperty)|false|none|An instance of concerto.metamodel@0.4.0.ObjectProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.BooleanProperty](#schemaconcerto.metamodel@0.4.0.booleanproperty)|false|none|An instance of concerto.metamodel@0.4.0.BooleanProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DateTimeProperty](#schemaconcerto.metamodel@0.4.0.datetimeproperty)|false|none|An instance of concerto.metamodel@0.4.0.DateTimeProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.StringProperty](#schemaconcerto.metamodel@0.4.0.stringproperty)|false|none|An instance of concerto.metamodel@0.4.0.StringProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DoubleProperty](#schemaconcerto.metamodel@0.4.0.doubleproperty)|false|none|An instance of concerto.metamodel@0.4.0.DoubleProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.IntegerProperty](#schemaconcerto.metamodel@0.4.0.integerproperty)|false|none|An instance of concerto.metamodel@0.4.0.IntegerProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.LongProperty](#schemaconcerto.metamodel@0.4.0.longproperty)|false|none|An instance of concerto.metamodel@0.4.0.LongProperty|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|name|string|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.EventDeclaration">concerto.metamodel@0.4.0.EventDeclaration</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.eventdeclaration"></a>
-<a id="schema_concerto.metamodel@0.4.0.EventDeclaration"></a>
-<a id="tocSconcerto.metamodel@0.4.0.eventdeclaration"></a>
-<a id="tocsconcerto.metamodel@0.4.0.eventdeclaration"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.EventDeclaration",
-  "isAbstract": false,
-  "identified": {
-    "$class": "concerto.metamodel@0.4.0.Identified"
-  },
-  "superType": {
-    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
-    "name": "string",
-    "namespace": "string"
-  },
-  "properties": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Property",
-      "name": "string",
-      "isArray": false,
-      "isOptional": false,
-      "decorators": [
-        {
-          "$class": "concerto.metamodel@0.4.0.Decorator",
-          "name": "string",
-          "arguments": [
-            {
-              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-              "location": {
-                "$class": "concerto.metamodel@0.4.0.Range",
-                "start": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "end": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "source": "string"
-              }
-            }
-          ],
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "name": "string",
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-EventDeclaration
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.EventDeclaration|
-|isAbstract|boolean|true|none|none|
-|identified|any|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Identified](#schemaconcerto.metamodel@0.4.0.identified)|false|none|An instance of concerto.metamodel@0.4.0.Identified|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.IdentifiedBy](#schemaconcerto.metamodel@0.4.0.identifiedby)|false|none|An instance of concerto.metamodel@0.4.0.IdentifiedBy|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|superType|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|false|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
-|properties|[anyOf]|true|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Property](#schemaconcerto.metamodel@0.4.0.property)|false|none|An instance of concerto.metamodel@0.4.0.Property|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.RelationshipProperty](#schemaconcerto.metamodel@0.4.0.relationshipproperty)|false|none|An instance of concerto.metamodel@0.4.0.RelationshipProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.ObjectProperty](#schemaconcerto.metamodel@0.4.0.objectproperty)|false|none|An instance of concerto.metamodel@0.4.0.ObjectProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.BooleanProperty](#schemaconcerto.metamodel@0.4.0.booleanproperty)|false|none|An instance of concerto.metamodel@0.4.0.BooleanProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DateTimeProperty](#schemaconcerto.metamodel@0.4.0.datetimeproperty)|false|none|An instance of concerto.metamodel@0.4.0.DateTimeProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.StringProperty](#schemaconcerto.metamodel@0.4.0.stringproperty)|false|none|An instance of concerto.metamodel@0.4.0.StringProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.DoubleProperty](#schemaconcerto.metamodel@0.4.0.doubleproperty)|false|none|An instance of concerto.metamodel@0.4.0.DoubleProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.IntegerProperty](#schemaconcerto.metamodel@0.4.0.integerproperty)|false|none|An instance of concerto.metamodel@0.4.0.IntegerProperty|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.LongProperty](#schemaconcerto.metamodel@0.4.0.longproperty)|false|none|An instance of concerto.metamodel@0.4.0.LongProperty|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|name|string|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.Property">concerto.metamodel@0.4.0.Property</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.property"></a>
-<a id="schema_concerto.metamodel@0.4.0.Property"></a>
-<a id="tocSconcerto.metamodel@0.4.0.property"></a>
-<a id="tocsconcerto.metamodel@0.4.0.property"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.Property",
-  "name": "string",
-  "isArray": false,
-  "isOptional": false,
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-Property
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Property|
-|name|string|true|none|none|
-|isArray|boolean|true|none|none|
-|isOptional|boolean|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.RelationshipProperty">concerto.metamodel@0.4.0.RelationshipProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.relationshipproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.RelationshipProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.relationshipproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.relationshipproperty"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.RelationshipProperty",
-  "type": {
-    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
-    "name": "string",
-    "namespace": "string"
-  },
-  "name": "string",
-  "isArray": false,
-  "isOptional": false,
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-RelationshipProperty
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.RelationshipProperty|
-|type|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|true|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
-|name|string|true|none|none|
-|isArray|boolean|true|none|none|
-|isOptional|boolean|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.ObjectProperty">concerto.metamodel@0.4.0.ObjectProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.objectproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.ObjectProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.objectproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.objectproperty"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.ObjectProperty",
-  "defaultValue": "string",
-  "type": {
-    "$class": "concerto.metamodel@0.4.0.TypeIdentifier",
-    "name": "string",
-    "namespace": "string"
-  },
-  "name": "string",
-  "isArray": false,
-  "isOptional": false,
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-ObjectProperty
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.ObjectProperty|
-|defaultValue|string|false|none|none|
-|type|[concerto.metamodel@0.4.0.TypeIdentifier](#schemaconcerto.metamodel@0.4.0.typeidentifier)|true|none|An instance of concerto.metamodel@0.4.0.TypeIdentifier|
-|name|string|true|none|none|
-|isArray|boolean|true|none|none|
-|isOptional|boolean|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.BooleanProperty">concerto.metamodel@0.4.0.BooleanProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.booleanproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.BooleanProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.booleanproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.booleanproperty"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.BooleanProperty",
-  "defaultValue": true,
-  "name": "string",
-  "isArray": false,
-  "isOptional": false,
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-BooleanProperty
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.BooleanProperty|
-|defaultValue|boolean|false|none|none|
-|name|string|true|none|none|
-|isArray|boolean|true|none|none|
-|isOptional|boolean|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.DateTimeProperty">concerto.metamodel@0.4.0.DateTimeProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.datetimeproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.DateTimeProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.datetimeproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.datetimeproperty"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.DateTimeProperty",
-  "name": "string",
-  "isArray": false,
-  "isOptional": false,
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-DateTimeProperty
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DateTimeProperty|
-|name|string|true|none|none|
-|isArray|boolean|true|none|none|
-|isOptional|boolean|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.StringProperty">concerto.metamodel@0.4.0.StringProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.stringproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.StringProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.stringproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.stringproperty"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.StringProperty",
-  "defaultValue": "string",
-  "validator": {
-    "$class": "concerto.metamodel@0.4.0.StringRegexValidator",
-    "pattern": "string",
-    "flags": "string"
-  },
-  "name": "string",
-  "isArray": false,
-  "isOptional": false,
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-StringProperty
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.StringProperty|
-|defaultValue|string|false|none|none|
-|validator|[concerto.metamodel@0.4.0.StringRegexValidator](#schemaconcerto.metamodel@0.4.0.stringregexvalidator)|false|none|An instance of concerto.metamodel@0.4.0.StringRegexValidator|
-|name|string|true|none|none|
-|isArray|boolean|true|none|none|
-|isOptional|boolean|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.StringRegexValidator">concerto.metamodel@0.4.0.StringRegexValidator</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.stringregexvalidator"></a>
-<a id="schema_concerto.metamodel@0.4.0.StringRegexValidator"></a>
-<a id="tocSconcerto.metamodel@0.4.0.stringregexvalidator"></a>
-<a id="tocsconcerto.metamodel@0.4.0.stringregexvalidator"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.StringRegexValidator",
-  "pattern": "string",
-  "flags": "string"
-}
-
-```
-
-StringRegexValidator
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.StringRegexValidator|
-|pattern|string|true|none|none|
-|flags|string|true|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.DoubleProperty">concerto.metamodel@0.4.0.DoubleProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.doubleproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.DoubleProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.doubleproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.doubleproperty"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.DoubleProperty",
-  "defaultValue": 0,
-  "validator": {
-    "$class": "concerto.metamodel@0.4.0.DoubleDomainValidator",
-    "lower": 0,
-    "upper": 0
-  },
-  "name": "string",
-  "isArray": false,
-  "isOptional": false,
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-DoubleProperty
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DoubleProperty|
-|defaultValue|number|false|none|none|
-|validator|[concerto.metamodel@0.4.0.DoubleDomainValidator](#schemaconcerto.metamodel@0.4.0.doubledomainvalidator)|false|none|An instance of concerto.metamodel@0.4.0.DoubleDomainValidator|
-|name|string|true|none|none|
-|isArray|boolean|true|none|none|
-|isOptional|boolean|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.DoubleDomainValidator">concerto.metamodel@0.4.0.DoubleDomainValidator</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
-<a id="schema_concerto.metamodel@0.4.0.DoubleDomainValidator"></a>
-<a id="tocSconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
-<a id="tocsconcerto.metamodel@0.4.0.doubledomainvalidator"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.DoubleDomainValidator",
-  "lower": 0,
-  "upper": 0
-}
-
-```
-
-DoubleDomainValidator
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.DoubleDomainValidator|
-|lower|number|false|none|none|
-|upper|number|false|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.IntegerProperty">concerto.metamodel@0.4.0.IntegerProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.integerproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.IntegerProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.integerproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.integerproperty"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.IntegerProperty",
-  "defaultValue": 0,
-  "validator": {
-    "$class": "concerto.metamodel@0.4.0.IntegerDomainValidator",
-    "lower": 0,
-    "upper": 0
-  },
-  "name": "string",
-  "isArray": false,
-  "isOptional": false,
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-IntegerProperty
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.IntegerProperty|
-|defaultValue|integer|false|none|none|
-|validator|[concerto.metamodel@0.4.0.IntegerDomainValidator](#schemaconcerto.metamodel@0.4.0.integerdomainvalidator)|false|none|An instance of concerto.metamodel@0.4.0.IntegerDomainValidator|
-|name|string|true|none|none|
-|isArray|boolean|true|none|none|
-|isOptional|boolean|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.IntegerDomainValidator">concerto.metamodel@0.4.0.IntegerDomainValidator</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
-<a id="schema_concerto.metamodel@0.4.0.IntegerDomainValidator"></a>
-<a id="tocSconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
-<a id="tocsconcerto.metamodel@0.4.0.integerdomainvalidator"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.IntegerDomainValidator",
-  "lower": 0,
-  "upper": 0
-}
-
-```
-
-IntegerDomainValidator
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.IntegerDomainValidator|
-|lower|integer|false|none|none|
-|upper|integer|false|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.LongProperty">concerto.metamodel@0.4.0.LongProperty</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.longproperty"></a>
-<a id="schema_concerto.metamodel@0.4.0.LongProperty"></a>
-<a id="tocSconcerto.metamodel@0.4.0.longproperty"></a>
-<a id="tocsconcerto.metamodel@0.4.0.longproperty"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.LongProperty",
-  "defaultValue": 0,
-  "validator": {
-    "$class": "concerto.metamodel@0.4.0.LongDomainValidator",
-    "lower": 0,
-    "upper": 0
-  },
-  "name": "string",
-  "isArray": false,
-  "isOptional": false,
-  "decorators": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Decorator",
-      "name": "string",
-      "arguments": [
-        {
-          "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ],
-  "location": {
-    "$class": "concerto.metamodel@0.4.0.Range",
-    "start": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "end": {
-      "$class": "concerto.metamodel@0.4.0.Position",
-      "line": 0,
-      "column": 0,
-      "offset": 0
-    },
-    "source": "string"
-  }
-}
-
-```
-
-LongProperty
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.LongProperty|
-|defaultValue|integer|false|none|none|
-|validator|[concerto.metamodel@0.4.0.LongDomainValidator](#schemaconcerto.metamodel@0.4.0.longdomainvalidator)|false|none|An instance of concerto.metamodel@0.4.0.LongDomainValidator|
-|name|string|true|none|none|
-|isArray|boolean|true|none|none|
-|isOptional|boolean|true|none|none|
-|decorators|[[concerto.metamodel@0.4.0.Decorator](#schemaconcerto.metamodel@0.4.0.decorator)]|false|none|[An instance of concerto.metamodel@0.4.0.Decorator]|
-|location|[concerto.metamodel@0.4.0.Range](#schemaconcerto.metamodel@0.4.0.range)|false|none|An instance of concerto.metamodel@0.4.0.Range|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.LongDomainValidator">concerto.metamodel@0.4.0.LongDomainValidator</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.longdomainvalidator"></a>
-<a id="schema_concerto.metamodel@0.4.0.LongDomainValidator"></a>
-<a id="tocSconcerto.metamodel@0.4.0.longdomainvalidator"></a>
-<a id="tocsconcerto.metamodel@0.4.0.longdomainvalidator"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.LongDomainValidator",
-  "lower": 0,
-  "upper": 0
-}
-
-```
-
-LongDomainValidator
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.LongDomainValidator|
-|lower|integer|false|none|none|
-|upper|integer|false|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.Import">concerto.metamodel@0.4.0.Import</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.import"></a>
-<a id="schema_concerto.metamodel@0.4.0.Import"></a>
-<a id="tocSconcerto.metamodel@0.4.0.import"></a>
-<a id="tocsconcerto.metamodel@0.4.0.import"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.Import",
-  "namespace": "string",
-  "uri": "string"
-}
-
-```
-
-Import
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Import|
-|namespace|string|true|none|none|
-|uri|string|false|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.ImportAll">concerto.metamodel@0.4.0.ImportAll</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.importall"></a>
-<a id="schema_concerto.metamodel@0.4.0.ImportAll"></a>
-<a id="tocSconcerto.metamodel@0.4.0.importall"></a>
-<a id="tocsconcerto.metamodel@0.4.0.importall"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.ImportAll",
-  "namespace": "string",
-  "uri": "string"
-}
-
-```
-
-ImportAll
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.ImportAll|
-|namespace|string|true|none|none|
-|uri|string|false|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.ImportType">concerto.metamodel@0.4.0.ImportType</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.importtype"></a>
-<a id="schema_concerto.metamodel@0.4.0.ImportType"></a>
-<a id="tocSconcerto.metamodel@0.4.0.importtype"></a>
-<a id="tocsconcerto.metamodel@0.4.0.importtype"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.ImportType",
-  "name": "string",
-  "namespace": "string",
-  "uri": "string"
-}
-
-```
-
-ImportType
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.ImportType|
-|name|string|true|none|none|
-|namespace|string|true|none|none|
-|uri|string|false|none|none|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.Model">concerto.metamodel@0.4.0.Model</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.model"></a>
-<a id="schema_concerto.metamodel@0.4.0.Model"></a>
-<a id="tocSconcerto.metamodel@0.4.0.model"></a>
-<a id="tocsconcerto.metamodel@0.4.0.model"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.Model",
-  "namespace": "string",
-  "sourceUri": "string",
-  "concertoVersion": "string",
-  "imports": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Import",
-      "namespace": "string",
-      "uri": "string"
-    }
-  ],
-  "declarations": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Declaration",
-      "name": "string",
-      "decorators": [
-        {
-          "$class": "concerto.metamodel@0.4.0.Decorator",
-          "name": "string",
-          "arguments": [
-            {
-              "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-              "location": {
-                "$class": "concerto.metamodel@0.4.0.Range",
-                "start": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "end": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "source": "string"
-              }
-            }
-          ],
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ],
-      "location": {
-        "$class": "concerto.metamodel@0.4.0.Range",
-        "start": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "$class": "concerto.metamodel@0.4.0.Position",
-          "line": 0,
-          "column": 0,
-          "offset": 0
-        },
-        "source": "string"
-      }
-    }
-  ]
-}
-
-```
-
-Model
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Model|
-|namespace|string|true|none|none|
-|sourceUri|string|false|none|none|
-|concertoVersion|string|false|none|none|
-|imports|[anyOf]|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Import](#schemaconcerto.metamodel@0.4.0.import)|false|none|An instance of concerto.metamodel@0.4.0.Import|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.ImportAll](#schemaconcerto.metamodel@0.4.0.importall)|false|none|An instance of concerto.metamodel@0.4.0.ImportAll|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.ImportType](#schemaconcerto.metamodel@0.4.0.importtype)|false|none|An instance of concerto.metamodel@0.4.0.ImportType|
-
-continued
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|declarations|[anyOf]|false|none|none|
-
-anyOf
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.Declaration](#schemaconcerto.metamodel@0.4.0.declaration)|false|none|An instance of concerto.metamodel@0.4.0.Declaration|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.EnumDeclaration](#schemaconcerto.metamodel@0.4.0.enumdeclaration)|false|none|An instance of concerto.metamodel@0.4.0.EnumDeclaration|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.ConceptDeclaration](#schemaconcerto.metamodel@0.4.0.conceptdeclaration)|false|none|An instance of concerto.metamodel@0.4.0.ConceptDeclaration|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.AssetDeclaration](#schemaconcerto.metamodel@0.4.0.assetdeclaration)|false|none|An instance of concerto.metamodel@0.4.0.AssetDeclaration|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.ParticipantDeclaration](#schemaconcerto.metamodel@0.4.0.participantdeclaration)|false|none|An instance of concerto.metamodel@0.4.0.ParticipantDeclaration|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.TransactionDeclaration](#schemaconcerto.metamodel@0.4.0.transactiondeclaration)|false|none|An instance of concerto.metamodel@0.4.0.TransactionDeclaration|
-
-or
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|» *anonymous*|[concerto.metamodel@0.4.0.EventDeclaration](#schemaconcerto.metamodel@0.4.0.eventdeclaration)|false|none|An instance of concerto.metamodel@0.4.0.EventDeclaration|
-
-<h2 id="tocS_concerto.metamodel@0.4.0.Models">concerto.metamodel@0.4.0.Models</h2>
-<!-- backwards compatibility -->
-<a id="schemaconcerto.metamodel@0.4.0.models"></a>
-<a id="schema_concerto.metamodel@0.4.0.Models"></a>
-<a id="tocSconcerto.metamodel@0.4.0.models"></a>
-<a id="tocsconcerto.metamodel@0.4.0.models"></a>
-
-```json
-{
-  "$class": "concerto.metamodel@0.4.0.Models",
-  "models": [
-    {
-      "$class": "concerto.metamodel@0.4.0.Model",
-      "namespace": "string",
-      "sourceUri": "string",
-      "concertoVersion": "string",
-      "imports": [
-        {
-          "$class": "concerto.metamodel@0.4.0.Import",
-          "namespace": "string",
-          "uri": "string"
-        }
-      ],
-      "declarations": [
-        {
-          "$class": "concerto.metamodel@0.4.0.Declaration",
-          "name": "string",
-          "decorators": [
-            {
-              "$class": "concerto.metamodel@0.4.0.Decorator",
-              "name": "string",
-              "arguments": [
-                {
-                  "$class": "concerto.metamodel@0.4.0.DecoratorLiteral",
-                  "location": {
-                    "$class": "concerto.metamodel@0.4.0.Range",
-                    "start": {},
-                    "end": {},
-                    "source": "string"
-                  }
-                }
-              ],
-              "location": {
-                "$class": "concerto.metamodel@0.4.0.Range",
-                "start": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "end": {
-                  "$class": "concerto.metamodel@0.4.0.Position",
-                  "line": 0,
-                  "column": 0,
-                  "offset": 0
-                },
-                "source": "string"
-              }
-            }
-          ],
-          "location": {
-            "$class": "concerto.metamodel@0.4.0.Range",
-            "start": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "end": {
-              "$class": "concerto.metamodel@0.4.0.Position",
-              "line": 0,
-              "column": 0,
-              "offset": 0
-            },
-            "source": "string"
-          }
-        }
-      ]
-    }
-  ]
-}
-
-```
-
-Models
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|$class|string|true|none|The class identifier for concerto.metamodel@0.4.0.Models|
-|models|[[concerto.metamodel@0.4.0.Model](#schemaconcerto.metamodel@0.4.0.model)]|true|none|[An instance of concerto.metamodel@0.4.0.Model]|
 

--- a/model/protocol.cto
+++ b/model/protocol.cto
@@ -218,7 +218,63 @@ concept TriggerRequest {
 @description("Response of triggering a function")
 concept TriggerResponse {
     o JSON result optional
+    o BaseObligation[] obligations optional
     o Boolean isError
     o String errorMessage optional
     o String errorDetails optional
+}
+
+// ============================================================
+// OBLIGATIONS
+// ============================================================
+
+@description("Status of an obligation")
+enum ObligationStatus {
+    o ACTIVE
+    o FULFILLED
+    o VIOLATED
+    o PARTIALLY_FULFILLED
+    o DISPUTED
+    o UNDER_REVIEW
+    o RESOLVED_WITH_ADJUSTMENT
+    o CANCELLED
+    o SUPERSEDED
+    o ERROR
+    o OTHER
+}
+
+@description("Abstract base for all legal obligations")
+abstract concept BaseObligation {
+    o ObligationStatus status
+    o String description optional
+}
+
+@description("Obligation to transfer ownership of an asset")
+concept OwnershipTransferObligation extends BaseObligation {
+    o String assetIdentifier
+    o String currentOwner
+    o String newOwner
+}
+
+@description("Obligation to make a financial payment")
+concept PaymentObligation extends BaseObligation {
+    o String debtor        // The party paying
+    o String creditor      // The party receiving
+    o Double amount
+    o String currency      // e.g. "USD", "EUR"
+}
+
+@description("Obligation to release funds/tokens from escrow")
+concept EscrowReleaseObligation extends BaseObligation {
+    o String escrowAgent
+    o String beneficiary
+    o String tokenIdentifier
+    o Double amount
+}
+
+@description("Obligation to grant access control permissions")
+concept AccessControlObligation extends BaseObligation {
+    o String grantee             // Who gets access?
+    o String resourceIdentifier  // What resource?
+    o String permission          // e.g. "READ", "WRITE"
 }

--- a/openapi.json
+++ b/openapi.json
@@ -880,6 +880,28 @@
           "result": {
             "type": "string"
           },
+          "obligations": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.BaseObligation"
+                },
+                {
+                  "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.OwnershipTransferObligation"
+                },
+                {
+                  "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.PaymentObligation"
+                },
+                {
+                  "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.EscrowReleaseObligation"
+                },
+                {
+                  "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.AccessControlObligation"
+                }
+              ]
+            }
+          },
           "isError": {
             "type": "boolean"
           },
@@ -899,6 +921,1686 @@
             "Response of triggering a function"
           ]
         }
+      },
+      "org.accordproject.protocol@1.0.0.ObligationStatus": {
+        "title": "ObligationStatus",
+        "description": "An instance of org.accordproject.protocol@1.0.0.ObligationStatus",
+        "enum": [
+          "ACTIVE",
+          "FULFILLED",
+          "VIOLATED",
+          "PARTIALLY_FULFILLED",
+          "DISPUTED",
+          "UNDER_REVIEW",
+          "RESOLVED_WITH_ADJUSTMENT",
+          "CANCELLED",
+          "SUPERSEDED",
+          "ERROR",
+          "OTHER"
+        ],
+        "$decorators": {
+          "description": [
+            "Status of an obligation"
+          ]
+        }
+      },
+      "org.accordproject.protocol@1.0.0.BaseObligation": {
+        "title": "BaseObligation",
+        "description": "An instance of org.accordproject.protocol@1.0.0.BaseObligation",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.accordproject.protocol@1.0.0.BaseObligation",
+            "pattern": "^org\\.accordproject\\.protocol@1\\.0\\.0\\.BaseObligation$",
+            "description": "The class identifier for org.accordproject.protocol@1.0.0.BaseObligation"
+          },
+          "status": {
+            "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.ObligationStatus"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "status"
+        ],
+        "$decorators": {
+          "description": [
+            "Abstract base for all legal obligations"
+          ]
+        }
+      },
+      "org.accordproject.protocol@1.0.0.OwnershipTransferObligation": {
+        "title": "OwnershipTransferObligation",
+        "description": "An instance of org.accordproject.protocol@1.0.0.OwnershipTransferObligation",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.accordproject.protocol@1.0.0.OwnershipTransferObligation",
+            "pattern": "^org\\.accordproject\\.protocol@1\\.0\\.0\\.OwnershipTransferObligation$",
+            "description": "The class identifier for org.accordproject.protocol@1.0.0.OwnershipTransferObligation"
+          },
+          "assetIdentifier": {
+            "type": "string"
+          },
+          "currentOwner": {
+            "type": "string"
+          },
+          "newOwner": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.ObligationStatus"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "assetIdentifier",
+          "currentOwner",
+          "newOwner",
+          "status"
+        ],
+        "$decorators": {
+          "description": [
+            "Obligation to transfer ownership of an asset"
+          ]
+        }
+      },
+      "org.accordproject.protocol@1.0.0.PaymentObligation": {
+        "title": "PaymentObligation",
+        "description": "An instance of org.accordproject.protocol@1.0.0.PaymentObligation",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.accordproject.protocol@1.0.0.PaymentObligation",
+            "pattern": "^org\\.accordproject\\.protocol@1\\.0\\.0\\.PaymentObligation$",
+            "description": "The class identifier for org.accordproject.protocol@1.0.0.PaymentObligation"
+          },
+          "debtor": {
+            "type": "string"
+          },
+          "creditor": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.ObligationStatus"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "debtor",
+          "creditor",
+          "amount",
+          "currency",
+          "status"
+        ],
+        "$decorators": {
+          "description": [
+            "Obligation to make a financial payment"
+          ]
+        }
+      },
+      "org.accordproject.protocol@1.0.0.EscrowReleaseObligation": {
+        "title": "EscrowReleaseObligation",
+        "description": "An instance of org.accordproject.protocol@1.0.0.EscrowReleaseObligation",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.accordproject.protocol@1.0.0.EscrowReleaseObligation",
+            "pattern": "^org\\.accordproject\\.protocol@1\\.0\\.0\\.EscrowReleaseObligation$",
+            "description": "The class identifier for org.accordproject.protocol@1.0.0.EscrowReleaseObligation"
+          },
+          "escrowAgent": {
+            "type": "string"
+          },
+          "beneficiary": {
+            "type": "string"
+          },
+          "tokenIdentifier": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "status": {
+            "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.ObligationStatus"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "escrowAgent",
+          "beneficiary",
+          "tokenIdentifier",
+          "amount",
+          "status"
+        ],
+        "$decorators": {
+          "description": [
+            "Obligation to release funds/tokens from escrow"
+          ]
+        }
+      },
+      "org.accordproject.protocol@1.0.0.AccessControlObligation": {
+        "title": "AccessControlObligation",
+        "description": "An instance of org.accordproject.protocol@1.0.0.AccessControlObligation",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.accordproject.protocol@1.0.0.AccessControlObligation",
+            "pattern": "^org\\.accordproject\\.protocol@1\\.0\\.0\\.AccessControlObligation$",
+            "description": "The class identifier for org.accordproject.protocol@1.0.0.AccessControlObligation"
+          },
+          "grantee": {
+            "type": "string"
+          },
+          "resourceIdentifier": {
+            "type": "string"
+          },
+          "permission": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/org.accordproject.protocol@1.0.0.ObligationStatus"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "grantee",
+          "resourceIdentifier",
+          "permission",
+          "status"
+        ],
+        "$decorators": {
+          "description": [
+            "Obligation to grant access control permissions"
+          ]
+        }
+      },
+      "org.accordproject.party@0.2.0.Party": {
+        "title": "Party",
+        "description": "An instance of org.accordproject.party@0.2.0.Party",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.accordproject.party@0.2.0.Party",
+            "pattern": "^org\\.accordproject\\.party@0\\.2\\.0\\.Party$",
+            "description": "The class identifier for org.accordproject.party@0.2.0.Party"
+          },
+          "partyId": {
+            "type": "string",
+            "description": "The instance identifier for this type"
+          }
+        },
+        "required": [
+          "$class",
+          "partyId"
+        ]
+      },
+      "concerto.metamodel@0.4.0.Position": {
+        "title": "Position",
+        "description": "An instance of concerto.metamodel@0.4.0.Position",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.Position",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Position$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.Position"
+          },
+          "line": {
+            "type": "integer"
+          },
+          "column": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "$class",
+          "line",
+          "column",
+          "offset"
+        ]
+      },
+      "concerto.metamodel@0.4.0.Range": {
+        "title": "Range",
+        "description": "An instance of concerto.metamodel@0.4.0.Range",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.Range",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Range$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.Range"
+          },
+          "start": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Position"
+          },
+          "end": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Position"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "start",
+          "end"
+        ]
+      },
+      "concerto.metamodel@0.4.0.TypeIdentifier": {
+        "title": "TypeIdentifier",
+        "description": "An instance of concerto.metamodel@0.4.0.TypeIdentifier",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.TypeIdentifier",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.TypeIdentifier$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.TypeIdentifier"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.DecoratorLiteral": {
+        "title": "DecoratorLiteral",
+        "description": "An instance of concerto.metamodel@0.4.0.DecoratorLiteral",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.DecoratorLiteral",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DecoratorLiteral$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.DecoratorLiteral"
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
+      "concerto.metamodel@0.4.0.DecoratorString": {
+        "title": "DecoratorString",
+        "description": "An instance of concerto.metamodel@0.4.0.DecoratorString",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.DecoratorString",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DecoratorString$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.DecoratorString"
+          },
+          "value": {
+            "type": "string"
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "value"
+        ]
+      },
+      "concerto.metamodel@0.4.0.DecoratorNumber": {
+        "title": "DecoratorNumber",
+        "description": "An instance of concerto.metamodel@0.4.0.DecoratorNumber",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.DecoratorNumber",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DecoratorNumber$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.DecoratorNumber"
+          },
+          "value": {
+            "type": "number"
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "value"
+        ]
+      },
+      "concerto.metamodel@0.4.0.DecoratorBoolean": {
+        "title": "DecoratorBoolean",
+        "description": "An instance of concerto.metamodel@0.4.0.DecoratorBoolean",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.DecoratorBoolean",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DecoratorBoolean$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.DecoratorBoolean"
+          },
+          "value": {
+            "type": "boolean"
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "value"
+        ]
+      },
+      "concerto.metamodel@0.4.0.DecoratorTypeReference": {
+        "title": "DecoratorTypeReference",
+        "description": "An instance of concerto.metamodel@0.4.0.DecoratorTypeReference",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.DecoratorTypeReference",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DecoratorTypeReference$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.DecoratorTypeReference"
+          },
+          "type": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
+          },
+          "isArray": {
+            "default": false,
+            "type": "boolean"
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "type",
+          "isArray"
+        ]
+      },
+      "concerto.metamodel@0.4.0.Decorator": {
+        "title": "Decorator",
+        "description": "An instance of concerto.metamodel@0.4.0.Decorator",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.Decorator",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Decorator$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.Decorator"
+          },
+          "name": {
+            "type": "string"
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DecoratorLiteral"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DecoratorString"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DecoratorNumber"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DecoratorBoolean"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DecoratorTypeReference"
+                }
+              ]
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.Identified": {
+        "title": "Identified",
+        "description": "An instance of concerto.metamodel@0.4.0.Identified",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.Identified",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Identified$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.Identified"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
+      "concerto.metamodel@0.4.0.IdentifiedBy": {
+        "title": "IdentifiedBy",
+        "description": "An instance of concerto.metamodel@0.4.0.IdentifiedBy",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.IdentifiedBy",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.IdentifiedBy$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.IdentifiedBy"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.Declaration": {
+        "title": "Declaration",
+        "description": "An instance of concerto.metamodel@0.4.0.Declaration",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.Declaration",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Declaration$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.Declaration"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.EnumDeclaration": {
+        "title": "EnumDeclaration",
+        "description": "An instance of concerto.metamodel@0.4.0.EnumDeclaration",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.EnumDeclaration",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.EnumDeclaration$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.EnumDeclaration"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.EnumProperty"
+            }
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "properties",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.EnumProperty": {
+        "title": "EnumProperty",
+        "description": "An instance of concerto.metamodel@0.4.0.EnumProperty",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.EnumProperty",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.EnumProperty$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.EnumProperty"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.ConceptDeclaration": {
+        "title": "ConceptDeclaration",
+        "description": "An instance of concerto.metamodel@0.4.0.ConceptDeclaration",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.ConceptDeclaration",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.ConceptDeclaration$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.ConceptDeclaration"
+          },
+          "isAbstract": {
+            "default": false,
+            "type": "boolean"
+          },
+          "identified": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Identified"
+              },
+              {
+                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IdentifiedBy"
+              }
+            ]
+          },
+          "superType": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Property"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.RelationshipProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ObjectProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.BooleanProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DateTimeProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongProperty"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "isAbstract",
+          "properties",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.AssetDeclaration": {
+        "title": "AssetDeclaration",
+        "description": "An instance of concerto.metamodel@0.4.0.AssetDeclaration",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.AssetDeclaration",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.AssetDeclaration$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.AssetDeclaration"
+          },
+          "isAbstract": {
+            "default": false,
+            "type": "boolean"
+          },
+          "identified": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Identified"
+              },
+              {
+                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IdentifiedBy"
+              }
+            ]
+          },
+          "superType": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Property"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.RelationshipProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ObjectProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.BooleanProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DateTimeProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongProperty"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "isAbstract",
+          "properties",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.ParticipantDeclaration": {
+        "title": "ParticipantDeclaration",
+        "description": "An instance of concerto.metamodel@0.4.0.ParticipantDeclaration",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.ParticipantDeclaration",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.ParticipantDeclaration$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.ParticipantDeclaration"
+          },
+          "isAbstract": {
+            "default": false,
+            "type": "boolean"
+          },
+          "identified": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Identified"
+              },
+              {
+                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IdentifiedBy"
+              }
+            ]
+          },
+          "superType": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Property"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.RelationshipProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ObjectProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.BooleanProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DateTimeProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongProperty"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "isAbstract",
+          "properties",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.TransactionDeclaration": {
+        "title": "TransactionDeclaration",
+        "description": "An instance of concerto.metamodel@0.4.0.TransactionDeclaration",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.TransactionDeclaration",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.TransactionDeclaration$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.TransactionDeclaration"
+          },
+          "isAbstract": {
+            "default": false,
+            "type": "boolean"
+          },
+          "identified": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Identified"
+              },
+              {
+                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IdentifiedBy"
+              }
+            ]
+          },
+          "superType": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Property"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.RelationshipProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ObjectProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.BooleanProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DateTimeProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongProperty"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "isAbstract",
+          "properties",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.EventDeclaration": {
+        "title": "EventDeclaration",
+        "description": "An instance of concerto.metamodel@0.4.0.EventDeclaration",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.EventDeclaration",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.EventDeclaration$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.EventDeclaration"
+          },
+          "isAbstract": {
+            "default": false,
+            "type": "boolean"
+          },
+          "identified": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Identified"
+              },
+              {
+                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IdentifiedBy"
+              }
+            ]
+          },
+          "superType": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Property"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.RelationshipProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ObjectProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.BooleanProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DateTimeProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongProperty"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "isAbstract",
+          "properties",
+          "name"
+        ]
+      },
+      "concerto.metamodel@0.4.0.Property": {
+        "title": "Property",
+        "description": "An instance of concerto.metamodel@0.4.0.Property",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.Property",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Property$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.Property"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "isArray": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isOptional": {
+            "default": false,
+            "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "name",
+          "isArray",
+          "isOptional"
+        ]
+      },
+      "concerto.metamodel@0.4.0.RelationshipProperty": {
+        "title": "RelationshipProperty",
+        "description": "An instance of concerto.metamodel@0.4.0.RelationshipProperty",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.RelationshipProperty",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.RelationshipProperty$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.RelationshipProperty"
+          },
+          "type": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "isArray": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isOptional": {
+            "default": false,
+            "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "type",
+          "name",
+          "isArray",
+          "isOptional"
+        ]
+      },
+      "concerto.metamodel@0.4.0.ObjectProperty": {
+        "title": "ObjectProperty",
+        "description": "An instance of concerto.metamodel@0.4.0.ObjectProperty",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.ObjectProperty",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.ObjectProperty$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.ObjectProperty"
+          },
+          "defaultValue": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "isArray": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isOptional": {
+            "default": false,
+            "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "type",
+          "name",
+          "isArray",
+          "isOptional"
+        ]
+      },
+      "concerto.metamodel@0.4.0.BooleanProperty": {
+        "title": "BooleanProperty",
+        "description": "An instance of concerto.metamodel@0.4.0.BooleanProperty",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.BooleanProperty",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.BooleanProperty$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.BooleanProperty"
+          },
+          "defaultValue": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "isArray": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isOptional": {
+            "default": false,
+            "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "name",
+          "isArray",
+          "isOptional"
+        ]
+      },
+      "concerto.metamodel@0.4.0.DateTimeProperty": {
+        "title": "DateTimeProperty",
+        "description": "An instance of concerto.metamodel@0.4.0.DateTimeProperty",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.DateTimeProperty",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DateTimeProperty$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.DateTimeProperty"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "isArray": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isOptional": {
+            "default": false,
+            "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "name",
+          "isArray",
+          "isOptional"
+        ]
+      },
+      "concerto.metamodel@0.4.0.StringProperty": {
+        "title": "StringProperty",
+        "description": "An instance of concerto.metamodel@0.4.0.StringProperty",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.StringProperty",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.StringProperty$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.StringProperty"
+          },
+          "defaultValue": {
+            "type": "string"
+          },
+          "validator": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringRegexValidator"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "isArray": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isOptional": {
+            "default": false,
+            "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "name",
+          "isArray",
+          "isOptional"
+        ]
+      },
+      "concerto.metamodel@0.4.0.StringRegexValidator": {
+        "title": "StringRegexValidator",
+        "description": "An instance of concerto.metamodel@0.4.0.StringRegexValidator",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.StringRegexValidator",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.StringRegexValidator$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.StringRegexValidator"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "flags": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "pattern",
+          "flags"
+        ]
+      },
+      "concerto.metamodel@0.4.0.DoubleProperty": {
+        "title": "DoubleProperty",
+        "description": "An instance of concerto.metamodel@0.4.0.DoubleProperty",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.DoubleProperty",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DoubleProperty$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.DoubleProperty"
+          },
+          "defaultValue": {
+            "type": "number"
+          },
+          "validator": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleDomainValidator"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "isArray": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isOptional": {
+            "default": false,
+            "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "name",
+          "isArray",
+          "isOptional"
+        ]
+      },
+      "concerto.metamodel@0.4.0.DoubleDomainValidator": {
+        "title": "DoubleDomainValidator",
+        "description": "An instance of concerto.metamodel@0.4.0.DoubleDomainValidator",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.DoubleDomainValidator",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DoubleDomainValidator$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.DoubleDomainValidator"
+          },
+          "lower": {
+            "type": "number"
+          },
+          "upper": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
+      "concerto.metamodel@0.4.0.IntegerProperty": {
+        "title": "IntegerProperty",
+        "description": "An instance of concerto.metamodel@0.4.0.IntegerProperty",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.IntegerProperty",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.IntegerProperty$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.IntegerProperty"
+          },
+          "defaultValue": {
+            "type": "integer"
+          },
+          "validator": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerDomainValidator"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "isArray": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isOptional": {
+            "default": false,
+            "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "name",
+          "isArray",
+          "isOptional"
+        ]
+      },
+      "concerto.metamodel@0.4.0.IntegerDomainValidator": {
+        "title": "IntegerDomainValidator",
+        "description": "An instance of concerto.metamodel@0.4.0.IntegerDomainValidator",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.IntegerDomainValidator",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.IntegerDomainValidator$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.IntegerDomainValidator"
+          },
+          "lower": {
+            "type": "integer"
+          },
+          "upper": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
+      "concerto.metamodel@0.4.0.LongProperty": {
+        "title": "LongProperty",
+        "description": "An instance of concerto.metamodel@0.4.0.LongProperty",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.LongProperty",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.LongProperty$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.LongProperty"
+          },
+          "defaultValue": {
+            "type": "integer"
+          },
+          "validator": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongDomainValidator"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
+          },
+          "isArray": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isOptional": {
+            "default": false,
+            "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
+          }
+        },
+        "required": [
+          "$class",
+          "name",
+          "isArray",
+          "isOptional"
+        ]
+      },
+      "concerto.metamodel@0.4.0.LongDomainValidator": {
+        "title": "LongDomainValidator",
+        "description": "An instance of concerto.metamodel@0.4.0.LongDomainValidator",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.LongDomainValidator",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.LongDomainValidator$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.LongDomainValidator"
+          },
+          "lower": {
+            "type": "integer"
+          },
+          "upper": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
+      "concerto.metamodel@0.4.0.Import": {
+        "title": "Import",
+        "description": "An instance of concerto.metamodel@0.4.0.Import",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.Import",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Import$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.Import"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "namespace"
+        ]
+      },
+      "concerto.metamodel@0.4.0.ImportAll": {
+        "title": "ImportAll",
+        "description": "An instance of concerto.metamodel@0.4.0.ImportAll",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.ImportAll",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.ImportAll$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.ImportAll"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "namespace"
+        ]
+      },
+      "concerto.metamodel@0.4.0.ImportType": {
+        "title": "ImportType",
+        "description": "An instance of concerto.metamodel@0.4.0.ImportType",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.ImportType",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.ImportType$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.ImportType"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "name",
+          "namespace"
+        ]
+      },
+      "concerto.metamodel@0.4.0.Model": {
+        "title": "Model",
+        "description": "An instance of concerto.metamodel@0.4.0.Model",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.Model",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Model$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.Model"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "sourceUri": {
+            "type": "string"
+          },
+          "concertoVersion": {
+            "type": "string"
+          },
+          "imports": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Import"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ImportAll"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ImportType"
+                }
+              ]
+            }
+          },
+          "declarations": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Declaration"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.EnumDeclaration"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ConceptDeclaration"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.AssetDeclaration"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ParticipantDeclaration"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TransactionDeclaration"
+                },
+                {
+                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.EventDeclaration"
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "$class",
+          "namespace"
+        ]
+      },
+      "concerto.metamodel@0.4.0.Models": {
+        "title": "Models",
+        "description": "An instance of concerto.metamodel@0.4.0.Models",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "concerto.metamodel@0.4.0.Models",
+            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Models$",
+            "description": "The class identifier for concerto.metamodel@0.4.0.Models"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Model"
+            }
+          }
+        },
+        "required": [
+          "$class",
+          "models"
+        ]
       },
       "org.accordproject.commonmark@0.5.0.Node": {
         "title": "Node",
@@ -4065,1468 +5767,6 @@
         },
         "required": [
           "$class"
-        ]
-      },
-      "org.accordproject.party@0.2.0.Party": {
-        "title": "Party",
-        "description": "An instance of org.accordproject.party@0.2.0.Party",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "org.accordproject.party@0.2.0.Party",
-            "pattern": "^org\\.accordproject\\.party@0\\.2\\.0\\.Party$",
-            "description": "The class identifier for org.accordproject.party@0.2.0.Party"
-          },
-          "partyId": {
-            "type": "string",
-            "description": "The instance identifier for this type"
-          }
-        },
-        "required": [
-          "$class",
-          "partyId"
-        ]
-      },
-      "concerto.metamodel@0.4.0.Position": {
-        "title": "Position",
-        "description": "An instance of concerto.metamodel@0.4.0.Position",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.Position",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Position$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.Position"
-          },
-          "line": {
-            "type": "integer"
-          },
-          "column": {
-            "type": "integer"
-          },
-          "offset": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "$class",
-          "line",
-          "column",
-          "offset"
-        ]
-      },
-      "concerto.metamodel@0.4.0.Range": {
-        "title": "Range",
-        "description": "An instance of concerto.metamodel@0.4.0.Range",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.Range",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Range$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.Range"
-          },
-          "start": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Position"
-          },
-          "end": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Position"
-          },
-          "source": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "$class",
-          "start",
-          "end"
-        ]
-      },
-      "concerto.metamodel@0.4.0.TypeIdentifier": {
-        "title": "TypeIdentifier",
-        "description": "An instance of concerto.metamodel@0.4.0.TypeIdentifier",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.TypeIdentifier",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.TypeIdentifier$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.TypeIdentifier"
-          },
-          "name": {
-            "type": "string"
-          },
-          "namespace": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "$class",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.DecoratorLiteral": {
-        "title": "DecoratorLiteral",
-        "description": "An instance of concerto.metamodel@0.4.0.DecoratorLiteral",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.DecoratorLiteral",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DecoratorLiteral$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.DecoratorLiteral"
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class"
-        ]
-      },
-      "concerto.metamodel@0.4.0.DecoratorString": {
-        "title": "DecoratorString",
-        "description": "An instance of concerto.metamodel@0.4.0.DecoratorString",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.DecoratorString",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DecoratorString$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.DecoratorString"
-          },
-          "value": {
-            "type": "string"
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "value"
-        ]
-      },
-      "concerto.metamodel@0.4.0.DecoratorNumber": {
-        "title": "DecoratorNumber",
-        "description": "An instance of concerto.metamodel@0.4.0.DecoratorNumber",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.DecoratorNumber",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DecoratorNumber$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.DecoratorNumber"
-          },
-          "value": {
-            "type": "number"
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "value"
-        ]
-      },
-      "concerto.metamodel@0.4.0.DecoratorBoolean": {
-        "title": "DecoratorBoolean",
-        "description": "An instance of concerto.metamodel@0.4.0.DecoratorBoolean",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.DecoratorBoolean",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DecoratorBoolean$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.DecoratorBoolean"
-          },
-          "value": {
-            "type": "boolean"
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "value"
-        ]
-      },
-      "concerto.metamodel@0.4.0.DecoratorTypeReference": {
-        "title": "DecoratorTypeReference",
-        "description": "An instance of concerto.metamodel@0.4.0.DecoratorTypeReference",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.DecoratorTypeReference",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DecoratorTypeReference$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.DecoratorTypeReference"
-          },
-          "type": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
-          },
-          "isArray": {
-            "default": false,
-            "type": "boolean"
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "type",
-          "isArray"
-        ]
-      },
-      "concerto.metamodel@0.4.0.Decorator": {
-        "title": "Decorator",
-        "description": "An instance of concerto.metamodel@0.4.0.Decorator",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.Decorator",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Decorator$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.Decorator"
-          },
-          "name": {
-            "type": "string"
-          },
-          "arguments": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DecoratorLiteral"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DecoratorString"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DecoratorNumber"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DecoratorBoolean"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DecoratorTypeReference"
-                }
-              ]
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.Identified": {
-        "title": "Identified",
-        "description": "An instance of concerto.metamodel@0.4.0.Identified",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.Identified",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Identified$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.Identified"
-          }
-        },
-        "required": [
-          "$class"
-        ]
-      },
-      "concerto.metamodel@0.4.0.IdentifiedBy": {
-        "title": "IdentifiedBy",
-        "description": "An instance of concerto.metamodel@0.4.0.IdentifiedBy",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.IdentifiedBy",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.IdentifiedBy$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.IdentifiedBy"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "$class",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.Declaration": {
-        "title": "Declaration",
-        "description": "An instance of concerto.metamodel@0.4.0.Declaration",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.Declaration",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Declaration$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.Declaration"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.EnumDeclaration": {
-        "title": "EnumDeclaration",
-        "description": "An instance of concerto.metamodel@0.4.0.EnumDeclaration",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.EnumDeclaration",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.EnumDeclaration$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.EnumDeclaration"
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.EnumProperty"
-            }
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "properties",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.EnumProperty": {
-        "title": "EnumProperty",
-        "description": "An instance of concerto.metamodel@0.4.0.EnumProperty",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.EnumProperty",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.EnumProperty$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.EnumProperty"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.ConceptDeclaration": {
-        "title": "ConceptDeclaration",
-        "description": "An instance of concerto.metamodel@0.4.0.ConceptDeclaration",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.ConceptDeclaration",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.ConceptDeclaration$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.ConceptDeclaration"
-          },
-          "isAbstract": {
-            "default": false,
-            "type": "boolean"
-          },
-          "identified": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Identified"
-              },
-              {
-                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IdentifiedBy"
-              }
-            ]
-          },
-          "superType": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Property"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.RelationshipProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ObjectProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.BooleanProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DateTimeProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongProperty"
-                }
-              ]
-            }
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "isAbstract",
-          "properties",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.AssetDeclaration": {
-        "title": "AssetDeclaration",
-        "description": "An instance of concerto.metamodel@0.4.0.AssetDeclaration",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.AssetDeclaration",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.AssetDeclaration$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.AssetDeclaration"
-          },
-          "isAbstract": {
-            "default": false,
-            "type": "boolean"
-          },
-          "identified": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Identified"
-              },
-              {
-                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IdentifiedBy"
-              }
-            ]
-          },
-          "superType": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Property"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.RelationshipProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ObjectProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.BooleanProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DateTimeProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongProperty"
-                }
-              ]
-            }
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "isAbstract",
-          "properties",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.ParticipantDeclaration": {
-        "title": "ParticipantDeclaration",
-        "description": "An instance of concerto.metamodel@0.4.0.ParticipantDeclaration",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.ParticipantDeclaration",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.ParticipantDeclaration$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.ParticipantDeclaration"
-          },
-          "isAbstract": {
-            "default": false,
-            "type": "boolean"
-          },
-          "identified": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Identified"
-              },
-              {
-                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IdentifiedBy"
-              }
-            ]
-          },
-          "superType": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Property"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.RelationshipProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ObjectProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.BooleanProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DateTimeProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongProperty"
-                }
-              ]
-            }
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "isAbstract",
-          "properties",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.TransactionDeclaration": {
-        "title": "TransactionDeclaration",
-        "description": "An instance of concerto.metamodel@0.4.0.TransactionDeclaration",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.TransactionDeclaration",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.TransactionDeclaration$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.TransactionDeclaration"
-          },
-          "isAbstract": {
-            "default": false,
-            "type": "boolean"
-          },
-          "identified": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Identified"
-              },
-              {
-                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IdentifiedBy"
-              }
-            ]
-          },
-          "superType": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Property"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.RelationshipProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ObjectProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.BooleanProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DateTimeProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongProperty"
-                }
-              ]
-            }
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "isAbstract",
-          "properties",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.EventDeclaration": {
-        "title": "EventDeclaration",
-        "description": "An instance of concerto.metamodel@0.4.0.EventDeclaration",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.EventDeclaration",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.EventDeclaration$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.EventDeclaration"
-          },
-          "isAbstract": {
-            "default": false,
-            "type": "boolean"
-          },
-          "identified": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Identified"
-              },
-              {
-                "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IdentifiedBy"
-              }
-            ]
-          },
-          "superType": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
-          },
-          "properties": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Property"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.RelationshipProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ObjectProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.BooleanProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DateTimeProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongProperty"
-                }
-              ]
-            }
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "isAbstract",
-          "properties",
-          "name"
-        ]
-      },
-      "concerto.metamodel@0.4.0.Property": {
-        "title": "Property",
-        "description": "An instance of concerto.metamodel@0.4.0.Property",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.Property",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Property$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.Property"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "isArray": {
-            "default": false,
-            "type": "boolean"
-          },
-          "isOptional": {
-            "default": false,
-            "type": "boolean"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
-      },
-      "concerto.metamodel@0.4.0.RelationshipProperty": {
-        "title": "RelationshipProperty",
-        "description": "An instance of concerto.metamodel@0.4.0.RelationshipProperty",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.RelationshipProperty",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.RelationshipProperty$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.RelationshipProperty"
-          },
-          "type": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "isArray": {
-            "default": false,
-            "type": "boolean"
-          },
-          "isOptional": {
-            "default": false,
-            "type": "boolean"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "type",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
-      },
-      "concerto.metamodel@0.4.0.ObjectProperty": {
-        "title": "ObjectProperty",
-        "description": "An instance of concerto.metamodel@0.4.0.ObjectProperty",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.ObjectProperty",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.ObjectProperty$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.ObjectProperty"
-          },
-          "defaultValue": {
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TypeIdentifier"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "isArray": {
-            "default": false,
-            "type": "boolean"
-          },
-          "isOptional": {
-            "default": false,
-            "type": "boolean"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "type",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
-      },
-      "concerto.metamodel@0.4.0.BooleanProperty": {
-        "title": "BooleanProperty",
-        "description": "An instance of concerto.metamodel@0.4.0.BooleanProperty",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.BooleanProperty",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.BooleanProperty$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.BooleanProperty"
-          },
-          "defaultValue": {
-            "type": "boolean"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "isArray": {
-            "default": false,
-            "type": "boolean"
-          },
-          "isOptional": {
-            "default": false,
-            "type": "boolean"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
-      },
-      "concerto.metamodel@0.4.0.DateTimeProperty": {
-        "title": "DateTimeProperty",
-        "description": "An instance of concerto.metamodel@0.4.0.DateTimeProperty",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.DateTimeProperty",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DateTimeProperty$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.DateTimeProperty"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "isArray": {
-            "default": false,
-            "type": "boolean"
-          },
-          "isOptional": {
-            "default": false,
-            "type": "boolean"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
-      },
-      "concerto.metamodel@0.4.0.StringProperty": {
-        "title": "StringProperty",
-        "description": "An instance of concerto.metamodel@0.4.0.StringProperty",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.StringProperty",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.StringProperty$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.StringProperty"
-          },
-          "defaultValue": {
-            "type": "string"
-          },
-          "validator": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.StringRegexValidator"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "isArray": {
-            "default": false,
-            "type": "boolean"
-          },
-          "isOptional": {
-            "default": false,
-            "type": "boolean"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
-      },
-      "concerto.metamodel@0.4.0.StringRegexValidator": {
-        "title": "StringRegexValidator",
-        "description": "An instance of concerto.metamodel@0.4.0.StringRegexValidator",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.StringRegexValidator",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.StringRegexValidator$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.StringRegexValidator"
-          },
-          "pattern": {
-            "type": "string"
-          },
-          "flags": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "$class",
-          "pattern",
-          "flags"
-        ]
-      },
-      "concerto.metamodel@0.4.0.DoubleProperty": {
-        "title": "DoubleProperty",
-        "description": "An instance of concerto.metamodel@0.4.0.DoubleProperty",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.DoubleProperty",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DoubleProperty$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.DoubleProperty"
-          },
-          "defaultValue": {
-            "type": "number"
-          },
-          "validator": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.DoubleDomainValidator"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "isArray": {
-            "default": false,
-            "type": "boolean"
-          },
-          "isOptional": {
-            "default": false,
-            "type": "boolean"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
-      },
-      "concerto.metamodel@0.4.0.DoubleDomainValidator": {
-        "title": "DoubleDomainValidator",
-        "description": "An instance of concerto.metamodel@0.4.0.DoubleDomainValidator",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.DoubleDomainValidator",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.DoubleDomainValidator$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.DoubleDomainValidator"
-          },
-          "lower": {
-            "type": "number"
-          },
-          "upper": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "$class"
-        ]
-      },
-      "concerto.metamodel@0.4.0.IntegerProperty": {
-        "title": "IntegerProperty",
-        "description": "An instance of concerto.metamodel@0.4.0.IntegerProperty",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.IntegerProperty",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.IntegerProperty$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.IntegerProperty"
-          },
-          "defaultValue": {
-            "type": "integer"
-          },
-          "validator": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.IntegerDomainValidator"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "isArray": {
-            "default": false,
-            "type": "boolean"
-          },
-          "isOptional": {
-            "default": false,
-            "type": "boolean"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
-      },
-      "concerto.metamodel@0.4.0.IntegerDomainValidator": {
-        "title": "IntegerDomainValidator",
-        "description": "An instance of concerto.metamodel@0.4.0.IntegerDomainValidator",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.IntegerDomainValidator",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.IntegerDomainValidator$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.IntegerDomainValidator"
-          },
-          "lower": {
-            "type": "integer"
-          },
-          "upper": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "$class"
-        ]
-      },
-      "concerto.metamodel@0.4.0.LongProperty": {
-        "title": "LongProperty",
-        "description": "An instance of concerto.metamodel@0.4.0.LongProperty",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.LongProperty",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.LongProperty$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.LongProperty"
-          },
-          "defaultValue": {
-            "type": "integer"
-          },
-          "validator": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.LongDomainValidator"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$"
-          },
-          "isArray": {
-            "default": false,
-            "type": "boolean"
-          },
-          "isOptional": {
-            "default": false,
-            "type": "boolean"
-          },
-          "decorators": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Decorator"
-            }
-          },
-          "location": {
-            "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Range"
-          }
-        },
-        "required": [
-          "$class",
-          "name",
-          "isArray",
-          "isOptional"
-        ]
-      },
-      "concerto.metamodel@0.4.0.LongDomainValidator": {
-        "title": "LongDomainValidator",
-        "description": "An instance of concerto.metamodel@0.4.0.LongDomainValidator",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.LongDomainValidator",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.LongDomainValidator$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.LongDomainValidator"
-          },
-          "lower": {
-            "type": "integer"
-          },
-          "upper": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "$class"
-        ]
-      },
-      "concerto.metamodel@0.4.0.Import": {
-        "title": "Import",
-        "description": "An instance of concerto.metamodel@0.4.0.Import",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.Import",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Import$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.Import"
-          },
-          "namespace": {
-            "type": "string"
-          },
-          "uri": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "$class",
-          "namespace"
-        ]
-      },
-      "concerto.metamodel@0.4.0.ImportAll": {
-        "title": "ImportAll",
-        "description": "An instance of concerto.metamodel@0.4.0.ImportAll",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.ImportAll",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.ImportAll$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.ImportAll"
-          },
-          "namespace": {
-            "type": "string"
-          },
-          "uri": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "$class",
-          "namespace"
-        ]
-      },
-      "concerto.metamodel@0.4.0.ImportType": {
-        "title": "ImportType",
-        "description": "An instance of concerto.metamodel@0.4.0.ImportType",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.ImportType",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.ImportType$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.ImportType"
-          },
-          "name": {
-            "type": "string"
-          },
-          "namespace": {
-            "type": "string"
-          },
-          "uri": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "$class",
-          "name",
-          "namespace"
-        ]
-      },
-      "concerto.metamodel@0.4.0.Model": {
-        "title": "Model",
-        "description": "An instance of concerto.metamodel@0.4.0.Model",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.Model",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Model$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.Model"
-          },
-          "namespace": {
-            "type": "string"
-          },
-          "sourceUri": {
-            "type": "string"
-          },
-          "concertoVersion": {
-            "type": "string"
-          },
-          "imports": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Import"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ImportAll"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ImportType"
-                }
-              ]
-            }
-          },
-          "declarations": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Declaration"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.EnumDeclaration"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ConceptDeclaration"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.AssetDeclaration"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.ParticipantDeclaration"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.TransactionDeclaration"
-                },
-                {
-                  "$ref": "#/components/schemas/concerto.metamodel@0.4.0.EventDeclaration"
-                }
-              ]
-            }
-          }
-        },
-        "required": [
-          "$class",
-          "namespace"
-        ]
-      },
-      "concerto.metamodel@0.4.0.Models": {
-        "title": "Models",
-        "description": "An instance of concerto.metamodel@0.4.0.Models",
-        "type": "object",
-        "properties": {
-          "$class": {
-            "type": "string",
-            "default": "concerto.metamodel@0.4.0.Models",
-            "pattern": "^concerto\\.metamodel@0\\.4\\.0\\.Models$",
-            "description": "The class identifier for concerto.metamodel@0.4.0.Models"
-          },
-          "models": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/concerto.metamodel@0.4.0.Model"
-            }
-          }
-        },
-        "required": [
-          "$class",
-          "models"
         ]
       }
     }

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -266,7 +266,15 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 }
 
                 res.json(inserted[0]);
-            } catch (error) {
+            } catch (error: any) {
+                // Handle Unique Constraint Violation (Duplicate URI)
+                if (error?.code === '23505') {
+                    return res.status(409).json({
+                        error: 'Conflict',
+                        details: `A resource with this unique identifier already exists for ${typeName}.`
+                    });
+                }
+
                 const message = error instanceof Error ? error.message : 'Unknown error';
                 res.status(500).json({ error: message });
             }
@@ -348,7 +356,15 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 }
 
                 res.json(updated[0]);
-            } catch (error) {
+            } catch (error: any) {
+                // FIXED: Handle Unique Constraint Violation (Duplicate URI during Update)
+                if (error?.code === '23505') {
+                    return res.status(409).json({
+                        error: 'Conflict',
+                        details: `A resource with this unique identifier already exists for ${typeName}.`
+                    });
+                }
+
                 const message = error instanceof Error ? error.message : 'Unknown error';
                 res.status(500).json({ error: message });
             }


### PR DESCRIPTION
### Description
Addresses Issue #57 "Create Obligation Definitions for triggering responses".

This PR extends the `protocol.cto` model to include standardized definitions for legal obligations. This standardizes the output of contract triggers, allowing external systems (like Banking APIs or Distributed Ledgers) to programmatically understand required actions (payments, transfers, etc.).

### Changes
* **Modified `model/protocol.cto`**: Added `ObligationStatus` enum and concepts:
    * `BaseObligation`
    * `PaymentObligation`
    * `OwnershipTransferObligation`
    * `EscrowReleaseObligation`
    * `AccessControlObligation`
* **Updated `TriggerResponse`**: Now includes an optional `obligations` array to emit these events.
* **Regenerated Artifacts**: Ran `npm run build` to update `openapi.json` and `client/typescript/apap.ts`.

### Verification
* Ran `npm run build` successfully.
* Verified `openapi.json` contains the new schema definitions (e.g., `PaymentObligation`).