### PR TITLE
fix: check concerto validation result before calling templateFromDatabase

### DIFF
--- a/server/handlers/templates.ts
+++ b/server/handlers/templates.ts
@@ -9,10 +9,15 @@ const router = express.Router();
 async function templateValidation(body:any) : Promise<ValidationResult> {
     try {
         const result = await concertoValidation('Template', body);
-        const template = await templateFromDatabase(body);
+
+        // Return validation errors before attempting deserialization,
+        // otherwise templateFromDatabase can throw and mask the real failure.
         if(!result.success) {
             return result;
         }
+
+        const template = await templateFromDatabase(body);
+
         return {
             success: true,
             data: result.data


### PR DESCRIPTION
## Summary

Fixes #138

## Problem

In `server/handlers/templates.ts`, the `templateValidation` function called
`templateFromDatabase(body)` before checking whether `concertoValidation`
returned success or failure. When the body was invalid, `templateFromDatabase`
threw a deserialization error that got caught by the outer catch block,
masking the structured validation error that concertoValidation had already
produced.

## Fix

Moved `templateFromDatabase` to after the `result.success` check. Invalid
payloads now return the Concerto validation error directly. Template
deserialization only runs on validated data.

## How to test

1. POST to `/templates` with a body missing required fields
2. Before: 500 with a deserialization error
3. After: 400 with structured validation details

Discord: Jay Guwalani (jayds22)