### PR TITLE
fix(ci): remove missing notify job from publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,6 @@ jobs:
   publish:
     needs:
       - build
-      - notify
-
     name: Publish to npm
     if: ${{ success() && github.event_name == 'push' && github.repository_owner == 'accordproject' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
Fix broken `publish` job in CI.

The automated publish workflow was broken because it referenced a nonexistent `notify` job. This prevents the action from throwing dependency errors.

### Changes Made
- Removed the dangling `- notify` dependency from the `publish.needs` block in `.github/workflows/build.yml`.
