### PR TITLE
docs(server): start documenting handler functions

### DIFF
--- a/server/handlers/agreements.ts
+++ b/server/handlers/agreements.ts
@@ -8,6 +8,14 @@ import { TemplateArchiveProcessor } from '@accordproject/template-engine';
 import { HttpTemplateRetriever } from './retrievers/HttpTemplateRetriever';
 import { Template as CiceroTemplate } from '@accordproject/cicero-core';
 
+/**
+ * @param db The database handle stored on `res.locals.db`.
+ * @param agreementId The numeric agreement identifier from the request path.
+ * @return The agreement row, its associated template row, and the reconstructed Cicero template.
+ * @details Loads an agreement from the database, resolves its backing template either
+ * through the cached `templateHash` or the stored template URI, and rebuilds the
+ * runtime template archive needed for draft and trigger operations.
+ */
 async function resolveAgreement(db: any, agreementId: string) {
     console.log('Getting agreement: ' + agreementId);
     const result = await db.select().from(Agreement).where(eq(Agreement.id, Number.parseInt(agreementId))).limit(1);
@@ -47,6 +55,14 @@ async function resolveAgreement(db: any, agreementId: string) {
 
 const router = express.Router();
 
+/**
+ * @param req The Express request containing the agreement payload to create.
+ * @param res The Express response used to return the created agreement or an error.
+ * @return Resolves after the agreement creation response has been written.
+ * @details Validates the incoming agreement body with Zod and Concerto, optionally
+ * resolves and caches a remote template archive when the template URI matches a supported
+ * retriever, and finally inserts the agreement into the database.
+ */
 router.post('/', async (req, res) => {
     try {
         const db = res.locals.db;
@@ -114,6 +130,13 @@ const crudRouter = buildCrudRouter({
     validateBody: { schema: AgreementInsertSchema, custom: (body) => concertoValidation('Agreement', body) }
 });
 
+/**
+ * @param req The Express request containing the agreement id and output format.
+ * @param res The Express response used to return the converted agreement draft.
+ * @return Resolves after the converted agreement text or an error response has been written.
+ * @details Resolves the agreement and its template, creates a `TemplateArchiveProcessor`,
+ * and delegates the conversion to the template engine's draft support for the requested format.
+ */
 crudRouter.get('/:id/convert/:format', async function (req, res) {
     try {
         const {agreement, apTemplate} = await resolveAgreement(res.locals.db, req.params.id);
@@ -129,6 +152,14 @@ crudRouter.get('/:id/convert/:format', async function (req, res) {
     }
 });
 
+/**
+ * @param req The Express request containing the agreement id and trigger payload.
+ * @param res The Express response used to return the trigger result or validation errors.
+ * @return Resolves after the trigger response has been written.
+ * @details Validates the incoming trigger request against the template request types,
+ * initializes agreement state when needed, executes the agreement logic through the
+ * template archive processor, and persists the updated agreement state back to the database.
+ */
 crudRouter.post('/:id/trigger', async function (req, res) {
     try {
         const {agreement, apTemplate} = await resolveAgreement(res.locals.db, req.params.id);

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -10,6 +10,15 @@ import { count } from 'drizzle-orm';
 import escapeString from '../db/escape';
 // import { getUserRoles } from '../auth0/client';
 
+/**
+ * @param req The current Express request.
+ * @param queryParams Parsed pagination, sorting, and filter parameters.
+ * @param table The optional Drizzle table used to validate filter keys.
+ * @return A SQL `where` clause built from query filters, or `undefined` when no filters are present.
+ * @details Converts query-string filters into a Drizzle SQL fragment. The function
+ * supports equality filters by default, handles explicit `null` values, and also
+ * accepts inline comparison operators such as `>=`, `<=`, `!=`, `>`, and `<`.
+ */
 function defaultWhereClause<T extends PgTable<any>>(
 	req: Request,
 	queryParams: QueryParams,
@@ -64,6 +73,12 @@ function defaultWhereClause<T extends PgTable<any>>(
 	return sql.join(conditions, sql` AND `);
 }
 
+/**
+ * @param v The raw filter operand read from the query string.
+ * @return A normalized primitive value, converted to boolean or number when possible.
+ * @details Used by filter parsing to interpret string operands like `true`, `false`,
+ * or numeric values before they are inserted into a SQL comparison expression.
+ */
 function parseValue(v: any) {
   const s = String(v).trim();
 
@@ -127,7 +142,13 @@ interface CrudRouterOptions<T extends PgTable<any> & TableWithId> {
     transformRequest?: (req: Request) => any;
 }
 
-// Parse and validate query parameters
+/**
+ * @param req The current Express request.
+ * @return A normalized `QueryParams` object with parsed paging, sorting, and filter values.
+ * @details Reads query-string parameters from the request and applies the current
+ * defaults and bounds for `page`, `limit`, and `sortOrder`, leaving all other
+ * query-string keys available as filter values.
+ */
 function parseQueryParams(req: Request): QueryParams {
     const {
         page = '1',
@@ -146,7 +167,14 @@ function parseQueryParams(req: Request): QueryParams {
     };
 }
 
-// Build order by clause
+/**
+ * @param table The Drizzle table being queried.
+ * @param sortBy The optional property name to sort by.
+ * @param sortOrder The requested sort direction, defaulting to ascending.
+ * @return A Drizzle order-by wrapper when the field exists on the table, otherwise `null`.
+ * @details Validates the requested sort field against the table definition and
+ * constructs either an ascending or descending order clause for list queries.
+ */
 function buildOrderClause<T extends PgTable<any>>(
     table: T,
     sortBy?: string,
@@ -159,7 +187,12 @@ function buildOrderClause<T extends PgTable<any>>(
     return null;
 }
 
-// In buildCrudRouter, add a helper to enhance user data
+/**
+ * @param user The user record returned from the database.
+ * @return The original user or a user object extended with a `roles` array.
+ * @details This helper is currently used only for the special `users` type path.
+ * The role lookup is stubbed out in the current code and returns an empty roles array.
+ */
 async function enhanceUserData(user: any) {
     console.log('user', user);
     if (!user?.email) return user;
@@ -167,6 +200,14 @@ async function enhanceUserData(user: any) {
     return { ...user, roles };
 }
 
+/**
+ * @param options The CRUD router configuration, including table metadata, validation hooks,
+ * and optional request/response transformations.
+ * @return An Express router exposing list, get, create, update, and delete routes for the table.
+ * @details Builds the shared CRUD router used by multiple APAP resources. The current
+ * implementation applies optional request validation, pagination, filtering, sorting,
+ * record transformation hooks, and basic database-backed handlers for standard CRUD operations.
+ */
 export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
     table,
     typeName,

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -15,7 +15,13 @@ const API_BASE_URL = process.env.API_BASE_URL || `http://${HOST}:${PORT}`
 // Get API authorization header from environment variable (optional)
 const API_AUTH_HEADER = process.env.APAP_API_AUTH_HEADER;
 
-// Helper function to make authenticated API requests
+/**
+ * @param url The APAP REST endpoint to call.
+ * @param options Optional fetch options such as method, headers, and request body.
+ * @return The fetch response returned by the local APAP REST API.
+ * @details Builds a JSON-based request to the local REST API and attaches the
+ * optional static authorization header from `APAP_API_AUTH_HEADER` when it is configured.
+ */
 async function makeApiRequest(url: string, options: RequestInit = {}) {
     const headers: Record<string, string> = {
         'Content-Type': 'application/json',
@@ -32,6 +38,13 @@ async function makeApiRequest(url: string, options: RequestInit = {}) {
     });
 }
 
+/**
+ * @param uri The MCP resource URI being resolved.
+ * @param agreementId The agreement identifier extracted from the resource template variables.
+ * @return A MCP resource payload containing the requested agreement as JSON content.
+ * @details Resolves a single agreement by calling the local REST API and converts
+ * the REST response into the `contents` structure expected by the MCP SDK.
+ */
 async function getAgreement(uri: string, { agreementId }: { agreementId: string }) {
     console.log(`Fetching agreement with ID: ${agreementId}`);
     const url = new URL(uri);
@@ -53,6 +66,12 @@ async function getAgreement(uri: string, { agreementId }: { agreementId: string 
     }
 }
 
+/**
+ * @param uri The MCP resource URI for the templates collection.
+ * @return A MCP resource payload containing all templates returned by the REST API.
+ * @details Loads the template collection from the local REST API and maps each
+ * database row into an MCP `contents` entry with an `apap://templates/{id}` URI.
+ */
 async function getTemplates(uri: URL) {
     console.log('getTemplates: ' + uri);
     const result = await makeApiRequest(`${API_BASE_URL}/templates`);
@@ -75,6 +94,12 @@ async function getTemplates(uri: URL) {
     }
 }
 
+/**
+ * @param uri The MCP resource URI for the agreements collection.
+ * @return A MCP resource payload containing all agreements returned by the REST API.
+ * @details Loads the agreement collection from the local REST API and serializes
+ * each item into the MCP resource format expected by agreement resources.
+ */
 async function getAgreements(uri: URL) {
     console.log('getAgreements: ' + uri);
     const result = await makeApiRequest(`${API_BASE_URL}/agreements`);
@@ -98,6 +123,13 @@ async function getAgreements(uri: URL) {
     }
 }
 
+/**
+ * @param agreementId The agreement identifier to convert.
+ * @param format The output format requested by the MCP tool.
+ * @return The rendered agreement text produced by the REST conversion endpoint.
+ * @details Delegates agreement conversion to the local REST API and returns the
+ * raw text body so it can be forwarded directly to the MCP client.
+ */
 async function draftAgreement(agreementId: string, format: string) : Promise<string> {
     console.log('draftAgreement: ' + agreementId);
     const result = await makeApiRequest(`${API_BASE_URL}/agreements/${agreementId}/convert/${format}`);
@@ -110,6 +142,13 @@ async function draftAgreement(agreementId: string, format: string) : Promise<str
     }
 }
 
+/**
+ * @param agreementId The agreement identifier to trigger.
+ * @param body A JSON string representing the trigger request payload.
+ * @return The trigger result serialized back into a JSON string.
+ * @details Sends the trigger payload to the local REST API, waits for the
+ * agreement logic to execute, and forwards the JSON response back to the MCP layer.
+ */
 async function triggerAgreement(agreementId: string, body: string) : Promise<string> {
     console.log('triggerAgreement: ' + agreementId);
     console.log('body: ' + body);
@@ -130,6 +169,12 @@ async function triggerAgreement(agreementId: string, body: string) : Promise<str
     }
 }
 
+/**
+ * @return A fully configured MCP server instance with the current resources,
+ * tools, and transport-facing capabilities registered.
+ * @details Creates a new MCP server and registers the template and agreement
+ * resources, resource templates, and tool handlers currently exposed by APAP.
+ */
 const getServer = () => {
     const server = new McpServer({
         name: 'apap-mcp-server',
@@ -307,7 +352,14 @@ const transports: Record<string, StreamableHTTPServerTransport | SSEServerTransp
 
 const router = express.Router();
 
-// Handle all MCP Streamable HTTP requests (GET, POST, DELETE) on a single endpoint
+/**
+ * @param req The incoming Express request for the Streamable HTTP MCP endpoint.
+ * @param res The Express response used to return JSON-RPC output.
+ * @return Resolves after the request has been processed or an error response has been written.
+ * @details Handles all `/mcp` traffic for the Streamable HTTP transport. The handler
+ * reuses an existing session transport when a valid `mcp-session-id` is supplied, creates
+ * a new transport during MCP initialization requests, and rejects invalid session usage.
+ */
 router.all('/mcp', async (req: Request, res: Response) => {
     console.log(`Received ${req.method} request to /mcp`);
     console.log(JSON.stringify(req.body, null, 2));
@@ -396,6 +448,13 @@ router.all('/mcp', async (req: Request, res: Response) => {
 // DEPRECATED HTTP+SSE TRANSPORT (PROTOCOL VERSION 2024-11-05)
 //=============================================================================
 
+/**
+ * @param req The incoming Express request for the legacy SSE bootstrap endpoint.
+ * @param res The Express response that is bound to the SSE transport stream.
+ * @return Resolves after the SSE transport is created and connected to a new MCP server.
+ * @details Creates a legacy `SSEServerTransport`, stores it by session id, and
+ * removes it again when the HTTP connection closes.
+ */
 router.get('/sse', async (req: Request, res: Response) => {
     console.log('Received GET request to /sse (deprecated SSE transport)');
     const transport = new SSEServerTransport('/messages', res);
@@ -407,6 +466,14 @@ router.get('/sse', async (req: Request, res: Response) => {
     await server.connect(transport);
 });
 
+/**
+ * @param req The incoming Express request carrying a legacy SSE message.
+ * @param res The Express response used for JSON-RPC output.
+ * @return Resolves after the message has been forwarded to the matching SSE session
+ * transport or an error response has been written.
+ * @details Looks up the existing SSE transport by `sessionId`, verifies that the
+ * session belongs to the legacy transport type, and forwards the posted MCP message.
+ */
 router.post("/messages", async (req: Request, res: Response) => {
     const sessionId = req.query.sessionId as string;
     let transport: SSEServerTransport;


### PR DESCRIPTION
## Summary
- This PR starts a documentation pass over the existing code in server/handlers/ by adding inline function-level documentation as a first step.

## Changes
- add JSDoc-style comments to the first documented handler functions
- document function parameters, return values, and current behavior
- establish the documentation style that will be used for the remaining handler files in follow-up commits

## Why
- The current handler layer contains important REST, MCP, validation, and transport logic, but many functions are not yet documented. This makes the code harder to follow for new contributors and raises the onboarding cost for future APAP/MCP work.

- This PR is intended as the beginning of a broader documentation pass across all files in server/handlers/, with additional commits to follow for the remaining handlers.

## Notes
- documentation only
- no runtime behavior changes
- no API changes

Fix: #141 