### PR TITLE
fix(crud): validate PUT request bodies before updating resources

### DIFF
--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -391,6 +391,32 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                     organization: res.locals.orgId
                 };
 
+                // Validate body if schema provided
+                if (validateBody?.schema) {
+                    const result = validateBody.schema.safeParse(req.body);
+                    if (!result.success) {
+                        return res.status(400).json({
+                            error: 'Invalid request body',
+                            details: result.error.errors
+                        });
+                    }
+                    req.body = result.data;
+                    if (validateBody.custom) {
+                        const customResult = await validateBody.custom(req.body);
+                        if (!customResult.success) {
+                            return res.status(400).json({
+                                error: 'Invalid request body',
+                                details: customResult.error.errors
+                            });
+                        }
+                        req.body = customResult.data;
+                    }
+                }
+
+                if (transformRequest) {
+                    req.body = transformRequest(req);
+                }
+
                 const queryParams = parseQueryParams(req);
                 const whereConditions = [
                     table.id.columnType === 'PgUUID' ? 


### PR DESCRIPTION
Closes #136

## Summary
This PR adds request validation to the generic `PUT /:id` update path in `buildCrudRouter`.

## Changes
- added schema validation to `PUT /:id`
- added custom validator execution to `PUT /:id`
- return `400` with validation details when update payload validation fails

## Why
`POST /` already validates request bodies, but `PUT /:id` was bypassing the same validation flow. This made create and update behavior inconsistent and allowed invalid updates to slip through.

## Notes
This change follows the same validation pattern already used in the create path and is intentionally scoped to the generic CRUD router.
