### PR TITLE
test(mcp): add contract tests for buildApiErrorMessage helper

### DIFF
--- a/server/handlers/mcp.test.ts
+++ b/server/handlers/mcp.test.ts
@@ -1,0 +1,119 @@
+import { buildApiErrorMessage } from './mcp';
+
+// Helper to create a mock failed Response. Only the fields buildApiErrorMessage
+// actually reads (ok, status, text) need to be present; the cast is safe because
+// the function never touches the rest of the Response surface.
+function mockFailedResponse(status: number, body: string): globalThis.Response {
+    return {
+        ok: false,
+        status,
+        text: async () => body,
+        json: async () => JSON.parse(body),
+    } as unknown as globalThis.Response;
+}
+
+describe('MCP Error Handling - buildApiErrorMessage', () => {
+
+    it('should include HTTP 404 status when a resource is not found', async () => {
+        const result = mockFailedResponse(404, '{"error": "Template not found"}');
+        const msg = await buildApiErrorMessage(result, "Failed to load template 'late-delivery'");
+
+        expect(msg).toContain('HTTP 404');
+        expect(msg).toContain("Failed to load template 'late-delivery'");
+        expect(msg).toContain('Template not found');
+    });
+
+    it('should include HTTP 400 status for validation errors', async () => {
+        const result = mockFailedResponse(400, '{"error": "Invalid Concerto model"}');
+        const msg = await buildApiErrorMessage(result, 'Failed to trigger agreement');
+
+        expect(msg).toContain('HTTP 400');
+        expect(msg).toContain('Invalid Concerto model');
+    });
+
+    it('should include HTTP 500 status for server errors', async () => {
+        const result = mockFailedResponse(500, 'Internal Server Error');
+        const msg = await buildApiErrorMessage(result, 'Failed to load agreements');
+
+        expect(msg).toContain('HTTP 500');
+        expect(msg).toContain('Internal Server Error');
+    });
+
+    it('should handle response body read failure gracefully', async () => {
+        const result = {
+            ok: false,
+            status: 502,
+            // Simulate a body that can't be read (stream already consumed, network error, etc.)
+            text: async () => { throw new Error('body stream already read'); },
+        } as unknown as globalThis.Response;
+        const msg = await buildApiErrorMessage(result, 'Failed to convert agreement');
+
+        expect(msg).toContain('HTTP 502');
+        expect(msg).toContain('No error details available');
+    });
+
+    it('should preserve resource identifiers in error context', async () => {
+        const result = mockFailedResponse(404, 'Not found');
+        const msg = await buildApiErrorMessage(result, "Failed to load agreement 'agreement-abc-123'");
+
+        expect(msg).toContain('agreement-abc-123');
+        expect(msg).toContain('HTTP 404');
+    });
+
+    it('should include format info for conversion failures', async () => {
+        const result = mockFailedResponse(422, '{"error": "Unsupported output format"}');
+        const msg = await buildApiErrorMessage(result, "Failed to convert agreement 'agr-1' to pdf");
+
+        expect(msg).toContain('agr-1');
+        expect(msg).toContain('pdf');
+        expect(msg).toContain('HTTP 422');
+    });
+});
+
+describe('MCP Error Handling - error distinctness', () => {
+
+    // The whole point of this fix: a 404, 400, and 500 should produce
+    // different error messages so an MCP client can tell them apart
+    it('should produce different messages for 404 vs 400 vs 500', async () => {
+        const ctx = 'Failed to load template';
+
+        const msg404 = await buildApiErrorMessage(
+            mockFailedResponse(404, 'Not found'), ctx
+        );
+        const msg400 = await buildApiErrorMessage(
+            mockFailedResponse(400, 'Validation failed'), ctx
+        );
+        const msg500 = await buildApiErrorMessage(
+            mockFailedResponse(500, 'Internal error'), ctx
+        );
+
+        // All three must be distinct strings
+        expect(msg404).not.toEqual(msg400);
+        expect(msg400).not.toEqual(msg500);
+        expect(msg404).not.toEqual(msg500);
+
+        // Each contains its own status code
+        expect(msg404).toContain('404');
+        expect(msg400).toContain('400');
+        expect(msg500).toContain('500');
+    });
+
+    // Make sure we didn't accidentally break the original context message
+    it('should always start with the context string', async () => {
+        const contexts = [
+            "Failed to load template 'my-template'",
+            "Failed to load agreement 'my-agreement'",
+            "Failed to trigger agreement 'agr-99'",
+            "Failed to convert agreement 'agr-1' to html",
+            'Failed to load templates',
+            'Failed to load agreements',
+        ];
+
+        for (const ctx of contexts) {
+            const msg = await buildApiErrorMessage(
+                mockFailedResponse(500, 'error'), ctx
+            );
+            expect(msg.startsWith(ctx)).toBe(true);
+        }
+    });
+});

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -41,7 +41,7 @@ async function makeApiRequest(url: string, options: RequestInit = {}) {
 // Builds a meaningful error message from a failed API response so that MCP clients
 // can tell apart a 404 (resource missing) from a 400 (bad input) or a 500 (server issue).
 // Without this, every failure just says "Failed to load ..." which is impossible to debug.
-async function buildApiErrorMessage(result: globalThis.Response, context: string): Promise<string> {
+export async function buildApiErrorMessage(result: globalThis.Response, context: string): Promise<string> {
     const body = await result.text().catch(() => 'No error details available');
     return `${context} (HTTP ${result.status}): ${body}`;
 }


### PR DESCRIPTION
The clean test-only follow-up to #155 (which merged Jun 13). Adds eight contract tests for the `buildApiErrorMessage` helper, plus a one-line `export` on the helper itself so the tests can import it rather than re-declare it.

This is the PR that was discussed as the replacement for the now-closed #153. The original #153 bundled the helper + error-path rewrites + the test file together; #155 took the helper and the rewrites, this PR takes the tests cleanly on top.

## What the tests cover

Two `describe` blocks, eight cases:

**`buildApiErrorMessage` itself:**
- HTTP 404, 400, 500, 422 status codes surface in the returned message
- Resource identifiers (`'late-delivery'`, `'agreement-abc-123'`, `'agr-1'`, format names like `'pdf'`) are preserved in the error context
- Body-read failures (stream already consumed, network error mid-read) degrade gracefully to `"No error details available"` instead of throwing

**Error distinctness (the original motivation):**
- A 404, 400, and 500 produce three distinct messages so MCP clients can tell them apart
- Every message starts with the context string passed by the caller

## Why the `export` change

The helper was added to `mcp.ts` as a module-local function in #155. This PR adds `export` to its declaration (one line) so `mcp.test.ts` can import it directly rather than re-declaring its logic, which was the coordination concern Niall and I discussed when planning to split #153.

## Diff

```
server/handlers/mcp.ts      |   2 +-      (export keyword)
server/handlers/mcp.test.ts | 118 +++++   (new test file)
```

## Coordination notes

- Doesn't conflict with @Satvik77777's #189 (his test file uses InMemoryTransport for tool-registration tests; mine covers the helper). If #189 merges first, this PR will simply have a more populated `mcp.test.ts` to coexist with; happy to rebase.
- Full server suite: 61/61 passing.

Closes #152 (jointly with merged #155).
