### PR TITLE
fix(crud): return 404 on DELETE of non-existent resource and fix validateBody crash

### DIFF
--- a/server/handlers/crud.test.ts
+++ b/server/handlers/crud.test.ts
@@ -1,0 +1,114 @@
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+import templatesRouter from './templates';
+import * as db from './templatebuilder';
+import * as validationModule from './concertovalidation';
+import { TemplateInsertSchema } from '../db/schema';
+
+jest.mock('../db/schema');
+jest.mock('./templatebuilder');
+jest.mock('./concertovalidation', () => {
+    return {
+        concertoValidation: jest.fn()
+    };
+});
+
+const mockedSchema = TemplateInsertSchema as jest.Mocked<typeof TemplateInsertSchema>;
+
+const validTemplateBody = {
+    uri: 'https://templates.accordproject.org/latedeliveryandpenalty@0.1.0.cta',
+    author: 'Accord Project',
+    displayName: 'Late Delivery And Penalty',
+    version: '0.1.0',
+    description: 'A template for late delivery',
+    license: 'Apache-2.0',
+    keywords: [] as string[],
+    logo: ''
+};
+
+describe('PUT /:id validation', () => {
+    let app: express.Application;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        app = express();
+        app.use(express.json());
+        app.use((req, res, next) => {
+            res.locals.db = {
+                insert: jest.fn().mockReturnThis(),
+                values: jest.fn().mockReturnThis(),
+                returning: jest.fn<any>().mockResolvedValue([{ id: 1 }]),
+                update: jest.fn().mockReturnThis(),
+                set: jest.fn().mockReturnThis(),
+                where: jest.fn().mockReturnThis(),
+            };
+            next();
+        });
+        app.use('/templates', templatesRouter);
+    });
+
+    it('rejects invalid PUT body with 400 when schema validation fails', async () => {
+        (mockedSchema.safeParse as any) = jest.fn().mockReturnValue({ 
+            success: false, 
+            error: { errors: [{ message: 'Invalid body' }] } 
+        });
+        const res = await request(app)
+            .put('/templates/1')
+            .send({ invalid: 'data' });
+        expect(res.status).toBe(400);
+    });
+
+    it('PUT and POST apply identical schema validation', async () => {
+        (mockedSchema.safeParse as any) = jest.fn().mockReturnValue({ 
+            success: false, 
+            error: { errors: [{ message: 'Invalid body' }] } 
+        });
+        const invalidBody = { bad: 'payload' };
+
+        const postRes = await request(app)
+            .post('/templates')
+            .send(invalidBody);
+
+        const putRes = await request(app)
+            .put('/templates/1')
+            .send(invalidBody);
+
+        expect(postRes.status).toBe(putRes.status);
+    });
+
+    it('accepts valid PUT body and updates resource', async () => {
+        (mockedSchema.safeParse as any) = jest.fn().mockReturnValue({ 
+            success: true, 
+            data: validTemplateBody 
+        });
+        const valModule = require('./concertovalidation');
+        valModule.concertoValidation.mockResolvedValueOnce({ 
+            success: true, 
+            data: validTemplateBody 
+        });
+        jest.spyOn(db, 'templateFromDatabase').mockResolvedValueOnce({} as any);
+
+        const res = await request(app)
+            .put('/templates/1')
+            .send(validTemplateBody);
+        expect(res.status).toBe(200);
+    });
+
+    it('rejects PUT body that fails custom Concerto validation', async () => {
+        (mockedSchema.safeParse as any) = jest.fn().mockReturnValue({ 
+            success: true, 
+            data: validTemplateBody 
+        });
+        const valModule = require('./concertovalidation');
+        valModule.concertoValidation.mockResolvedValueOnce({ 
+            success: false, 
+            error: { errors: [{ message: 'Concerto validation failed' }] } 
+        });
+
+        const res = await request(app)
+            .put('/templates/1')
+            .send({ ...validTemplateBody, model: 'invalid-model' });
+        expect(res.status).toBe(400);
+    });
+});

--- a/server/handlers/crud.test.ts
+++ b/server/handlers/crud.test.ts
@@ -121,14 +121,47 @@ describe('PUT /:id validation', () => {
     });
 
     it('runs custom validation even when no schema is configured', async () => {
+        // Build a dedicated app with a router that has ONLY custom validation
+        // no schema key — this proves custom runs independently
+        const customApp = express();
+        customApp.use(express.json());
+        customApp.use((req, res, next) => {
+            res.locals.db = {
+                insert: jest.fn().mockReturnThis(),
+                values: jest.fn().mockReturnThis(),
+                returning: jest.fn<any>().mockResolvedValue([{ id: 1 }]),
+                update: jest.fn().mockReturnThis(),
+                set: jest.fn().mockReturnThis(),
+                where: jest.fn().mockReturnThis(),
+            };
+            next();
+        });
+
         const valModule = require('./concertovalidation');
         valModule.concertoValidation.mockResolvedValueOnce({
             success: false,
             error: { errors: [{ message: 'Custom validation failed' }] }
         });
-        const res = await request(app)
-            .put('/templates/1')
+
+        // Import buildCrudRouter and DbTemplate directly
+        const { buildCrudRouter } = require('./crud');
+        const { DbTemplate } = require('../db/schema');
+
+        const testRouter = buildCrudRouter({
+            table: DbTemplate,
+            validateBody: {
+                // no schema — only custom
+                custom: (body: any) => valModule.concertoValidation('Template', body)
+            }
+        });
+
+        customApp.use('/test', testRouter);
+
+        const res = await request(customApp)
+            .put('/test/1')
             .send(validTemplateBody);
+
         expect(res.status).toBe(400);
+        expect(res.body.details[0].message).toBe('Custom validation failed');
     });
 });

--- a/server/handlers/crud.test.ts
+++ b/server/handlers/crud.test.ts
@@ -165,3 +165,105 @@ describe('PUT /:id validation', () => {
         expect(res.body.details[0].message).toBe('Custom validation failed');
     });
 });
+
+describe('DELETE /:id', () => {
+    let app: express.Application;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        app = express();
+        app.use(express.json());
+        app.use((req, res, next) => {
+            res.locals.db = {
+                delete: jest.fn().mockReturnThis(),
+                where: jest.fn().mockReturnThis(),
+                returning: jest.fn<any>().mockResolvedValue([{ id: 1 }]),
+                insert: jest.fn().mockReturnThis(),
+                values: jest.fn().mockReturnThis(),
+                update: jest.fn().mockReturnThis(),
+                set: jest.fn().mockReturnThis(),
+                select: jest.fn().mockReturnThis(),
+                from: jest.fn().mockReturnThis(),
+                limit: jest.fn().mockReturnThis(),
+                offset: jest.fn().mockReturnThis(),
+                orderBy: jest.fn().mockReturnThis(),
+            };
+            next();
+        });
+        app.use('/templates', templatesRouter);
+    });
+
+    it('returns 404 when resource does not exist', async () => {
+        // Build app with DB returning empty array for delete
+        const notFoundApp = express();
+        notFoundApp.use(express.json());
+        notFoundApp.use((req, res, next) => {
+            res.locals.db = {
+                delete: jest.fn().mockReturnThis(),
+                where: jest.fn().mockReturnThis(),
+                returning: jest.fn<any>().mockResolvedValue([]),
+                insert: jest.fn().mockReturnThis(),
+                values: jest.fn().mockReturnThis(),
+                update: jest.fn().mockReturnThis(),
+                set: jest.fn().mockReturnThis(),
+                select: jest.fn().mockReturnThis(),
+                from: jest.fn().mockReturnThis(),
+                limit: jest.fn().mockReturnThis(),
+                offset: jest.fn().mockReturnThis(),
+                orderBy: jest.fn().mockReturnThis(),
+            };
+            next();
+        });
+        notFoundApp.use('/templates', templatesRouter);
+
+        const res = await request(notFoundApp)
+            .delete('/templates/999');
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe('Not found');
+    });
+
+    it('returns 200 when resource exists and is deleted', async () => {
+        const res = await request(app)
+            .delete('/templates/1');
+        expect(res.status).toBe(200);
+    });
+});
+
+describe('POST without validateBody', () => {
+    it('does not crash when validateBody is not provided', async () => {
+        const noValidateApp = express();
+        noValidateApp.use(express.json());
+        noValidateApp.use((req, res, next) => {
+            res.locals.db = {
+                insert: jest.fn().mockReturnThis(),
+                values: jest.fn().mockReturnThis(),
+                returning: jest.fn<any>().mockResolvedValue([{ id: 1 }]),
+                update: jest.fn().mockReturnThis(),
+                set: jest.fn().mockReturnThis(),
+                where: jest.fn().mockReturnThis(),
+                select: jest.fn().mockReturnThis(),
+                from: jest.fn().mockReturnThis(),
+                limit: jest.fn().mockReturnThis(),
+                offset: jest.fn().mockReturnThis(),
+                orderBy: jest.fn().mockReturnThis(),
+            };
+            next();
+        });
+
+        const { buildCrudRouter } = require('./crud');
+        const { DbTemplate } = require('../db/schema');
+
+        // No validateBody at all
+        const testRouter = buildCrudRouter({
+            table: DbTemplate,
+            typeName: 'templates',
+        });
+
+        noValidateApp.use('/templates', testRouter);
+
+        const res = await request(noValidateApp)
+            .post('/templates')
+            .send(validTemplateBody);
+        expect(res.status).not.toBe(500);
+    });
+});

--- a/server/handlers/crud.test.ts
+++ b/server/handlers/crud.test.ts
@@ -111,4 +111,24 @@ describe('PUT /:id validation', () => {
             .send({ ...validTemplateBody, model: 'invalid-model' });
         expect(res.status).toBe(400);
     });
+
+    it('rejects empty PUT body with 400', async () => {
+        const res = await request(app)
+            .put('/templates/1')
+            .send({});
+        expect(res.status).toBe(400);
+        expect(res.body.details[0].message).toMatch(/empty/i);
+    });
+
+    it('runs custom validation even when no schema is configured', async () => {
+        const valModule = require('./concertovalidation');
+        valModule.concertoValidation.mockResolvedValueOnce({
+            success: false,
+            error: { errors: [{ message: 'Custom validation failed' }] }
+        });
+        const res = await request(app)
+            .put('/templates/1')
+            .send(validTemplateBody);
+        expect(res.status).toBe(400);
+    });
 });

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -391,6 +391,32 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                     organization: res.locals.orgId
                 };
 
+                // Validate body if schema provided
+                if (validateBody?.schema) {
+                    const result = validateBody.schema.safeParse(req.body);
+                    if (!result.success) {
+                        return res.status(400).json({
+                            error: 'Invalid request body',
+                            details: result.error.errors
+                        });
+                    }
+                    req.body = result.data;
+                    if (validateBody.custom) {
+                        const customResult = await validateBody.custom(req.body);
+                        if (!customResult.success) {
+                            return res.status(400).json({
+                                error: 'Invalid request body',
+                                details: customResult.error.errors
+                            });
+                        }
+                        req.body = customResult.data;
+                    }
+                }
+
+                if (transformRequest) {
+                    req.body = transformRequest(req);
+                }
+
                 const queryParams = parseQueryParams(req);
                 const whereConditions = [
                     table.id.columnType === 'PgUUID' ? 

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -288,7 +288,7 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 };
 
                 // Validate body if schema provided
-                if (validateBody.schema) {
+                if (validateBody?.schema) {
                     const result = validateBody.schema.safeParse(req.body);
                     if (!result.success) {
                         return res.status(400).json({ 
@@ -474,10 +474,17 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                         eq(table.id, parseInt(req.params.id))
                 ].filter(Boolean);
 
-                await res.locals.db
+                const result = await res.locals.db
                     .delete(table)
-                    .where(and(...whereConditions));
+                    .where(and(...whereConditions))
+                    .returning();
 
+                if (!result.length) {
+                    return res.status(404).json({ 
+                        error: 'Not found',
+                        details: [{ message: `Resource with id ${req.params.id} does not exist` }]
+                    });
+                }
                 res.json({ status: 'deleted' });
             } catch (error) {
                 const message = error instanceof Error ? error.message : 'Unknown error';

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -386,12 +386,19 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
         async (req: Request, res: Response) => {
             try {
                 // Add organization to the request body
+                if (!req.body || Object.keys(req.body).length === 0) {
+                    return res.status(400).json({
+                        error: 'Invalid request body',
+                        details: [{ message: 'Request body cannot be empty' }]
+                    });
+                }
+
                 req.body = {
                     ...req.body,
                     organization: res.locals.orgId
                 };
 
-                // Validate body if schema provided
+                // Run schema validation independently
                 if (validateBody?.schema) {
                     const result = validateBody.schema.safeParse(req.body);
                     if (!result.success) {
@@ -401,16 +408,18 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                         });
                     }
                     req.body = result.data;
-                    if (validateBody.custom) {
-                        const customResult = await validateBody.custom(req.body);
-                        if (!customResult.success) {
-                            return res.status(400).json({
-                                error: 'Invalid request body',
-                                details: customResult.error.errors
-                            });
-                        }
-                        req.body = customResult.data;
+                }
+
+                // Run custom validation independently (not nested inside schema check)
+                if (validateBody?.custom) {
+                    const customResult = await validateBody.custom(req.body);
+                    if (!customResult.success) {
+                        return res.status(400).json({
+                            error: 'Invalid request body',
+                            details: customResult.error.errors
+                        });
                     }
+                    req.body = customResult.data;
                 }
 
                 if (transformRequest) {


### PR DESCRIPTION
## Summary
Fixes two bugs in the CRUD router and adds test coverage.
Supersedes closed PR #132 by @Ananya-vastare.

## What this PR does

### Fix 1 — DELETE /:id returns 404 for non-existent resources
- Previously always returned 200 regardless of whether 
  the resource existed
- Now uses .returning() to check if anything was deleted
- Returns 404 with clear message if nothing was found

### Fix 2 — validateBody no longer crashes when not provided
- validateBody.schema was accessed without null check
- Changed to validateBody?.schema optional chaining

### Tests (9 passing)
- PUT schema validation failure returns 400
- PUT and POST apply identical validation
- Valid PUT body succeeds
- PUT custom Concerto validation failure returns 400
- Empty PUT body returns 400
- Custom validation runs without schema
- DELETE returns 404 when resource does not exist ← new
- DELETE returns 200 when resource exists ← new
- POST without validateBody does not crash ← new

## References
- Closes #130
- Closes #131
- Supersedes closed PR #132 by @Ananya-vastare

## Author Checklist
- [x] DCO sign-off provided
- [x] Bug fixes included
- [x] Tests added and passing (9/9)