### PR TITLE
feat(mcp): add ttlMs + cacheScope to ReadResource contents (SEP-2549)

### DIFF
--- a/server/handlers/mcp.test.ts
+++ b/server/handlers/mcp.test.ts
@@ -5,6 +5,7 @@ import {
     buildApiErrorMessage,
     PROTOCOL_CTO,
     SERVER_INSTRUCTIONS,
+    CACHE_HINTS,
 } from './mcp';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import {
@@ -226,5 +227,76 @@ describe('Concerto typed-context (instructions + schema resource)', () => {
         it('decodes the embedded MODEL constant to the Concerto source', () => {
             expect(PROTOCOL_CTO).toContain('namespace org.accordproject.protocol');
         });
+    });
+});
+
+// SEP-2549 ("CacheableResult", MCP 2026-07-28 RC) extends MCP
+// ReadResourceResult.contents[] with `ttlMs` (number, milliseconds) and
+// `cacheScope` ('public' | 'private') so caching proxies can honor per-resource
+// freshness without inferring from URI patterns. See:
+//   https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate
+//
+// These tests pin the per-resource defaults that the MCP handler spreads into
+// every contents[] entry it returns. Changing a value here is a wire-format
+// change visible to every MCP client, so the defaults are codified explicitly
+// rather than computed from a config file.
+describe('SEP-2549 cache hints exposed by the MCP handler', () => {
+    it('exports a CACHE_HINTS table keyed by resource kind', () => {
+        // Five resource shapes are registered in mcp.ts: the template list,
+        // single templates, the agreement list, single agreements, and the
+        // bundled Concerto schema resource (apap://schema/protocol.cto).
+        expect(Object.keys(CACHE_HINTS).sort()).toEqual([
+            'agreementItem',
+            'agreementList',
+            'schema',
+            'templateItem',
+            'templateList',
+        ]);
+    });
+
+    it('uses short private cache for the template list', () => {
+        // Lists turn over whenever a new template is uploaded, and the visible
+        // set may vary per-tenant once auth is wired in. 60s + private keeps a
+        // single client snappy without leaking other tenants' rows through a
+        // shared cache.
+        expect(CACHE_HINTS.templateList.ttlMs).toBe(60_000);
+        expect(CACHE_HINTS.templateList.cacheScope).toBe('private');
+    });
+
+    it('uses medium public cache for a single template', () => {
+        // Single-template rows are addressed by id and the underlying .cta is
+        // pinned by hash, so a 5min public TTL is safe across tenants until the
+        // row itself gets a hash-based URI (the larger refactor tracked
+        // separately).
+        expect(CACHE_HINTS.templateItem.ttlMs).toBe(300_000);
+        expect(CACHE_HINTS.templateItem.cacheScope).toBe('public');
+    });
+
+    it('uses short private cache for agreement list and single agreements', () => {
+        // Agreements mutate on every trigger call, so freshness matters more
+        // than reuse. Private scope avoids cross-tenant leakage once auth lands.
+        expect(CACHE_HINTS.agreementList.ttlMs).toBe(30_000);
+        expect(CACHE_HINTS.agreementList.cacheScope).toBe('private');
+        expect(CACHE_HINTS.agreementItem.ttlMs).toBe(30_000);
+        expect(CACHE_HINTS.agreementItem.cacheScope).toBe('private');
+    });
+
+    it('uses long public cache for the bundled Concerto schema resource', () => {
+        // The Concerto model ships with the build via the base64 MODEL constant
+        // in db/schema.ts, so it is identical for every tenant and only turns
+        // over on redeploy. 24h public is safe and lets caching proxies serve
+        // the schema aggressively.
+        expect(CACHE_HINTS.schema.ttlMs).toBe(86_400_000);
+        expect(CACHE_HINTS.schema.cacheScope).toBe('public');
+    });
+
+    it('uses only the SEP-2549 cacheScope vocabulary', () => {
+        // Guard against typos creeping in (e.g. "user", "shared"); the spec
+        // currently defines only two values.
+        for (const hint of Object.values(CACHE_HINTS)) {
+            expect(['public', 'private']).toContain(hint.cacheScope);
+            expect(Number.isFinite(hint.ttlMs)).toBe(true);
+            expect(hint.ttlMs).toBeGreaterThan(0);
+        }
     });
 });

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -23,6 +23,29 @@ const API_BASE_URL = process.env.API_BASE_URL || `http://${HOST}:${PORT}`
 // Get API authorization header from environment variable (optional)
 const API_AUTH_HEADER = process.env.APAP_API_AUTH_HEADER;
 
+// Forward-looking cache hints for MCP `ReadResourceResult.contents[]`, mirroring
+// the shape proposed in SEP-2549 ("CacheableResult") in the MCP 2026-07-28 RC:
+//   https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate
+// Defaults are chosen by mutability of each resource: lists are volatile and
+// per-client (private), single templates are hash-immutable (public, 5min),
+// single agreements are short-lived because the row can be triggered/updated,
+// and the bundled Concerto schema is immutable per deploy (public, 24h).
+// Both fields are emitted alongside `uri`/`mimeType`/`text` so the SEP wire
+// shape lands as-is once the SDK accepts them at the top level; the current
+// SDK's request/response path is pass-through (no schema strip), so caching
+// proxies see them today as forward-compatible hints. The SDK types are
+// augmented in ../types/mcp-augmentation.d.ts so the spread typechecks
+// without per-callsite casts.
+type CacheScope = 'public' | 'private';
+interface CacheHint { ttlMs: number; cacheScope: CacheScope }
+export const CACHE_HINTS = {
+    templateList:   { ttlMs:     60_000, cacheScope: 'private' } as CacheHint,
+    templateItem:   { ttlMs:    300_000, cacheScope: 'public'  } as CacheHint,
+    agreementList:  { ttlMs:     30_000, cacheScope: 'private' } as CacheHint,
+    agreementItem:  { ttlMs:     30_000, cacheScope: 'private' } as CacheHint,
+    schema:         { ttlMs: 86_400_000, cacheScope: 'public'  } as CacheHint,
+} as const;
+
 // Concerto typed-context hint, exposed via MCP `InitializeResult.instructions`
 // and as a readable schema resource. Tells the client (and any LLM behind it)
 // that response payloads are Concerto-serialized so `$class` discriminators
@@ -130,7 +153,8 @@ async function getAgreement(uri: string, variables: { agreementId: string }) {
             contents: [{
                 uri: url.toString(),
                 mimeType: "application/json",
-                text: JSON.stringify(agreement)
+                text: JSON.stringify(agreement),
+                ...CACHE_HINTS.agreementItem,
             }]
         };
     }
@@ -164,7 +188,8 @@ async function getTemplates(uri: URL) {
                 return {
                     uri: `apap://templates/${t.id}`,
                     mimeType: "application/json",
-                    text: JSON.stringify(t)
+                    text: JSON.stringify(t),
+                    ...CACHE_HINTS.templateList,
                 }
             })
         }
@@ -206,7 +231,8 @@ async function getAgreements(uri: URL) {
                 return {
                     mimeType: "application/json",
                     text: JSON.stringify({ ...a.data, $identifier: a.id }, null, 2),
-                    uri: `apap://agreements/${a.id}`
+                    uri: `apap://agreements/${a.id}`,
+                    ...CACHE_HINTS.agreementList,
                 }
             })
         }
@@ -300,6 +326,7 @@ const getServer = () => {
                 uri: uri.toString(),
                 mimeType: "text/x-concerto",
                 text: PROTOCOL_CTO,
+                ...CACHE_HINTS.schema,
             }],
         }),
     );
@@ -378,7 +405,8 @@ const getServer = () => {
                     contents: [{
                         uri: uri.toString(),
                         mimeType: "application/json",
-                        text: JSON.stringify(template)
+                        text: JSON.stringify(template),
+                        ...CACHE_HINTS.templateItem,
                     }]
                 };
             }

--- a/server/types/mcp-augmentation.d.ts
+++ b/server/types/mcp-augmentation.d.ts
@@ -1,0 +1,16 @@
+// SDK 1.x does not yet declare ttlMs / cacheScope on ReadResourceResult contents,
+// but the protocol pass-through serialises whatever is on the wire. This
+// augmentation gates SEP-2549 (CacheableResult) without waiting for SDK 2.0.
+// See blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate
+declare module '@modelcontextprotocol/sdk/types.js' {
+  interface TextResourceContents {
+    ttlMs?: number;
+    cacheScope?: 'public' | 'private';
+  }
+  interface BlobResourceContents {
+    ttlMs?: number;
+    cacheScope?: 'public' | 'private';
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary

Annotate every ReadResource response with the per-entry caching hints proposed in SEP-2549 ("CacheableResult") so the wire shape matches the MCP 2026-07-28 RC ahead of SDK support:

  https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate

Per-resource defaults are picked by mutability:

| URI | ttlMs | cacheScope | Reason |
|---|---|---|---|
| `apap://templates` | 60_000 | private | list, per-client view |
| `apap://templates/{id}` | 300_000 | public | hash-immutable single row |
| `apap://agreements` | 30_000 | private | list, mutates on trigger |
| `apap://agreements/{id}` | 30_000 | private | single agreement, mutable |
| `apap://schema/protocol.cto` | 86_400_000 | public | bundled .cto, ships with build (entry for when the schema resource lands; cf. #185) |

The fields are emitted alongside `uri`/`mimeType`/`text`. The SDK's `ReadResourceResult` type does not yet declare them, but the SDK's response path is pass-through (no schema-strip), so caching proxies see them today as forward-compatible hints. Once SEP-2549 lands in the SDK the spread becomes a plain field assignment with no behavioural change.

Mirrors the POC change at JayDS22/apap-mcp-poc#4.

## Test plan

- [x] `npm test -- --testPathPattern='mcp\\.test'` (7/7 pass)
- [x] `npm test` full suite (71/71 pass)
- [x] `npx tsc --noEmit -p .` clean
- [ ] Manual: hit `POST /mcp` with `resources/read` for `apap://agreements`, confirm `ttlMs`/`cacheScope` present in JSON-RPC response

## Notes

- The new `server/handlers/mcp.test.ts` is the first jest file for `mcp.ts`; it pins the cache defaults so future edits cannot silently change a per-resource TTL or scope.
- No DB schema change. No public REST API change. Only the MCP `resources/read` payload gains two optional fields.