### PR TITLE
feat(server): slice 2 typed errors (agreements + templatebuilder)

### DIFF
--- a/server/handlers/agreements.test.ts
+++ b/server/handlers/agreements.test.ts
@@ -324,7 +324,7 @@ describe('Agreements Router - POST /:id/trigger', () => {
             });
         });
 
-        it('should return 500 when template referenced by agreement does not exist', async () => {
+        it('should return 404 with TEMPLATE_NOT_FOUND when template referenced by agreement does not exist', async () => {
             const mockAgreementData = {
                 id: 1,
                 template: 'test://template/nonexistent'
@@ -338,10 +338,14 @@ describe('Agreements Router - POST /:id/trigger', () => {
             const response = await request(app)
                 .post('/agreements/1/trigger')
                 .send({})
-                .expect(500);
+                .expect(404);
 
             expect(response.body).toEqual({
-                error: 'Template with uri test://template/nonexistent referenced by agreement 1 does not exist'
+                error: {
+                    code: 'TEMPLATE_NOT_FOUND',
+                    message: 'Template not found: test://template/nonexistent',
+                    details: { identifier: 'test://template/nonexistent' },
+                },
             });
         });
 

--- a/server/handlers/agreements.ts
+++ b/server/handlers/agreements.ts
@@ -7,7 +7,7 @@ import { eq } from 'drizzle-orm';
 import { TemplateArchiveProcessor } from '@accordproject/template-engine';
 import { HttpTemplateRetriever } from './retrievers/HttpTemplateRetriever';
 import { Template as CiceroTemplate } from '@accordproject/cicero-core';
-import { ServiceError, AgreementNotFoundError } from '../services/errors';
+import { ServiceError, AgreementNotFoundError, TemplateNotFoundError, InvalidPayloadError } from '../services/errors';
 
 /**
  * @param db The database handle stored on `res.locals.db`.
@@ -36,7 +36,7 @@ async function resolveAgreement(db: any, agreementId: string) {
             apTemplate = await templateFromDatabase(templateRow);
             return { agreement, template: templateRow, apTemplate };
         }
-        throw new Error(`Cached template missing from database.`);
+        throw new TemplateNotFoundError(`cached hash ${agreement.templateHash}`);
     }
 
     let templateUri = agreement.template;
@@ -46,7 +46,7 @@ async function resolveAgreement(db: any, agreementId: string) {
 
     const result2 = await db.select().from(DbTemplate).where(eq(DbTemplate.uri, templateUri)).limit(1);
     if (!result2.length) {
-        throw new Error(`Template with uri ${templateUri} referenced by agreement ${agreementId} does not exist`);
+        throw new TemplateNotFoundError(templateUri);
     }
     templateRow = result2[0];
     apTemplate = await templateFromDatabase(templateRow);
@@ -174,9 +174,13 @@ crudRouter.post('/:id/trigger', async function (req, res) {
             console.log(JSON.stringify(agreement.data));
             console.log(JSON.stringify(agreement.state));
 
-            const requestSchema = apTemplate.getRequestTypes().find((rt: any) => rt === req.body.$class);
+            const expectedTypes = apTemplate.getRequestTypes();
+            const requestSchema = expectedTypes.find((rt: any) => rt === req.body.$class);
             if (!requestSchema) {
-                throw new Error(`Invalid request type: ${req.body.$class}. Expected one of: ${apTemplate.getRequestTypes().join(', ')}`);
+                throw new InvalidPayloadError(
+                    `Invalid request type: ${req.body.$class}. Expected one of: ${expectedTypes.join(', ')}`,
+                    { received: req.body.$class, expected: expectedTypes },
+                );
             }
             
             const { success, error } = await concertoValidation(req.body.$class, req.body, apTemplate.getModelManager());

--- a/server/handlers/templatebuilder.ts
+++ b/server/handlers/templatebuilder.ts
@@ -1,6 +1,7 @@
 import { Template as ApTemplate } from '@accordproject/cicero-core';
 import AdmZip from "adm-zip";
 import { Template } from '../db/schema';
+import { InvalidPayloadError } from '../services/errors';
 
 interface ApModelFile {
     getNamespace?(): string;
@@ -78,7 +79,10 @@ export async function templateFromDatabase(db: typeof Template | any): Promise<A
             }
         });
     } else {
-        throw new Error('Model type is not supported');
+        throw new InvalidPayloadError('Model type is not supported', {
+            received: domainModel.$class,
+            expected: 'org.accordproject.protocol@1.0.0.CtoModel',
+        });
     }
 
     const logic: Record<string, any> = db.logic;


### PR DESCRIPTION
Follow-up to #184 per @niallroche's "two updates per PR" guidance and @mttrbrts's "the other handlers can come later" approval comment.

Converts the remaining bare `throw new Error()` patterns in the agreements flow to typed `ServiceError` subclasses. Marked draft because slice 3 (mcp.ts) will land separately once @Satvik77777's overlapping PRs (#189, #192, #194) settle.

## What's wired

**`agreements.ts`** (`resolveAgreement`):
- "Cached template missing from database" → `TemplateNotFoundError` with `cached hash {hash}` as the identifier
- "Template with URI X referenced by agreement Y does not exist" → `TemplateNotFoundError(templateUri)`

A missing template now surfaces as **404 with structured body** instead of a bare 500.

**`agreements.ts`** (trigger handler):
- "Invalid request type: X. Expected one of: Y" → `InvalidPayloadError` with `received` and `expected` in details

MCP clients can now distinguish a bad `$class` from other failure modes.

**`templatebuilder.ts`** (`templateFromDatabase`):
- "Model type is not supported" → `InvalidPayloadError` with `received` and `expected` `$class` in details

This is the helper every agreement-resolution path calls; the typed error propagates to whichever route triggered it.

## Demo

Before:
```
POST /agreements/1/trigger (template URI broken)
HTTP 500  {"error":"Template with uri test://... referenced by agreement 1 does not exist"}
```

After:
```
POST /agreements/1/trigger (template URI broken)
HTTP 404  {
  "error": {
    "code": "TEMPLATE_NOT_FOUND",
    "message": "Template not found: test://...",
    "details": { "identifier": "test://..." }
  }
}
```

## Tests

- `agreements.test.ts`: the existing "should return 500 when template referenced by agreement does not exist" test is updated to assert the new 404 + structured body (that test was itself encoding the old bug, same pattern as the slice 1 update for "agreement not found").
- Full server suite: **64/64 passing**.

## Out of scope (slice 3)

The eight `throw new Error(errorMsg)` calls in `mcp.ts` are deliberately left for slice 3, since `mcp.ts` is also touched by @Satvik77777's open #189, #192, and #194. Once those merge (or the architecture in #192 settles), slice 3 will wire mcp.ts to ServiceError on top of whatever shape mcp.ts ends up in.

cc @mttrbrts @niallroche