### PR TITLE
fix: prevent ```Agreement.uri``` from overriding resource URI

### DIFF
--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -62,6 +62,7 @@ async function getTemplates(uri: URL) {
         return {
             contents: templates.items.map((t: typeof Template) => {
                 return {
+                    ...t,
                     uri: `apap://templates/${t.id}`,
                     mimeType: "application/json",
                     text: JSON.stringify(t)
@@ -84,10 +85,10 @@ async function getAgreements(uri: URL) {
         return {
             contents: agreements.items.map((a: typeof Agreement) => {
                 return {
+                    ...a,
                     uri: `apap://agreements/${a.id}`,
                     mimeType: "application/json",
                     text: JSON.stringify({ ...a.data, $identifier: a.id }, null, 2),
-                    ...a
                 }
             })
         }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8145,6 +8145,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -8155,6 +8176,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/esutils": {


### PR DESCRIPTION
# Problem
 In ```getAgreements```, the object spread ...a was placed after the explicitly defined uri field. Since Agreement has its own uri property, it was silently overwriting the apap://agreements/${a.id} URI we were trying to set — meaning MCP clients were getting the wrong URI back.

# Solution
Moved ```...a``` to the top of the returned object so that our explicit ```uri```, ```mimeType```, and text fields always take precedence over whatever's on the schema.

```
// before
return {
    uri: `apap://agreements/${a.id}`,   // overridden by ...a
    mimeType: "application/json",
    text: JSON.stringify({ ...a.data, $identifier: a.id }, null, 2),
    ...a
}

// after
return {
    ...a,
    uri: `apap://agreements/${a.id}`, 
    mimeType: "application/json",
    text: JSON.stringify({ ...a.data, $identifier: a.id }, null, 2),
}
```
And it finally return the correct URI: 

<img width="1854" height="738" alt="image" src="https://github.com/user-attachments/assets/5809d692-2ec0-41ef-bdcf-765f0d249ed0" />



Fixes: #128