### PR TITLE
fix(bug): number id parse issue

### DIFF
--- a/server/handlers/agreements.ts
+++ b/server/handlers/agreements.ts
@@ -10,7 +10,11 @@ import { Template as CiceroTemplate } from '@accordproject/cicero-core';
 
 async function resolveAgreement(db: any, agreementId: string) {
     console.log('Getting agreement: ' + agreementId);
-    const result = await db.select().from(Agreement).where(eq(Agreement.id, Number.parseInt(agreementId))).limit(1);
+    const parsedId = Number(agreementId);
+    if (Number.isNaN(parsedId)) {
+        throw new Error(`Invalid agreement ID format`);
+    }
+    const result = await db.select().from(Agreement).where(eq(Agreement.id, parsedId)).limit(1);
     if (!result.length) {
         throw new Error(`Agreement with id ${agreementId} does not exist`);
     }

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -343,11 +343,14 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
         async (req: Request, res: Response) => {
             try {
                 const queryParams = parseQueryParams(req);
+                if (table.id.columnType !== 'PgUUID' && isNaN(Number(req.params.id))) {
+                    return res.status(400).json({ error: 'Invalid ID format' });
+                }
                 const whereConditions = [
                     // Check if table has UUID primary key
                     table.id.columnType === 'PgUUID' ? 
                         eq(table.id, req.params.id) :
-                        eq(table.id, parseInt(req.params.id))
+                        eq(table.id, Number(req.params.id))
                 ].filter(Boolean);
 
                 const result = await res.locals.db
@@ -392,10 +395,13 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 };
 
                 const queryParams = parseQueryParams(req);
+                if (table.id.columnType !== 'PgUUID' && isNaN(Number(req.params.id))) {
+                    return res.status(400).json({ error: 'Invalid ID format' });
+                }
                 const whereConditions = [
                     table.id.columnType === 'PgUUID' ? 
                         eq(table.id, req.params.id) :
-                        eq(table.id, parseInt(req.params.id))
+                        eq(table.id, Number(req.params.id))
                 ].filter(Boolean);
 
                 const updated = await res.locals.db
@@ -433,10 +439,13 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
         async (req: Request, res: Response) => {
             try {
                 const queryParams = parseQueryParams(req);
+                if (table.id.columnType !== 'PgUUID' && isNaN(Number(req.params.id))) {
+                    return res.status(400).json({ error: 'Invalid ID format' });
+                }
                 const whereConditions = [
                     table.id.columnType === 'PgUUID' ? 
                         eq(table.id, req.params.id) :
-                        eq(table.id, parseInt(req.params.id))
+                        eq(table.id, Number(req.params.id))
                 ].filter(Boolean);
 
                 await res.locals.db


### PR DESCRIPTION
## Description
Fixes #162

this pr resolves a vulnerability where numeric `:id` route parameters were partially parsed due to the use of `parseInt()`. For example, requests like `GET /templates/1abc` were incorrectly truncated and executed as `GET /templates/1`, potentially leading to unexpected resource modification or deletion.
### Tests passed
<img width="1919" height="453" alt="Screenshot 2026-04-14 100207" src="https://github.com/user-attachments/assets/c76bed4d-a57b-4384-a799-1e87eba852a0" />

### Postman screenshot after FIX
<img width="1919" height="657" alt="Screenshot 2026-04-14 101328" src="https://github.com/user-attachments/assets/bf0318ce-6385-45d7-bb59-d8735c7eb6e2" />
