### PR TITLE
fix: sanitize pagination params to prevent NaN in sql queries 

### DIFF
--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -137,9 +137,12 @@ function parseQueryParams(req: Request): QueryParams {
         ...filters
     } = req.query;
 
+    const parsedPage = parseInt(page as string);
+    const parsedLimit = parseInt(limit as string);
+
     return {
-        page: Math.max(1, parseInt(page as string)),
-        limit: Math.min(100, Math.max(1, parseInt(limit as string))),
+        page: Math.max(1, Number.isNaN(parsedPage) ? 1 : parsedPage),
+        limit: Math.min(100, Math.max(1, Number.isNaN(parsedLimit) ? 100 : parsedLimit)),
         sortBy: sortBy as string,
         sortOrder: (sortOrder as string).toLowerCase() === 'desc' ? 'desc' : 'asc',
         filters


### PR DESCRIPTION
# fixes #168

when non-numeric values like `page=abc` or `limit=foo` are passed as query params,
`parseInt` returns `NaN` which flows straight into drizzle's `.limit()` and `.offset()`,
producing broken sql or postgres errors.

added `Number.isNaN()` checks in `parseQueryParams` so invalid input falls back
to safe defaults (page 1, limit 100) instead of crashing.

affects all routes using `buildCrudRouter` — agreements, templates, shared models.
