### PR TITLE
fix(mcp): surface HTTP status and API error details in MCP tool error responses

### DIFF
--- a/server/handlers/mcp.test.ts
+++ b/server/handlers/mcp.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// The buildApiErrorMessage helper isn't exported, so we replicate its logic here
+// to validate the expected error format across different HTTP failure scenarios.
+// This ensures MCP clients get actionable errors instead of generic "Failed to load" messages.
+
+async function buildApiErrorMessage(
+    result: { status: number; text: () => Promise<string> },
+    context: string
+): Promise<string> {
+    const body = await result.text().catch(() => 'No error details available');
+    return `${context} (HTTP ${result.status}): ${body}`;
+}
+
+// Helper to create a mock failed response matching the fetch Response shape
+function mockFailedResponse(status: number, body: string) {
+    return {
+        ok: false,
+        status,
+        text: async () => body,
+        json: async () => JSON.parse(body),
+    };
+}
+
+describe('MCP Error Handling - buildApiErrorMessage', () => {
+
+    it('should include HTTP 404 status when a resource is not found', async () => {
+        const result = mockFailedResponse(404, '{"error": "Template not found"}');
+        const msg = await buildApiErrorMessage(result, "Failed to load template 'late-delivery'");
+
+        expect(msg).toContain('HTTP 404');
+        expect(msg).toContain("Failed to load template 'late-delivery'");
+        expect(msg).toContain('Template not found');
+    });
+
+    it('should include HTTP 400 status for validation errors', async () => {
+        const result = mockFailedResponse(400, '{"error": "Invalid Concerto model"}');
+        const msg = await buildApiErrorMessage(result, 'Failed to trigger agreement');
+
+        expect(msg).toContain('HTTP 400');
+        expect(msg).toContain('Invalid Concerto model');
+    });
+
+    it('should include HTTP 500 status for server errors', async () => {
+        const result = mockFailedResponse(500, 'Internal Server Error');
+        const msg = await buildApiErrorMessage(result, 'Failed to load agreements');
+
+        expect(msg).toContain('HTTP 500');
+        expect(msg).toContain('Internal Server Error');
+    });
+
+    it('should handle response body read failure gracefully', async () => {
+        const result = {
+            ok: false,
+            status: 502,
+            // Simulate a body that can't be read (stream already consumed, network error, etc.)
+            text: async () => { throw new Error('body stream already read'); },
+        };
+        const msg = await buildApiErrorMessage(result, 'Failed to convert agreement');
+
+        expect(msg).toContain('HTTP 502');
+        expect(msg).toContain('No error details available');
+    });
+
+    it('should preserve resource identifiers in error context', async () => {
+        const result = mockFailedResponse(404, 'Not found');
+        const msg = await buildApiErrorMessage(result, "Failed to load agreement 'agreement-abc-123'");
+
+        expect(msg).toContain('agreement-abc-123');
+        expect(msg).toContain('HTTP 404');
+    });
+
+    it('should include format info for conversion failures', async () => {
+        const result = mockFailedResponse(422, '{"error": "Unsupported output format"}');
+        const msg = await buildApiErrorMessage(result, "Failed to convert agreement 'agr-1' to pdf");
+
+        expect(msg).toContain('agr-1');
+        expect(msg).toContain('pdf');
+        expect(msg).toContain('HTTP 422');
+    });
+});
+
+describe('MCP Error Handling - error distinctness', () => {
+
+    // The whole point of this fix: a 404, 400, and 500 should produce
+    // different error messages so an MCP client can tell them apart
+    it('should produce different messages for 404 vs 400 vs 500', async () => {
+        const ctx = 'Failed to load template';
+
+        const msg404 = await buildApiErrorMessage(
+            mockFailedResponse(404, 'Not found'), ctx
+        );
+        const msg400 = await buildApiErrorMessage(
+            mockFailedResponse(400, 'Validation failed'), ctx
+        );
+        const msg500 = await buildApiErrorMessage(
+            mockFailedResponse(500, 'Internal error'), ctx
+        );
+
+        // All three must be distinct strings
+        expect(msg404).not.toEqual(msg400);
+        expect(msg400).not.toEqual(msg500);
+        expect(msg404).not.toEqual(msg500);
+
+        // Each contains its own status code
+        expect(msg404).toContain('404');
+        expect(msg400).toContain('400');
+        expect(msg500).toContain('500');
+    });
+
+    // Make sure we didn't accidentally break the original context message
+    it('should always start with the context string', async () => {
+        const contexts = [
+            "Failed to load template 'my-template'",
+            "Failed to load agreement 'my-agreement'",
+            "Failed to trigger agreement 'agr-99'",
+            "Failed to convert agreement 'agr-1' to html",
+            'Failed to load templates',
+            'Failed to load agreements',
+        ];
+
+        for (const ctx of contexts) {
+            const msg = await buildApiErrorMessage(
+                mockFailedResponse(500, 'error'), ctx
+            );
+            expect(msg.startsWith(ctx)).toBe(true);
+        }
+    });
+});

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -32,6 +32,14 @@ async function makeApiRequest(url: string, options: RequestInit = {}) {
     });
 }
 
+// Builds a meaningful error message from a failed API response so that MCP clients
+// can tell apart a 404 (resource missing) from a 400 (bad input) or a 500 (server issue).
+// Without this, every failure just says "Failed to load ..." which is impossible to debug.
+async function buildApiErrorMessage(result: globalThis.Response, context: string): Promise<string> {
+    const body = await result.text().catch(() => 'No error details available');
+    return `${context} (HTTP ${result.status}): ${body}`;
+}
+
 async function getAgreement(uri: string, { agreementId }: { agreementId: string }) {
     console.log(`Fetching agreement with ID: ${agreementId}`);
     const url = new URL(uri);
@@ -48,8 +56,10 @@ async function getAgreement(uri: string, { agreementId }: { agreementId: string 
         };
     }
     else {
-        console.error(`Failed to load agreement with ID: ${agreementId}`);
-        throw new Error('Failed to load agreement');
+        // Surface the actual status code and API response so the client knows what went wrong
+        const errorMsg = await buildApiErrorMessage(result, `Failed to load agreement '${agreementId}'`);
+        console.error(errorMsg);
+        throw new Error(errorMsg);
     }
 }
 
@@ -70,8 +80,10 @@ async function getTemplates(uri: URL) {
         }
     }
     else {
-        console.error('Failed to load templates');
-        throw new Error('Failed to load template');
+        // Previously just threw "Failed to load template" with no status or details
+        const errorMsg = await buildApiErrorMessage(result, 'Failed to load templates');
+        console.error(errorMsg);
+        throw new Error(errorMsg);
     }
 }
 
@@ -93,8 +105,9 @@ async function getAgreements(uri: URL) {
         }
     }
     else {
-        console.error('Failed to load agreements');
-        throw new Error('Failed to load agreement');
+        const errorMsg = await buildApiErrorMessage(result, 'Failed to load agreements');
+        console.error(errorMsg);
+        throw new Error(errorMsg);
     }
 }
 
@@ -106,7 +119,10 @@ async function draftAgreement(agreementId: string, format: string) : Promise<str
         return text;
     }
     else {
-        throw new Error(`Failed to convert agreement to ${format}`);
+        // Include the agreement ID and target format so the caller knows exactly which conversion failed
+        const errorMsg = await buildApiErrorMessage(result, `Failed to convert agreement '${agreementId}' to ${format}`);
+        console.error(errorMsg);
+        throw new Error(errorMsg);
     }
 }
 
@@ -126,7 +142,11 @@ async function triggerAgreement(agreementId: string, body: string) : Promise<str
         return JSON.stringify(json);
     }
     else {
-        throw new Error(`Failed to trigger agreement ${agreementId}.`);
+        // Trigger failures are especially important to surface clearly since they often
+        // come from bad payload shapes that don't match the template's request type
+        const errorMsg = await buildApiErrorMessage(result, `Failed to trigger agreement '${agreementId}'`);
+        console.error(errorMsg);
+        throw new Error(errorMsg);
     }
 }
 
@@ -161,6 +181,10 @@ const getServer = () => {
                     }
                 }
                 else {
+                    // List operations return empty rather than throwing, but we still log
+                    // the actual error for debugging
+                    const errorMsg = await buildApiErrorMessage(result, 'Failed to list agreements');
+                    console.error(errorMsg);
                     return { resources: [] };
                 }
             }
@@ -190,6 +214,8 @@ const getServer = () => {
                     }
                 }
                 else {
+                    const errorMsg = await buildApiErrorMessage(result, 'Failed to list templates');
+                    console.error(errorMsg);
                     return { resources: [] };
                 }
             }
@@ -208,7 +234,9 @@ const getServer = () => {
                 };
             }
             else {
-                throw new Error('Failed to load template');
+                const errorMsg = await buildApiErrorMessage(result, `Failed to load template '${templateId}'`);
+                console.error(errorMsg);
+                throw new Error(errorMsg);
             }
         }
     );
@@ -262,7 +290,9 @@ Refer to the agreement's template model to determine which fields are required o
                     content: [{ type: "text", text: JSON.stringify(template) }]
                 };
             } else {
-                throw new Error('Failed to load template');
+                const errorMsg = await buildApiErrorMessage(result, `Failed to load template '${templateId}'`);
+                console.error(errorMsg);
+                throw new Error(errorMsg);
             }
         }
     );
@@ -288,7 +318,9 @@ Refer to the agreement's template model to determine which fields are required o
                     content: [{ type: "text", text: JSON.stringify(agreement) }]
                 };
             } else {
-                throw new Error('Failed to load agreement');
+                const errorMsg = await buildApiErrorMessage(result, `Failed to load agreement '${agreementId}'`);
+                console.error(errorMsg);
+                throw new Error(errorMsg);
             }
         }
     );


### PR DESCRIPTION
Closes #152

### Problem

All MCP tools and resource handlers in `handlers/mcp.ts` discard the HTTP status code and error body when `makeApiRequest()` returns a non-ok response. Every failure produces a generic `throw new Error('Failed to load ...')` regardless of whether the REST API returned 400, 404, or 500. MCP clients receive identical error messages for completely different failure modes.

### Changes

**Added `buildApiErrorMessage()` helper** that extracts the HTTP status code and response body from failed API responses, producing errors like:
Failed to load template 'abc-123' (HTTP 404): {"error": "Template not found"}

instead of:
Failed to load template

**Updated all 8 error paths** in `mcp.ts`:
- `getAgreement()` - now includes agreement ID and HTTP status
- `getTemplates()` - now includes HTTP status and API error body
- `getAgreements()` - now includes HTTP status and API error body
- `draftAgreement()` - now includes agreement ID, format, and HTTP status
- `triggerAgreement()` - now includes agreement ID and HTTP status
- Template resource handler (single fetch) - now includes template ID and HTTP status
- `getTemplate` tool - now includes template ID and HTTP status
- `getAgreement` tool - now includes agreement ID and HTTP status

Also improved error logging in the two resource list handlers (agreements and templates) which already returned empty arrays on failure but were logging without status context.

### Why This Matters

MCP clients like Claude Desktop and ChatGPT need to distinguish between "this template doesn't exist" (404) and "the server is down" (500) to provide useful feedback to users. This change makes every MCP error actionable.