### PR TITLE
fix(crud): harden pagination query parsing

### DIFF
--- a/server/handlers/crud.test.ts
+++ b/server/handlers/crud.test.ts
@@ -1,9 +1,11 @@
+import type { Request } from 'express';
 import request from 'supertest';
 import express from 'express';
 import { jest } from '@jest/globals';
 import templatesRouter from './templates';
 import * as db from './templatebuilder';
 import * as validationModule from './concertovalidation';
+import { parseQueryParams } from './crud';
 import { TemplateInsertSchema } from '../db/schema';
 
 jest.mock('../db/schema');
@@ -434,5 +436,47 @@ describe('SQL injection prevention in defaultWhereClause', () => {
         const res = await request(app)
             .get('/templates?author=null');
         expect(res.status).not.toBe(500);
+    });
+});
+
+function createRequest(query: Request['query']): Request {
+    return {
+        query
+    } as Request;
+}
+
+describe('parseQueryParams', () => {
+    it('falls back to safe defaults for non-numeric pagination params', () => {
+        const queryParams = parseQueryParams(createRequest({
+            page: 'abc',
+            limit: 'foo'
+        }));
+
+        expect(queryParams.page).toBe(1);
+        expect(queryParams.limit).toBe(100);
+    });
+
+    it('rejects partially numeric and non-decimal pagination values', () => {
+        const queryParams = parseQueryParams(createRequest({
+            page: '12abc',
+            limit: '0x10'
+        }));
+
+        expect(queryParams.page).toBe(1);
+        expect(queryParams.limit).toBe(100);
+    });
+
+    it('uses the first repeated query param and still clamps values', () => {
+        const queryParams = parseQueryParams(createRequest({
+            page: ['2', '3'],
+            limit: ['250', '10'],
+            sortBy: ['createdAt', 'updatedAt'],
+            sortOrder: ['DESC', 'asc']
+        }));
+
+        expect(queryParams.page).toBe(2);
+        expect(queryParams.limit).toBe(100);
+        expect(queryParams.sortBy).toBe('createdAt');
+        expect(queryParams.sortOrder).toBe('desc');
     });
 });

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -181,6 +181,31 @@ interface CrudRouterOptions<T extends PgTable<any> & TableWithId> {
     transformRequest?: (req: Request) => any;
 }
 
+function getSingleQueryParam(value: unknown): string | undefined {
+    if (Array.isArray(value)) {
+        return typeof value[0] === 'string' ? value[0] : undefined;
+    }
+
+    return typeof value === 'string' ? value : undefined;
+}
+
+function parsePositiveIntegerQueryParam(value: unknown, fallback: number): number {
+    const rawValue = getSingleQueryParam(value);
+
+    if (rawValue === undefined) {
+        return fallback;
+    }
+
+    const normalizedValue = rawValue.trim();
+
+    if (!/^\d+$/.test(normalizedValue)) {
+        return fallback;
+    }
+
+    const parsedValue = Number.parseInt(normalizedValue, 10);
+    return Number.isSafeInteger(parsedValue) ? parsedValue : fallback;
+}
+
 /**
  * @param req The current Express request.
  * @return A normalized `QueryParams` object with parsed paging, sorting, and filter values.
@@ -188,20 +213,20 @@ interface CrudRouterOptions<T extends PgTable<any> & TableWithId> {
  * defaults and bounds for `page`, `limit`, and `sortOrder`, leaving all other
  * query-string keys available as filter values.
  */
-function parseQueryParams(req: Request): QueryParams {
+export function parseQueryParams(req: Request): QueryParams {
     const {
-        page = '1',
-        limit = '10000',
+        page,
+        limit,
         sortBy,
         sortOrder = 'asc',
         ...filters
     } = req.query;
 
     return {
-        page: Math.max(1, parseInt(page as string)),
-        limit: Math.min(100, Math.max(1, parseInt(limit as string))),
-        sortBy: sortBy as string,
-        sortOrder: (sortOrder as string).toLowerCase() === 'desc' ? 'desc' : 'asc',
+        page: Math.max(1, parsePositiveIntegerQueryParam(page, 1)),
+        limit: Math.min(100, Math.max(1, parsePositiveIntegerQueryParam(limit, 100))),
+        sortBy: getSingleQueryParam(sortBy),
+        sortOrder: getSingleQueryParam(sortOrder)?.toLowerCase() === 'desc' ? 'desc' : 'asc',
         filters
     };
 }


### PR DESCRIPTION
## Summary

Follow-up to #169 for the pagination sanitization fix related to #168.

This PR hardens pagination query parsing in `buildCrudRouter` so malformed `page` and `limit` query params cannot leak unintended values into SQL pagination.

## References

- follows up on #169
- related to #168

## What Changed

- accept only whole decimal strings for `page` and `limit`
- fall back to safe defaults when pagination params are invalid
- normalize repeated query params by using the first value
- preserve the existing `limit <= 100` clamp
- add focused unit coverage for invalid, partially numeric, and repeated pagination params

## Root Cause

The original fix in #169 handled the `NaN` case from `parseInt`, but it still allowed partially numeric values like `12abc` and alternate numeric forms like `0x10` to parse into unintended pagination values.

## Impact

This makes CRUD pagination behavior more predictable and prevents malformed query strings from producing surprising offsets or limits.

## Validation

- `npm run build` in `server`
- `npm test` in `server`
- `npm test` in repository root