### PR TITLE
fix: resource entries missing required name field in MCP ```ResourceTemplate``` list handlers

### DIFF
--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -153,6 +153,7 @@ const getServer = () => {
                     return {
                         resources: agreements.items.map((a: typeof Agreement) => {
                             return {
+                                name: `agreement-${a.id}`,
                                 ...a,
                                 uri: `apap://agreements/${a.id}`
                             }
@@ -181,6 +182,7 @@ const getServer = () => {
                     return {
                         resources: templates.items.map((t: typeof Template) => {
                             return {
+                                name: `template-${t.id}`,
                                 ...t,
                                 uri: `apap://templates/${t.id}`
                             }


### PR DESCRIPTION
Fix: #115 
Add the required ```name``` field to each returned resource object:
```
// agreements
resources: agreements.items.map((a: typeof Agreement) => {
    return {
        name: `agreement-${a.id}`, 
        ...a,
        uri: `apap://agreements/${a.id}`
    }
})

// templates
resources: templates.items.map((t: typeof Template) => {
    return {
        name: `template-${t.id}`,  
        ...t,
        uri: `apap://templates/${t.id}`
    }
})
```
<img width="1848" height="869" alt="Screenshot 2026-03-06 175020" src="https://github.com/user-attachments/assets/91f91fdf-53c8-4ebd-8bcd-e072c5ddc137" />

