### PR TITLE
fix(templates): stop building invalid templates before validation passes

### DIFF
--- a/server/handlers/templates.ts
+++ b/server/handlers/templates.ts
@@ -9,10 +9,10 @@ const router = express.Router();
 async function templateValidation(body:any) : Promise<ValidationResult> {
     try {
         const result = await concertoValidation('Template', body);
-        const template = await templateFromDatabase(body);
         if(!result.success) {
             return result;
         }
+        await templateFromDatabase(body);
         return {
             success: true,
             data: result.data


### PR DESCRIPTION
Closes #138 

## Summary
This PR short-circuits template validation before template build logic runs on invalid input.

## Changes
- return immediately when `concertoValidation('Template', body)` fails
- only call `templateFromDatabase(body)` after validation succeeds

## Why
The previous flow attempted to build templates even after validation had already failed, which caused unnecessary work and could obscure the original validation error.

## Notes
This is a small control-flow fix in the template validation path. It does not change the success path for valid templates.
