### PR TITLE
Implemented TODO for supporting more functionalities in default "WHERE" clause

### DIFF
--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -10,13 +10,70 @@ import { count } from 'drizzle-orm';
 import escapeString from '../db/escape';
 // import { getUserRoles } from '../auth0/client';
 
-function defaultWhereClause<T extends PgTable<any>>(req: Request, queryParams: QueryParams) : SQL | undefined {
-    const conditions = queryParams.filters ? Object.keys(queryParams.filters).map(key => {
-        const value = queryParams.filters[key];
-        // TODO, only works for string cols as we use "=" to compare LHS and RHS
-        return sql.raw(`"${toSnakeCase(key)}"=${escapeString(value.toString())}`);
-    }) : [];
-    return conditions.length > 0 ? and(...conditions) : undefined;
+function defaultWhereClause<T extends PgTable<any>>(
+	req: Request,
+	queryParams: QueryParams,
+	table?: T
+): SQL | undefined {
+	const filters = queryParams.filters;
+	if (!filters || Object.keys(filters).length === 0) {
+		// no filters -> no "where" clause
+		return undefined;
+	}
+
+	const conditions: SQL[] = [];
+
+	for (const key of Object.keys(filters)) {
+		let value = filters[key];
+
+		if (table && !(key in table)) {
+			// if table is given we check if key exists in it
+			continue;
+		}
+
+		const column = sql.raw(`"${toSnakeCase(key)}"`);
+
+		if (value === null || value === 'null') {
+			// NULL handling
+			conditions.push(sql`${column} IS NULL`);
+			continue;
+		}
+
+		// detect operator inside value (no naming convention needed)
+		if (typeof value === 'string') {
+			const trimmed = value.trim();
+			const opMatch = trimmed.match(/^(>=|<=|<>|!=|>|<)\s*(.+)$/);
+			if (opMatch) {
+				const operator = opMatch[1];
+				const operandRaw = opMatch[2];
+				const operand = parseValue(operandRaw);
+				conditions.push(sql`${column} ${sql.raw(operator)} ${operand}`);
+				continue;
+			}
+		}
+
+		// default equality
+		conditions.push(sql`${column} = ${value}`);
+	}
+
+	if (conditions.length === 0)
+		return undefined;
+	if (conditions.length === 1)
+		return conditions[0];
+
+	return sql.join(conditions, sql` AND `);
+}
+
+function parseValue(v: any) {
+  const s = String(v).trim();
+
+  if (s.toLowerCase() === 'true') return true;
+  if (s.toLowerCase() === 'false') return false;
+  
+  const n = Number(s);
+  if (!isNaN(n)) return n;
+
+  return v;
 }
 
 // Types for query parameters
@@ -148,7 +205,7 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 const queryParams = parseQueryParams(req);
                 const { page, limit, sortBy, sortOrder } = queryParams;
                 const whereClause = buildWhereClause ? buildWhereClause(req, queryParams) : 
-                    defaultWhereClause(req, queryParams);
+                    defaultWhereClause(req, queryParams, table);
                 const orderClause = buildOrderClause(table, sortBy, sortOrder);
 
                 // Log the generated SQL


### PR DESCRIPTION
I refactored the `defaultWhereClause` in `server/index.ts` because filtering in the CRUD router was fragile and limited.

Before this change, it only really worked for simple string comparisons. Operators like `>`, `<`, `>=`, `<=`, `!=` were not supported, `null` values were handled poorly, and values were interpolated directly into SQL.

Now the function:
- supports numbers, booleans, strings, and nulls
- understands operator syntax in query values (e.g. `>5`, `<=10`, `!=3`)
- uses parameterized SQL instead of string interpolation
- joins multiple conditions correctly with `AND`
- can optionally validate keys against the provided `PgTable`

I did some tests and all passed succesfully.

I provide a request that is parsed with the `defaultWhereClause` as a demonstration that it works:
```bash
(base) vaggelisarg@Vaggelis-Arg:~/apap$ curl "http://localhost:9000/templates?id<2"
{"items":[{"id":1,"uri":"resource:org.accordproject.protocol@1.0.0.Template#dan","author":"dan","displayName":"Late Delivery and Penalty","version":"1.0.0","description":"This is late delivery and penalty template","license":"Apache-2","keywords":["one","two"],"metadata":{"$class":"org.accordproject.protocol@1.0.0.TemplateMetadata","runtime":"typescript","template":"clause","cicero":"0.25.x"},"logo":null,"templateModel":{"$class":"org.accordproject.protocol@1.0.0.TemplateModel","typeName":"foo","model":{"$class":"org.accordproject.protocol@1.0.0.CtoModel","ctoFiles":[{"$class":"org.accordproject.protocol@1.0.0.CtoFile","contents":"namespace io.clause.latedeliveryandpenalty@0.1.0\r\n\r\nimport org.accordproject.time@0.3.0.{Duration, TemporalUnit} from https://models.accordproject.org/time@0.3.0.cto\r\n\r\nimport org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto\r\nimport org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto\r\n\r\n/**\r\n * Defines the data model for the LateDeliveryAndPenalty template.\r\n * This defines the structure of the abstract syntax tree that the parser for the template\r\n * must generate from input source text.\r\n */\r\n@template\r\nasset TemplateModel extends Clause {\r\n  /**\r\n   * Does the clause include a force majeure provision?\r\n   */\r\n  o Boolean forceMajeure\r\n\r\n  /**\r\n   * For every penaltyDuration that the goods are late\r\n   */\r\n  o Duration penaltyDuration\r\n\r\n  /**\r\n   * Seller pays the buyer penaltyPercentage % of the value of the goods\r\n   */\r\n  o Double penaltyPercentage\r\n\r\n  /**\r\n   * Up to capPercentage % of the value of the goods\r\n   */\r\n  o Double capPercentage\r\n\r\n  /**\r\n   * If the goods are >= termination late then the buyer may terminate the contract\r\n   */\r\n  o Duration termination\r\n\r\n  /**\r\n   * Fractional part of a ... is considered a whole ...\r\n   */\r\n  o TemporalUnit fractionalPart\r\n}\r\n\r\n/**\r\n * Defines the input data required by the template\r\n */\r\ntransaction LateDeliveryAndPenaltyRequest extends Request {\r\n\r\n  /**\r\n   * Are we in a force majeure situation?\r\n   */\r\n  o Boolean forceMajeure\r\n\r\n  /**\r\n   * What was the agreed delivery date for the goods?\r\n   */\r\n  o DateTime agreedDelivery\r\n\r\n  /**\r\n   * If the goods have been delivered, when where they delivered?\r\n   */\r\n  o DateTime deliveredAt optional\r\n\r\n  /**\r\n   * What is the value of the goods?\r\n   */\r\n  o Double goodsValue\r\n}\r\n\r\n/**\r\n * Defines the output data for the template\r\n */\r\ntransaction LateDeliveryAndPenaltyResponse extends Response {\r\n  /**\r\n   * The penalty to be paid by the seller\r\n   */\r\n  o Double penalty\r\n\r\n  /**\r\n   * Whether the buyer may terminate the contract\r\n   */\r\n  o Boolean buyerMayTerminate\r\n}","filename":"test.cto"}]}},"text":{"$class":"org.accordproject.protocol@1.0.0.Text","templateText":"Late Delivery and Penalty – {{% return now.toLocaleString() %}}\r\n----\r\n\r\nIn case of delayed delivery{{#if forceMajeure}}, except for Force Majeure cases,{{/if}} the Seller shall pay to the Buyer for every _{{% return `${penaltyDuration.amount} ${penaltyDuration.unit}` %}} of delay_ ***Penalty*** amounting to {{penaltyPercentage}}% of the total value of the Equipment whose delivery has been delayed.\r\n\r\n1. Any fractional part of a {{fractionalPart}} is to be considered a full {{fractionalPart}}.\r\n1. The total amount of penalty shall not however, exceed {{capPercentage}}% of the total value of the Equipment involved in late delivery.\r\n1. If the delay is more than {{% return `${termination.amount} ${termination.unit}` %}}, the Buyer is entitled to terminate this Contract."},"logic":null,"sampleRequest":null}],"total":1,"page":1,"limit":100,"totalPages":1}
```