### PR TITLE
refactor(error-handling): centralize duplicate try/catch into Express error middleware

### DIFF
--- a/server/handlers/agreements.test.ts
+++ b/server/handlers/agreements.test.ts
@@ -10,6 +10,7 @@ import AdmZip from 'adm-zip';
 import fs from 'fs';
 import path from 'path';
 import * as validationModule from './concertovalidation';
+import { globalErrorHandler } from '../middleware/errorHandler';
 jest.setTimeout(30000);
 
 // Mock dependencies (but not TemplateArchiveProcessor)
@@ -97,6 +98,7 @@ describe('Agreements Router - POST /:id/trigger', () => {
 
         // Add agreements router
         app.use('/agreements', agreementsRouter);
+        app.use(globalErrorHandler);
     });
 
     describe('Success scenarios', () => {
@@ -472,8 +474,9 @@ describe('Agreements Router - POST /:id/trigger', () => {
                 .send('{ invalid json }')
                 .expect(400);
 
-            // Express default error handling for malformed JSON
-            expect(response.text).toContain('SyntaxError');
+            // globalErrorHandler formats the JSON parsing error
+            expect(response.text).toContain('error');
+            expect(response.body.error).toBeDefined();
         });
     });
 

--- a/server/handlers/agreements.ts
+++ b/server/handlers/agreements.ts
@@ -7,7 +7,8 @@ import { eq } from 'drizzle-orm';
 import { TemplateArchiveProcessor } from '@accordproject/template-engine';
 import { HttpTemplateRetriever } from './retrievers/HttpTemplateRetriever';
 import { Template as CiceroTemplate } from '@accordproject/cicero-core';
-import { ServiceError, AgreementNotFoundError } from '../services/errors';
+import { AgreementNotFoundError } from '../services/errors';
+import { asyncHandler } from '../middleware/errorHandler';
 
 /**
  * @param db The database handle stored on `res.locals.db`.
@@ -64,8 +65,7 @@ const router = express.Router();
  * resolves and caches a remote template archive when the template URI matches a supported
  * retriever, and finally inserts the agreement into the database.
  */
-router.post('/', async (req, res) => {
-    try {
+router.post('/', asyncHandler(async (req, res) => {
         const db = res.locals.db;
         
         const zodValidation = AgreementInsertSchema.safeParse(req.body);
@@ -119,11 +119,7 @@ router.post('/', async (req, res) => {
 
         const inserted = await db.insert(Agreement).values(insertData).returning();
         res.json(inserted[0]);
-
-    } catch (err: any) {
-        res.status(500).json({ error: "Agreement Instantiation Failed", details: err.message });
-    }
-});
+}));
 
 const crudRouter = buildCrudRouter({
     table: Agreement,
@@ -138,24 +134,12 @@ const crudRouter = buildCrudRouter({
  * @details Resolves the agreement and its template, creates a `TemplateArchiveProcessor`,
  * and delegates the conversion to the template engine's draft support for the requested format.
  */
-crudRouter.get('/:id/convert/:format', async function (req, res) {
-    try {
+crudRouter.get('/:id/convert/:format', asyncHandler(async function (req, res) {
         const {agreement, apTemplate} = await resolveAgreement(res.locals.db, req.params.id);
         const templateArchiveProcessor = new TemplateArchiveProcessor(apTemplate);
         const draftResult = await templateArchiveProcessor.draft(agreement.data, req.params.format, {});
-        console.log(draftResult);
-        res.setHeader("Content-Type", `text/${req.params.format}`);
         res.send(draftResult);
-    } catch (error) {
-        console.log(error);
-        if (error instanceof ServiceError) {
-            res.status(error.statusCode).json(error.toJSON());
-            return;
-        }
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        res.status(500).json({ error: message });
-    }
-});
+}));
 
 /**
  * @param req The Express request containing the agreement id and trigger payload.
@@ -165,14 +149,10 @@ crudRouter.get('/:id/convert/:format', async function (req, res) {
  * initializes agreement state when needed, executes the agreement logic through the
  * template archive processor, and persists the updated agreement state back to the database.
  */
-crudRouter.post('/:id/trigger', async function (req, res) {
-    try {
+crudRouter.post('/:id/trigger', asyncHandler(async function (req, res) {
         const {agreement, apTemplate} = await resolveAgreement(res.locals.db, req.params.id);
         const templateArchiveProcessor = new TemplateArchiveProcessor(apTemplate);
         try {
-            console.log(JSON.stringify(req.body));
-            console.log(JSON.stringify(agreement.data));
-            console.log(JSON.stringify(agreement.state));
 
             const requestSchema = apTemplate.getRequestTypes().find((rt: any) => rt === req.body.$class);
             if (!requestSchema) {
@@ -194,28 +174,20 @@ crudRouter.post('/:id/trigger', async function (req, res) {
             
             const triggerResult = await templateArchiveProcessor.trigger(agreement.data, req.body, agreement.state);
             agreement.state = triggerResult.state;
-            console.log(JSON.stringify(triggerResult));
 
             // Persist updated state.
             await res.locals.db.update(Agreement).set(agreement).where(eq(Agreement.id, Number.parseInt(agreement.id)));
             res.json(triggerResult);
         } catch (err: any) {
-            console.log("\n=== TRIGGER EXECUTION ERROR ===");
-            console.log(err.stack);
-            console.log("===============================\n");
+            console.error({ 
+                type: 'operation_failed', 
+                operation: 'triggerAgreement',
+                agreementId: req.params.id 
+            });
             
             res.json({ isError: true, errorMessage: err.message, errorDetails: err.toString() });
         }
-    } catch (error) {
-        console.log(error);
-        if (error instanceof ServiceError) {
-            res.status(error.statusCode).json(error.toJSON());
-            return;
-        }
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        res.status(500).json({ error: message });
-    }
-});
+}));
 
 router.use('/', crudRouter);
 export default router;

--- a/server/handlers/agreements.ts
+++ b/server/handlers/agreements.ts
@@ -138,6 +138,7 @@ crudRouter.get('/:id/convert/:format', asyncHandler(async function (req, res) {
         const {agreement, apTemplate} = await resolveAgreement(res.locals.db, req.params.id);
         const templateArchiveProcessor = new TemplateArchiveProcessor(apTemplate);
         const draftResult = await templateArchiveProcessor.draft(agreement.data, req.params.format, {});
+        res.setHeader("Content-Type", `text/${req.params.format}`);
         res.send(draftResult);
 }));
 

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -10,6 +10,7 @@ import { count } from 'drizzle-orm';
 // escapeString import removed — it is designed for SQL string values, not
 // identifiers. Column-name safety is enforced by SAFE_IDENTIFIER_RX below.
 // import { getUserRoles } from '../auth0/client';
+import { asyncHandler } from '../middleware/errorHandler';
 
 /**
  * Regex that matches only characters safe for a SQL column identifier.
@@ -294,8 +295,7 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
     // GET with pagination, sorting, and filtering
     router.get('/',
         // authRequiredPermissions('read:' + typeName),
-        async (req: Request, res: Response) => {
-            try {
+        asyncHandler(async (req: Request, res: Response) => {
                 const queryParams = parseQueryParams(req);
                 const { page, limit, sortBy, sortOrder } = queryParams;
                 const whereClause = buildWhereClause ? buildWhereClause(req, queryParams) : 
@@ -314,10 +314,7 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                     logQuery = logQuery.orderBy(orderClause as SQL<unknown>);
                 }
 
-                const sql = logQuery.toSQL();
-                
-                console.log(`[${typeName}] SQL:`, sql.sql);
-                console.log(`[${typeName}] Params:`, sql.params);
+
 
                 // Get total count for pagination
                 const [{ count: total }] = await res.locals.db
@@ -359,18 +356,12 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 }
 
                 res.json(response);
-            } catch (error) {
-                console.log(error);
-                const message = error instanceof Error ? error.message : 'Unknown error';
-                res.status(500).json({ error: message });
-            }
-        });
+        }));
 
     // POST new item
     router.post('/',
         // authRequiredPermissions('write:' + typeName),
-        async (req: Request, res: Response) => {
-            try {
+        asyncHandler(async (req: Request, res: Response) => {
                 if (!req.body) {
                     return res.status(400).json({ error: 'Missing request body' });
                 }
@@ -417,25 +408,12 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 }
 
                 res.json(inserted[0]);
-            } catch (error: any) {
-                // Handle Unique Constraint Violation (Duplicate URI)
-                if (error?.code === '23505') {
-                    return res.status(409).json({
-                        error: 'Conflict',
-                        details: `A resource with this unique identifier already exists for ${typeName}.`
-                    });
-                }
-
-                const message = error instanceof Error ? error.message : 'Unknown error';
-                res.status(500).json({ error: message });
-            }
-        });
+        }));
 
     // GET single item
     router.get('/:id',
         // authRequiredPermissions('read:' + typeName),
-        async (req: Request, res: Response) => {
-            try {
+        asyncHandler(async (req: Request, res: Response) => {
                 const queryParams = parseQueryParams(req);
                 const whereConditions = [
                     // Check if table has UUID primary key
@@ -468,17 +446,12 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 }
 
                 res.json(result[0]);
-            } catch (error) {
-                const message = error instanceof Error ? error.message : 'Unknown error';
-                res.status(500).json({ error: message });
-            }
-        });
+        }));
 
     // PUT update item
     router.put('/:id',
         // authRequiredPermissions('write:' + typeName),
-        async (req: Request, res: Response) => {
-            try {
+        asyncHandler(async (req: Request, res: Response) => {
                 // Add organization to the request body
                 if (!req.body || Object.keys(req.body).length === 0) {
                     return res.status(400).json({
@@ -542,25 +515,12 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                 }
 
                 res.json(updated[0]);
-            } catch (error: any) {
-                // FIXED: Handle Unique Constraint Violation (Duplicate URI during Update)
-                if (error?.code === '23505') {
-                    return res.status(409).json({
-                        error: 'Conflict',
-                        details: `A resource with this unique identifier already exists for ${typeName}.`
-                    });
-                }
-
-                const message = error instanceof Error ? error.message : 'Unknown error';
-                res.status(500).json({ error: message });
-            }
-        });
+        }));
 
     // DELETE item
     router.delete('/:id',
         // authRequiredPermissions('write:' + typeName),
-        async (req: Request, res: Response) => {
-            try {
+        asyncHandler(async (req: Request, res: Response) => {
                 const queryParams = parseQueryParams(req);
                 const whereConditions = [
                     table.id.columnType === 'PgUUID' ? 
@@ -580,11 +540,7 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                     });
                 }
                 res.json({ status: 'deleted' });
-            } catch (error) {
-                const message = error instanceof Error ? error.message : 'Unknown error';
-                res.status(500).json({ error: message });
-            }
-        });
+        }));
 
     return router;
 }

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -398,10 +398,21 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                     req.body = transformRequest(req);
                 }
 
-                const inserted = await res.locals.db
-                    .insert(table)
-                    .values(req.body)
-                    .returning();
+                let inserted;
+                try {
+                    inserted = await res.locals.db
+                        .insert(table)
+                        .values(req.body)
+                        .returning();
+                } catch (error: any) {
+                    if (error?.code === '23505') {
+                        const pgError = new Error('Unique constraint violation') as any;
+                        pgError.code = '23505';
+                        pgError.typeName = typeName;
+                        throw pgError;
+                    }
+                    throw error;
+                }
 
                 if (transformResponse) {
                     inserted[0] = transformResponse(inserted[0]);
@@ -500,11 +511,22 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
                         eq(table.id, parseInt(req.params.id))
                 ].filter(Boolean);
 
-                const updated = await res.locals.db
-                    .update(table)
-                    .set(req.body)
-                    .where(and(...whereConditions))
-                    .returning();
+                let updated;
+                try {
+                    updated = await res.locals.db
+                        .update(table)
+                        .set(req.body)
+                        .where(and(...whereConditions))
+                        .returning();
+                } catch (error: any) {
+                    if (error?.code === '23505') {
+                        const pgError = new Error('Unique constraint violation') as any;
+                        pgError.code = '23505';
+                        pgError.typeName = typeName;
+                        throw pgError;
+                    }
+                    throw error;
+                }
 
                 if (!updated.length) {
                     return res.status(404).json({ error: 'Not found' });

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -143,13 +143,13 @@ export function serviceErrorToResourceError(error: ServiceError): McpError {
  */
 async function getAgreement(uri: string, variables: { agreementId: string }) {
     const { agreementId } = variables;
-    console.log(`Fetching agreement with ID: ${agreementId}`);
+    console.log({ type: 'fetching_agreement', agreementId });
     const url = new URL(uri);
     const requestUrl = `${API_BASE_URL}/agreements/${agreementId}`;
     const result = await makeApiRequest(requestUrl);
     if (result.ok) {
         const agreement = await result.json();
-        console.log(`Successfully fetched agreement: ${JSON.stringify(agreement)}`);
+        console.log({ type: 'fetched_agreement_success', agreementId });
         return {
             contents: [{
                 uri: url.toString(),
@@ -163,7 +163,7 @@ async function getAgreement(uri: string, variables: { agreementId: string }) {
         // Surface the actual status code and API response so the client knows what went wrong
         const body = await result.text().catch(() => 'No error details available');
         const errorMsg = `Failed to load agreement '${agreementId}' (HTTP ${result.status}): ${body}`;
-        console.error(errorMsg);
+        console.error({ type: 'api_error', operation: 'getAgreement', agreementId, status: result.status });
         if (result.status === 404) {
             throw serviceErrorToResourceError(new AgreementNotFoundError(agreementId));
         }
@@ -178,12 +178,12 @@ async function getAgreement(uri: string, variables: { agreementId: string }) {
  * database row into an MCP `contents` entry with an `apap://templates/{id}` URI.
  */
 async function getTemplates(uri: URL) {
-    console.log('getTemplates: ' + uri);
+    console.log({ type: 'get_templates_requested', uri: uri.toString() });
     const requestUrl = `${API_BASE_URL}/templates`;
     const result = await makeApiRequest(requestUrl);
     if (result.ok) {
         const templates = await result.json();
-        console.log(`Successfully fetched templates: ${JSON.stringify(templates)}`);
+        console.log({ type: 'fetched_templates_success', count: templates.items?.length });
         return {
             contents: templates.items.map((t: typeof Template) => {
                 return {
@@ -198,7 +198,7 @@ async function getTemplates(uri: URL) {
     else {
         // Previously just threw "Failed to load template" with no status or details
         const body = await result.text().catch(() => 'No error details available');
-        console.error(`Failed to load templates (HTTP ${result.status}): ${body}`);
+        console.error({ type: 'api_error', operation: 'getTemplates', status: result.status });
         throw serviceErrorToResourceError(new UpstreamApiError(requestUrl, result.status, body));
     }
 }
@@ -210,12 +210,12 @@ async function getTemplates(uri: URL) {
  * each item into the MCP resource format expected by agreement resources.
  */
 async function getAgreements(uri: URL) {
-    console.log('getAgreements: ' + uri);
+    console.log({ type: 'get_agreements_requested', uri: uri.toString() });
     const requestUrl = `${API_BASE_URL}/agreements`;
     const result = await makeApiRequest(requestUrl);
     if (result.ok) {
         const agreements = await result.json();
-        console.log(`Successfully fetched agreements: ${JSON.stringify(agreements)}`);
+        console.log({ type: 'fetched_agreements_success', count: agreements.items?.length });
         return {
             // FIX for issue #128: The previous version spread the full agreement object
             // (...a) after setting the uri field. Because the Agreement row from the
@@ -240,7 +240,7 @@ async function getAgreements(uri: URL) {
     }
     else {
         const body = await result.text().catch(() => 'No error details available');
-        console.error(`Failed to load agreements (HTTP ${result.status}): ${body}`);
+        console.error({ type: 'api_error', operation: 'getAgreements', status: result.status });
         throw serviceErrorToResourceError(new UpstreamApiError(requestUrl, result.status, body));
     }
 }
@@ -253,7 +253,7 @@ async function getAgreements(uri: URL) {
  * raw text body so it can be forwarded directly to the MCP client.
  */
 async function draftAgreement(agreementId: string, format: string) : Promise<string> {
-    console.log('draftAgreement: ' + agreementId);
+    console.log({ type: 'draft_agreement_requested', agreementId });
     const result = await makeApiRequest(`${API_BASE_URL}/agreements/${agreementId}/convert/${format}`);
     if (result.ok) {
         const text = await result.text();
@@ -262,7 +262,7 @@ async function draftAgreement(agreementId: string, format: string) : Promise<str
     else {
         // Include the agreement ID and target format so the caller knows exactly which conversion failed
         const errorMsg = await buildApiErrorMessage(result, `Failed to convert agreement '${agreementId}' to ${format}`);
-        console.error(errorMsg);
+        console.error({ type: 'api_error', operation: 'draftAgreement', agreementId, format, status: result.status });
         if (result.status === 404) {
             throw new AgreementNotFoundError(agreementId);
         }
@@ -278,8 +278,7 @@ async function draftAgreement(agreementId: string, format: string) : Promise<str
  * agreement logic to execute, and forwards the JSON response back to the MCP layer.
  */
 async function triggerAgreement(agreementId: string, body: string) : Promise<string> {
-    console.log('triggerAgreement: ' + agreementId);
-    console.log('body: ' + body);
+    console.log({ type: 'trigger_agreement_requested', agreementId });
     const headers = new Headers();
     headers.append("Content-Type", "application/json");
     const result = await makeApiRequest(`${API_BASE_URL}/agreements/${agreementId}/trigger`,
@@ -296,7 +295,7 @@ async function triggerAgreement(agreementId: string, body: string) : Promise<str
         // Trigger failures are especially important to surface clearly since they often
         // come from bad payload shapes that don't match the template's request type
         const body = await result.text().catch(() => 'No error details available');
-        console.error(`Failed to trigger agreement '${agreementId}' (HTTP ${result.status}): ${body}`);
+        console.error({ type: 'api_error', operation: 'triggerAgreement', agreementId, status: result.status });
         if (result.status === 404) {
             throw new AgreementNotFoundError(agreementId);
         }
@@ -360,7 +359,7 @@ const getServer = () => {
                     // List operations return empty rather than throwing, but we still log
                     // the actual error for debugging
                     const errorMsg = await buildApiErrorMessage(result, 'Failed to list agreements');
-                    console.error(errorMsg);
+                    console.error({ type: 'api_error', operation: 'listAgreements', status: result.status });
                     return { resources: [] };
                 }
             }
@@ -391,7 +390,7 @@ const getServer = () => {
                 }
                 else {
                     const errorMsg = await buildApiErrorMessage(result, 'Failed to list templates');
-                    console.error(errorMsg);
+                    console.error({ type: 'api_error', operation: 'listTemplates', status: result.status });
                     return { resources: [] };
                 }
             }
@@ -413,7 +412,7 @@ const getServer = () => {
             }
             else {
                 const body = await result.text().catch(() => 'No error details available');
-                console.error(`Failed to load template '${templateId}' (HTTP ${result.status}): ${body}`);
+                console.error({ type: 'api_error', operation: 'getTemplate', templateId, status: result.status });
                 if (result.status === 404) {
                     throw serviceErrorToResourceError(new TemplateNotFoundError(templateId));
                 }
@@ -487,7 +486,7 @@ Refer to the agreement's template model to determine which fields are required o
                 };
             } else {
                 const body = await result.text().catch(() => 'No error details available');
-                console.error(`Failed to load template '${templateId}' (HTTP ${result.status}): ${body}`);
+                console.error({ type: 'api_error', operation: 'getTemplateTool', templateId, status: result.status });
                 if (result.status === 404) {
                     return serviceErrorToCallToolResult(new TemplateNotFoundError(templateId));
                 }
@@ -519,7 +518,7 @@ Refer to the agreement's template model to determine which fields are required o
                 };
             } else {
                 const body = await result.text().catch(() => 'No error details available');
-                console.error(`Failed to load agreement '${agreementId}' (HTTP ${result.status}): ${body}`);
+                console.error({ type: 'api_error', operation: 'getAgreementTool', agreementId, status: result.status });
                 if (result.status === 404) {
                     return serviceErrorToCallToolResult(new AgreementNotFoundError(agreementId));
                 }
@@ -574,7 +573,7 @@ export function startSessionCleanup(): void {
                     try {
                         transport.close?.();
                     } catch (err) {
-                        console.error('Error closing transport during cleanup:', err);
+                        console.error({ type: 'transport_close_error', sessionId, error: err instanceof Error ? err.message : String(err) });
                     }
                 }
                 delete transports[sessionId];
@@ -637,7 +636,7 @@ router.all('/mcp', async (req: Request, res: Response) => {
                 eventStore, // Enable resumability
                 onsessioninitialized: (sessionId) => {
                     // Store the transport by session ID when session is initialized
-                    console.log(`StreamableHTTP session initialized with ID: ${sessionId}`);
+                    console.log({ type: 'streamable_http_session_initialized', sessionId });
                     transports[sessionId] = transport;
                     sessionLastActivity[sessionId] = Date.now();
                 }
@@ -658,9 +657,9 @@ router.all('/mcp', async (req: Request, res: Response) => {
             // Connect the transport to the MCP server
             const server = getServer();
             await server.connect(transport);
-            console.log('Connected server to transport');
+            console.log({ type: 'connected_server_to_transport' });
         } else {
-            console.log('Invalid request');
+            console.log({ type: 'invalid_mcp_request' });
             // Invalid request - no session ID or not initialization request
             res.status(400).json({
                 jsonrpc: '2.0',
@@ -675,9 +674,9 @@ router.all('/mcp', async (req: Request, res: Response) => {
 
         // Handle the request with the transport
         await transport.handleRequest(req, res, req.body);
-        console.log('Transport handled request');
+        console.log({ type: 'transport_handled_request' });
     } catch (error) {
-        console.error('Error handling MCP request:', error);
+        console.error({ type: 'mcp_request_failed', error: error instanceof Error ? error.message : String(error) });
         if (!res.headersSent) {
             res.status(500).json({
                 jsonrpc: '2.0',

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response } from 'express';
+import { asyncHandler } from '../middleware/errorHandler';
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from 'zod';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
@@ -601,8 +602,8 @@ const router = express.Router();
  * a new transport during MCP initialization requests, and rejects invalid session usage.
  */
 router.all('/mcp', async (req: Request, res: Response) => {
-    console.log(`Received ${req.method} request to /mcp`);
-    console.log(JSON.stringify(req.body, null, 2));
+    // Structured log without PII
+    console.log({ type: 'mcp_request', method: req.method, path: '/mcp' });
 
     try {
         // Check for existing session ID
@@ -701,8 +702,7 @@ router.all('/mcp', async (req: Request, res: Response) => {
  * @details Creates a legacy `SSEServerTransport`, stores it by session id, and
  * removes it again when the HTTP connection closes.
  */
-router.get('/sse', async (req: Request, res: Response) => {
-    console.log('Received GET request to /sse (deprecated SSE transport)');
+router.get('/sse', asyncHandler(async (req: Request, res: Response) => {
     const transport = new SSEServerTransport('/messages', res);
     transports[transport.sessionId] = transport;
     res.on("close", () => {
@@ -711,7 +711,7 @@ router.get('/sse', async (req: Request, res: Response) => {
     });
     const server = getServer();
     await server.connect(transport);
-});
+}));
 
 /**
  * @param req The incoming Express request carrying a legacy SSE message.
@@ -721,7 +721,7 @@ router.get('/sse', async (req: Request, res: Response) => {
  * @details Looks up the existing SSE transport by `sessionId`, verifies that the
  * session belongs to the legacy transport type, and forwards the posted MCP message.
  */
-router.post("/messages", async (req: Request, res: Response) => {
+router.post("/messages", asyncHandler(async (req: Request, res: Response) => {
     const sessionId = req.query.sessionId as string;
     let transport: SSEServerTransport;
     const existingTransport = transports[sessionId];
@@ -745,6 +745,6 @@ router.post("/messages", async (req: Request, res: Response) => {
     } else {
         res.status(400).send('No transport found for sessionId');
     }
-});
+}));
 
 export default router;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
 import 'source-map-support/register';
+import { globalErrorHandler } from './middleware/errorHandler';
 import Express from 'express';
 import morgan from 'morgan';
 import path from 'path';
@@ -71,6 +72,9 @@ startSessionCleanup();
 
 // logging
 app.use(morgan('combined'));
+
+// Global error handler — registered AFTER all routes
+app.use(globalErrorHandler);
 
 const HOST = process.env.HOST || 'localhost';
 const PORT = parseInt(process.env.PORT || '9000', 10);

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -53,7 +53,7 @@ export function globalErrorHandler(
     if (typeof err === 'object' && err !== null && 'code' in err && (err as any).code === '23505') {
         res.status(409).json({
             error: 'Conflict',
-            details: 'A resource with this unique identifier already exists.'
+            details: `A resource with this unique identifier already exists${(err as any).typeName ? ` for ${(err as any).typeName}` : ''}.`
         });
         return;
     }

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -1,0 +1,97 @@
+import { Request, Response, NextFunction } from 'express';
+import { ServiceError } from '../services/errors';
+
+/**
+ * Normalizes an unknown caught value into a safe, 
+ * non-leaking error message string.
+ * Never exposes raw stack traces or internal paths 
+ * to the client.
+ */
+function toSafeMessage(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    if (typeof err === 'string') return err;
+    return 'An unexpected error occurred';
+}
+
+/**
+ * Global Express error handling middleware.
+ * Replaces the 20+ duplicate try/catch -> res.status(500) 
+ * patterns across agreements.ts, crud.ts, and mcp.ts.
+ * 
+ * Usage: app.use(globalErrorHandler) after all routes.
+ * 
+ * @param err - The error passed via next(err)
+ * @param req - Express Request
+ * @param res - Express Response
+ * @param next - Express NextFunction (required for Express to 
+ *               recognize this as error middleware)
+ */
+export function globalErrorHandler(
+    err: unknown,
+    req: Request,
+    res: Response,
+    next: NextFunction
+): void {
+    // Log structured error internally — never expose 
+    // stack traces to client
+    console.error({
+        type: 'unhandled_error',
+        method: req.method,
+        path: req.path,
+        message: toSafeMessage(err),
+        // Only log stack in development
+        ...(process.env.NODE_ENV === 'development' && {
+            stack: err instanceof Error ? err.stack : undefined
+        })
+    });
+
+    if (res.headersSent) {
+        return next(err);
+    }
+
+    // Handle Postgres unique constraint violation
+    if (typeof err === 'object' && err !== null && 'code' in err && (err as any).code === '23505') {
+        res.status(409).json({
+            error: 'Conflict',
+            details: 'A resource with this unique identifier already exists.'
+        });
+        return;
+    }
+
+    if (err instanceof ServiceError) {
+        res.status(err.statusCode).json(err.toJSON());
+        return;
+    }
+
+    // Handle Express middleware errors (like malformed JSON)
+    const statusCode = (typeof err === 'object' && err !== null && 'status' in err && typeof (err as any).status === 'number') 
+        ? (err as any).status 
+        : 500;
+
+    res.status(statusCode).json({
+        error: toSafeMessage(err)
+    });
+}
+
+/**
+ * Wraps an async Express route handler to automatically 
+ * forward any thrown errors to next(err), so they reach
+ * globalErrorHandler without needing try/catch in every route.
+ * 
+ * @param fn - The async route handler to wrap
+ * @returns A wrapped handler that calls next(err) on failure
+ * 
+ * @example
+ * router.get('/:id', asyncHandler(async (req, res) => {
+ *     const item = await db.find(req.params.id);
+ *     res.json(item);
+ * }));
+ */
+export function asyncHandler(
+    fn: (req: Request, res: Response, next: NextFunction) 
+        => Promise<unknown>
+) {
+    return (req: Request, res: Response, next: NextFunction) => {
+        Promise.resolve(fn(req, res, next)).catch(next);
+    };
+}


### PR DESCRIPTION
## Summary
The same try/catch → console.log → res.status(500) pattern 
was duplicated 20+ times across agreements.ts, crud.ts, 
and mcp.ts. Several console.log statements also exposed 
PII and internal details to stdout. This PR centralizes 
error handling into a single Express error middleware.

## What this PR does

### New file — server/middleware/errorHandler.ts
- globalErrorHandler — single centralized error response 
  location, replaces 20+ duplicate catch blocks
- asyncHandler — wraps async route handlers to forward 
  errors via next() without try/catch in every route
- toSafeMessage — prevents stack traces and internal 
  paths from leaking to API clients

### Refactor — agreements.ts
- Wrapped async route handlers with asyncHandler
- Removed duplicate try/catch blocks
- Removed console.log statements exposing:
  * req.body (user PII)
  * agreement.data and agreement.state (contract data)
  * err.stack (internal stack traces)

### Refactor — crud.ts
- Wrapped async route handlers with asyncHandler
- Removed duplicate try/catch blocks
- Removed console.log(sql.sql) and console.log(sql.params)
  which leaked raw SQL query structure to stdout

### Refactor — mcp.ts
- Removed console.log(req.body) on every MCP POST request
- Replaced with structured console.error using 
  non-sensitive context only

## Why this matters

### Security
Raw contract data, SQL queries, and stack traces were 
being logged to stdout. In any hosted environment these 
appear in server logs accessible to operators and 
potentially leaked in log aggregation tools.

### Maintainability
20+ identical catch blocks meant any change to error 
handling required editing every handler file. Now 
there is one place to update.

### Reliability
asyncHandler ensures unhandled promise rejections in 
route handlers are always caught and forwarded to 
Express error handling — preventing silent process 
crashes in Node.js.

## References
- Closes #191
- Coordinates with #184 — middleware honours ServiceError statusCode and toJSON() shape introduced there.

## Author Checklist
- [x] DCO sign-off provided
- [x] New middleware file with JSDoc
- [x] All existing tests passing
- [x] TypeScript compilation verified (npx tsc --noEmit)
- [x] ServiceError instances return typed status codes and structured body via #184 integration
