### PR TITLE
fix: correct MCP template resource handler using wrong variables and endpoint

### DIFF
--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -177,12 +177,12 @@ const getServer = () => {
             list: async () => {
                 const result = await makeApiRequest(`${API_BASE_URL}/templates`);
                 if (result.ok) {
-                    const agreements = await result.json();
+                    const templates = await result.json();
                     return {
-                        resources: agreements.items.map((a: typeof Agreement) => {
+                        resources: templates.items.map((t: typeof Template) => {
                             return {
-                                ...a,
-                                uri: `apap://templates/${a.id}`
+                                ...t,
+                                uri: `apap://templates/${t.id}`
                             }
                         })
                     }
@@ -193,8 +193,21 @@ const getServer = () => {
             }
         }),
         async (uri: URL, variables: any) => {
-            const agreementId = variables.agreementId;
-            return await getAgreement(uri.toString(), { agreementId });
+            const templateId = variables.templateId;
+            const result = await makeApiRequest(`${API_BASE_URL}/templates/${templateId}`);
+            if (result.ok) {
+                const template = await result.json();
+                return {
+                    contents: [{
+                        uri: uri.toString(),
+                        mimeType: "application/json",
+                        text: JSON.stringify(template)
+                    }]
+                };
+            }
+            else {
+                throw new Error('Failed to load template');
+            }
         }
     );
 


### PR DESCRIPTION
Closes #99

### Description

The MCP template resource handler ([handlers/mcp.ts](cci:7://file:///home/shubhraj/OpenSource/apap/server/handlers/mcp.ts:0:0-0:0), lines 173-199) was a copy-paste of the agreement resource handler with incorrect variable names and function calls. When an MCP client requested a template by ID via `apap://templates/{templateId}`, it would:

1. Read `variables.agreementId` (which is `undefined` since the URL defines `{templateId}`)
2. Call [getAgreement()](cci:1://file:///home/shubhraj/OpenSource/apap/server/handlers/mcp.ts:34:0-53:1) hitting `/agreements/undefined` instead of `/templates/{id}`
3. Use `typeof Agreement` type annotation instead of `typeof Template` in the list callback

### Changes

- Renamed `agreements` → `templates` and `a` → `t` in the list callback
- Changed `typeof Agreement` → `typeof Template`
- Changed `variables.agreementId` → `variables.templateId` in the read callback
- Replaced [getAgreement()](cci:1://file:///home/shubhraj/OpenSource/apap/server/handlers/mcp.ts:34:0-53:1) call with inline fetch to `/templates/${templateId}`

### Testing

- TypeScript build passes (`npm run build`)
- All 37 tests pass across 2 test suites (`npm test`)