### PR TITLE
implement Cypress end-to-end testing for APAP and MCP smoke coverage

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,5 @@
 .env
 scripts/drizzle-gen.js
 htpasswd
+cypress/videos
+cypress/screenshots

--- a/server/cypress.config.ts
+++ b/server/cypress.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="node" />
+
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  video: false,
+  e2e: {
+    baseUrl: process.env.CYPRESS_BASE_URL || 'http://localhost:9000',
+    specPattern: 'cypress/e2e/**/*.cy.ts',
+    supportFile: false,
+  },
+});

--- a/server/cypress/e2e/apap-mcp-smoke.cy.ts
+++ b/server/cypress/e2e/apap-mcp-smoke.cy.ts
@@ -1,0 +1,30 @@
+describe('APAP + MCP smoke tests', () => {
+  it('returns server capabilities', () => {
+    cy.request('/capabilities').then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.include('TEMPLATE_MANAGE');
+      expect(response.body).to.include('AGREEMENT_MANAGE');
+      expect(response.body).to.include('SHARED_MODEL_MANAGE');
+      expect(response.body).to.include('AGREEMENT_CONVERT_HTML');
+      expect(response.body).to.include('AGREEMENT_TRIGGER');
+    });
+  });
+
+  it('rejects invalid MCP request without a valid session', () => {
+    cy.request({
+      method: 'POST',
+      url: '/mcp',
+      failOnStatusCode: false,
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(400);
+      expect(response.body).to.have.property('jsonrpc', '2.0');
+      expect(response.body).to.have.property('error');
+      expect(response.body.error.message).to.contain('No valid session ID provided');
+    });
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -19,9 +19,13 @@
     "watch-build": "tsc -w",
     "start": "node dist/index.js",
     "watch-start": "nodemon --delay 2 -w dist/ -x 'npm run start'",
+    "start:test": "npm run build && npm run start",
     "dev": "concurrently -k -p '[{name}]' -n 'typescript,api' -c 'yellow.bold,cyan.bold' npm:watch-build npm:watch-start",
     "lint": "tslint --format prose --project .",
-    "test": "node --experimental-vm-modules node_modules/.bin/jest"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "test:e2e": "cypress run",
+    "test:e2e:open": "cypress open",
+    "test:e2e:local": "start-server-and-test start:test http://localhost:9000/capabilities test:e2e"
   },
   "dependencies": {
     "@accordproject/cicero-core": "0.25.1-20250328175253",
@@ -52,9 +56,11 @@
     "@types/supertest": "6.0.3",
     "axios": "1.13.5",
     "concurrently": "6.2.0",
+    "cypress": "^15.13.0",
     "drizzle-kit": "0.31.0",
     "jest": "29.7.0",
     "nodemon": "1.18.10",
+    "start-server-and-test": "^3.0.0",
     "supertest": "7.1.4",
     "ts-jest": "29.0.3",
     "tslint": "5.12.1",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -23,4 +23,10 @@
     "include": [
       "**/*"
     ],
+    "exclude": [
+      "cypress",
+      "cypress.config.ts",
+      "dist",
+      "node_modules"
+    ]
   }


### PR DESCRIPTION
This PR implements Cypress-based end-to-end testing for APAP and MCP server behavior, focused on first-pass smoke coverage through real HTTP flows.

Implementation details


1. Added Cypress configuration for server-level E2E execution at [cypress.config.ts](vscode-file://vscode-app/c:/Users/ET/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. Added smoke tests at [apap-mcp-smoke.cy.ts](vscode-file://vscode-app/c:/Users/ET/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
3. Added E2E scripts in [package.json](vscode-file://vscode-app/c:/Users/ET/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html):   test:e2e, test:e2e:open, test:e2e:local
4. Isolated Cypress from main TypeScript build in [tsconfig.json](vscode-file://vscode-app/c:/Users/ET/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to avoid type-scope conflicts.
5. Added Cypress artifact ignores in [.gitignore](vscode-file://vscode-app/c:/Users/ET/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Coverage implemented in this PR

1. APAP smoke check:( Capabilities endpoint returns expected response.)
2. MCP smoke check:( Invalid request without valid session is rejected with expected error response.)

Validation run

1. npm test
2. npm run test:e2e:local

closes #147 
