### PR TITLE
feat: implement HTTP retrieval for external shared models

### DIFF
--- a/server/handlers/retrievers/HttpModelRetriever.ts
+++ b/server/handlers/retrievers/HttpModelRetriever.ts
@@ -1,0 +1,27 @@
+import { IModelRetriever } from './IModelRetriever';
+
+export class HttpModelRetriever implements IModelRetriever {
+    public getURISchemes(): string[] {
+        return ['http', 'https'];
+    }
+
+    async fetchModel(uri: string): Promise<string> {
+        if (!uri.startsWith('http://') && !uri.startsWith('https://')) {
+            throw new Error(`Invalid URI scheme: ${uri}`);
+        }
+
+        const headers: Record<string, string> = {};
+
+        if (process.env.EXTERNAL_TEMPLATE_TOKEN) {
+            headers['Authorization'] = `Bearer ${process.env.EXTERNAL_TEMPLATE_TOKEN}`;
+        }
+
+        const response = await fetch(uri, { headers });
+        
+        if (!response.ok) {
+            throw new Error(`Failed to fetch model from ${uri}: ${response.statusText} (${response.status})`);
+        }
+
+        return await response.text();
+    }
+}

--- a/server/handlers/retrievers/HttpModelRetriever.ts
+++ b/server/handlers/retrievers/HttpModelRetriever.ts
@@ -1,13 +1,32 @@
 import { IModelRetriever } from './IModelRetriever';
 
+const ALLOWED_DOMAINS = [
+    'models.accordproject.org',
+    'templates.accordproject.org',
+    'raw.githubusercontent.com'
+];
+
 export class HttpModelRetriever implements IModelRetriever {
     public getURISchemes(): string[] {
         return ['http', 'https'];
     }
 
+    private isAllowedUrl(urlString: string): boolean {
+        try {
+            const parsedUrl = new URL(urlString);
+            return ALLOWED_DOMAINS.includes(parsedUrl.hostname);
+        } catch (e) {
+            return false;
+        }
+    }
+
     async fetchModel(uri: string): Promise<string> {
         if (!uri.startsWith('http://') && !uri.startsWith('https://')) {
             throw new Error(`Invalid URI scheme: ${uri}`);
+        }
+
+        if (!this.isAllowedUrl(uri)) {
+            throw new Error(`SSRF Prevention: Domain not in allowlist. Received: ${uri}`);
         }
 
         const headers: Record<string, string> = {};
@@ -16,12 +35,22 @@ export class HttpModelRetriever implements IModelRetriever {
             headers['Authorization'] = `Bearer ${process.env.EXTERNAL_TEMPLATE_TOKEN}`;
         }
 
-        const response = await fetch(uri, { headers });
-        
-        if (!response.ok) {
-            throw new Error(`Failed to fetch model from ${uri}: ${response.statusText} (${response.status})`);
-        }
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 5000);
 
-        return await response.text();
+        try {
+            const response = await fetch(uri, { 
+                headers,
+                signal: controller.signal
+            });
+            
+            if (!response.ok) {
+                throw new Error(`Failed to fetch model from ${uri}: ${response.statusText} (${response.status})`);
+            }
+
+            return await response.text();
+        } finally {
+            clearTimeout(timeoutId);
+        }
     }
 }

--- a/server/handlers/retrievers/HttpModelRetriever.ts
+++ b/server/handlers/retrievers/HttpModelRetriever.ts
@@ -11,26 +11,25 @@ export class HttpModelRetriever implements IModelRetriever {
         return ['http', 'https'];
     }
 
-    private isAllowedUrl(urlString: string): boolean {
-        try {
-            const parsedUrl = new URL(urlString);
-            return ALLOWED_DOMAINS.includes(parsedUrl.hostname);
-        } catch (e) {
-            return false;
-        }
-    }
-
     async fetchModel(uri: string): Promise<string> {
         if (!uri.startsWith('http://') && !uri.startsWith('https://')) {
             throw new Error(`Invalid URI scheme: ${uri}`);
         }
 
-        if (!this.isAllowedUrl(uri)) {
-            throw new Error(`SSRF Prevention: Domain not in allowlist. Received: ${uri}`);
+        // 1. Create a brand new URL object to break the CodeQL taint chain
+        let safeUrl: URL;
+        try {
+            safeUrl = new URL(uri);
+        } catch (e) {
+            throw new Error(`Malformed URL provided.`);
+        }
+
+        // 2. Validate the host of the new object
+        if (!ALLOWED_DOMAINS.includes(safeUrl.hostname)) {
+            throw new Error(`SSRF Prevention: Domain not in allowlist. Received: ${safeUrl.hostname}`);
         }
 
         const headers: Record<string, string> = {};
-
         if (process.env.EXTERNAL_TEMPLATE_TOKEN) {
             headers['Authorization'] = `Bearer ${process.env.EXTERNAL_TEMPLATE_TOKEN}`;
         }
@@ -39,13 +38,14 @@ export class HttpModelRetriever implements IModelRetriever {
         const timeoutId = setTimeout(() => controller.abort(), 5000);
 
         try {
-            const response = await fetch(uri, { 
+            // 3. Pass the validated URL object string, NOT the user's original 'uri'
+            const response = await fetch(safeUrl.toString(), { 
                 headers,
                 signal: controller.signal
             });
             
             if (!response.ok) {
-                throw new Error(`Failed to fetch model from ${uri}: ${response.statusText} (${response.status})`);
+                throw new Error(`Failed to fetch model from ${safeUrl.toString()}: ${response.statusText} (${response.status})`);
             }
 
             return await response.text();

--- a/server/handlers/retrievers/HttpModelRetriever.ts
+++ b/server/handlers/retrievers/HttpModelRetriever.ts
@@ -1,12 +1,39 @@
 import { IModelRetriever } from './IModelRetriever';
 
-const ALLOWED_DOMAINS = [
-    'models.accordproject.org',
-    'templates.accordproject.org',
-    'raw.githubusercontent.com'
-];
+export const MAX_FILE_SIZE = 1024 * 1024; 
 
-const MAX_FILE_SIZE = 1024 * 1024; 
+export function assertAllowedUrl(uri: string): URL {
+    if (!uri.startsWith('https://')) {
+        throw new Error(`Invalid URI scheme. Only https is allowed.`);
+    }
+
+    let safeUrl: URL;
+    try {
+        safeUrl = new URL(uri);
+    } catch (e) {
+        throw new Error(`Malformed URL provided.`);
+    }
+
+    if (safeUrl.port !== '' && safeUrl.port !== '443') {
+        throw new Error(`SSRF Prevention: Custom ports are not allowed.`);
+    }
+
+    const host = safeUrl.hostname;
+
+    if (
+        host !== 'models.accordproject.org' &&
+        host !== 'templates.accordproject.org' &&
+        host !== 'raw.githubusercontent.com'
+    ) {
+        throw new Error(`SSRF Prevention: Domain not in allowlist.`);
+    }
+
+    if (host === 'raw.githubusercontent.com' && !safeUrl.pathname.startsWith('/accordproject/')) {
+        throw new Error(`SSRF Prevention: Only official accordproject GitHub repositories are allowed.`);
+    }
+
+    return safeUrl;
+}
 
 export class HttpModelRetriever implements IModelRetriever {
     public getURISchemes(): string[] {
@@ -14,28 +41,7 @@ export class HttpModelRetriever implements IModelRetriever {
     }
 
     async fetchModel(uri: string): Promise<string> {
-        if (!uri.startsWith('https://')) {
-            throw new Error(`Invalid URI scheme. Only https is allowed.`);
-        }
-
-        let safeUrl: URL;
-        try {
-            safeUrl = new URL(uri);
-        } catch (e) {
-            throw new Error(`Malformed URL provided.`);
-        }
-
-        if (safeUrl.port !== '' && safeUrl.port !== '443') {
-            throw new Error(`SSRF Prevention: Custom ports are not allowed.`);
-        }
-
-        if (!ALLOWED_DOMAINS.includes(safeUrl.hostname)) {
-            throw new Error(`SSRF Prevention: Domain not in allowlist.`);
-        }
-
-        if (safeUrl.hostname === 'raw.githubusercontent.com' && !safeUrl.pathname.startsWith('/accordproject/')) {
-            throw new Error(`SSRF Prevention: Only official accordproject GitHub repositories are allowed.`);
-        }
+        const safeUrl = assertAllowedUrl(uri);
 
         const headers: Record<string, string> = {};
         if (process.env.EXTERNAL_TEMPLATE_TOKEN) {
@@ -44,12 +50,12 @@ export class HttpModelRetriever implements IModelRetriever {
 
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 5000);
-
+        
         try {
             const response = await fetch(safeUrl.toString(), { 
                 headers,
                 signal: controller.signal,
-                redirect: 'error' 
+                redirect: 'error'
             });
             
             if (!response.ok) {
@@ -62,7 +68,7 @@ export class HttpModelRetriever implements IModelRetriever {
             }
 
             const text = await response.text();
-
+            
             if (Buffer.byteLength(text, 'utf8') > MAX_FILE_SIZE) {
                 throw new Error('Model file exceeds the 1MB size limit after download.');
             }

--- a/server/handlers/retrievers/HttpModelRetriever.ts
+++ b/server/handlers/retrievers/HttpModelRetriever.ts
@@ -6,17 +6,18 @@ const ALLOWED_DOMAINS = [
     'raw.githubusercontent.com'
 ];
 
+const MAX_FILE_SIZE = 1024 * 1024; 
+
 export class HttpModelRetriever implements IModelRetriever {
     public getURISchemes(): string[] {
-        return ['http', 'https'];
+        return ['https'];
     }
 
     async fetchModel(uri: string): Promise<string> {
-        if (!uri.startsWith('http://') && !uri.startsWith('https://')) {
-            throw new Error(`Invalid URI scheme: ${uri}`);
+        if (!uri.startsWith('https://')) {
+            throw new Error(`Invalid URI scheme. Only https is allowed.`);
         }
 
-        // 1. Create a brand new URL object to break the CodeQL taint chain
         let safeUrl: URL;
         try {
             safeUrl = new URL(uri);
@@ -24,9 +25,16 @@ export class HttpModelRetriever implements IModelRetriever {
             throw new Error(`Malformed URL provided.`);
         }
 
-        // 2. Validate the host of the new object
+        if (safeUrl.port !== '' && safeUrl.port !== '443') {
+            throw new Error(`SSRF Prevention: Custom ports are not allowed.`);
+        }
+
         if (!ALLOWED_DOMAINS.includes(safeUrl.hostname)) {
-            throw new Error(`SSRF Prevention: Domain not in allowlist. Received: ${safeUrl.hostname}`);
+            throw new Error(`SSRF Prevention: Domain not in allowlist.`);
+        }
+
+        if (safeUrl.hostname === 'raw.githubusercontent.com' && !safeUrl.pathname.startsWith('/accordproject/')) {
+            throw new Error(`SSRF Prevention: Only official accordproject GitHub repositories are allowed.`);
         }
 
         const headers: Record<string, string> = {};
@@ -38,17 +46,31 @@ export class HttpModelRetriever implements IModelRetriever {
         const timeoutId = setTimeout(() => controller.abort(), 5000);
 
         try {
-            // 3. Pass the validated URL object string, NOT the user's original 'uri'
             const response = await fetch(safeUrl.toString(), { 
                 headers,
-                signal: controller.signal
+                signal: controller.signal,
+                redirect: 'error' 
             });
             
             if (!response.ok) {
-                throw new Error(`Failed to fetch model from ${safeUrl.toString()}: ${response.statusText} (${response.status})`);
+                throw new Error(`HTTP request failed with status ${response.status}`);
             }
 
-            return await response.text();
+            const contentLength = response.headers.get('content-length');
+            if (contentLength && parseInt(contentLength, 10) > MAX_FILE_SIZE) {
+                throw new Error('Model file exceeds the 1MB size limit.');
+            }
+
+            const text = await response.text();
+
+            if (Buffer.byteLength(text, 'utf8') > MAX_FILE_SIZE) {
+                throw new Error('Model file exceeds the 1MB size limit after download.');
+            }
+
+            return text;
+        } catch (error: any) {
+            console.error(`[HttpModelRetriever Error]:`, error);
+            throw new Error('Failed to securely fetch the external model. Ensure the URL is valid, public, and within allowed limits.');
         } finally {
             clearTimeout(timeoutId);
         }

--- a/server/handlers/retrievers/HttpModelRetriever.ts
+++ b/server/handlers/retrievers/HttpModelRetriever.ts
@@ -2,7 +2,7 @@ import { IModelRetriever } from './IModelRetriever';
 
 export const MAX_FILE_SIZE = 1024 * 1024; 
 
-export function assertAllowedUrl(uri: string): URL {
+export function assertAllowedUrl(uri: string): { host: string; pathname: string; search: string } {
     if (!uri.startsWith('https://')) {
         throw new Error(`Invalid URI scheme. Only https is allowed.`);
     }
@@ -32,7 +32,7 @@ export function assertAllowedUrl(uri: string): URL {
         throw new Error(`SSRF Prevention: Only official accordproject GitHub repositories are allowed.`);
     }
 
-    return safeUrl;
+    return { host: safeUrl.host, pathname: safeUrl.pathname, search: safeUrl.search };
 }
 
 export class HttpModelRetriever implements IModelRetriever {
@@ -41,7 +41,8 @@ export class HttpModelRetriever implements IModelRetriever {
     }
 
     async fetchModel(uri: string): Promise<string> {
-        const safeUrl = assertAllowedUrl(uri);
+        const { host, pathname, search } = assertAllowedUrl(uri);
+        const finalUrl = `https://${host}${pathname}${search}`;
 
         const headers: Record<string, string> = {};
         if (process.env.EXTERNAL_TEMPLATE_TOKEN) {
@@ -52,7 +53,7 @@ export class HttpModelRetriever implements IModelRetriever {
         const timeoutId = setTimeout(() => controller.abort(), 5000);
         
         try {
-            const response = await fetch(safeUrl.toString(), { 
+            const response = await fetch(finalUrl, {
                 headers,
                 signal: controller.signal,
                 redirect: 'error'

--- a/server/handlers/retrievers/HttpModelRetriever.ts
+++ b/server/handlers/retrievers/HttpModelRetriever.ts
@@ -1,6 +1,6 @@
 import { IModelRetriever } from './IModelRetriever';
 
-export const MAX_FILE_SIZE = 1024 * 1024; 
+export const MAX_FILE_SIZE = 1024 * 1024;
 
 export function assertAllowedUrl(uri: string): { host: string; pathname: string; search: string } {
     if (!uri.startsWith('https://')) {
@@ -12,6 +12,10 @@ export function assertAllowedUrl(uri: string): { host: string; pathname: string;
         safeUrl = new URL(uri);
     } catch (e) {
         throw new Error(`Malformed URL provided.`);
+    }
+
+    if (safeUrl.username || safeUrl.password) {
+        throw new Error(`SSRF Prevention: User credentials in URL are not allowed.`);
     }
 
     if (safeUrl.port !== '' && safeUrl.port !== '443') {

--- a/server/handlers/retrievers/IModelRetriever.ts
+++ b/server/handlers/retrievers/IModelRetriever.ts
@@ -1,0 +1,4 @@
+export interface IModelRetriever {
+    getURISchemes(): string[];
+    fetchModel(uri: string): Promise<string>;
+}

--- a/server/handlers/sharedmodels.test.ts
+++ b/server/handlers/sharedmodels.test.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import express from 'express';
+import sharedModelsRouter from './sharedmodels';
+
+const app = express();
+app.use(express.json());
+app.use('/sharedmodels', sharedModelsRouter);
+
+describe('SharedModels SSRF Prevention', () => {
+    const originalFetch = (global as any).fetch;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    afterAll(() => {
+        (global as any).fetch = originalFetch;
+    });
+
+    it('should reject a transitive import from a non-allowlisted domain', async () => {
+        (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+            if (url === 'https://models.accordproject.org/safe.cto') {
+                return {
+                    ok: true,
+                    headers: { get: (name: string): string | null => name === 'content-length' ? '100' : null },
+                    text: async (): Promise<string> => `
+                        namespace org.accordproject.safe@1.0.0
+                        import org.evil@1.0.0.MaliciousAsset from https://evil-attacker.com/malicious.cto
+                    `
+                };
+            }
+            
+            return {
+                ok: true,
+                headers: { get: (name: string): string | null => null },
+                text: async (): Promise<string> => `namespace org.evil@1.0.0`
+            };
+        });
+
+        const response = await request(app)
+            .post('/sharedmodels')
+            .send({ uri: 'https://models.accordproject.org/safe.cto' });
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe('Failed to fetch or parse external model safely.');
+        
+        expect(response.body.details).toBe('SSRF Prevention: Transitive import domain or URL not allowed: https://evil-attacker.com/malicious.cto');
+        
+        expect((global as any).fetch).toHaveBeenCalledTimes(1); 
+        expect((global as any).fetch).toHaveBeenCalledWith(
+            'https://models.accordproject.org/safe.cto', 
+            expect.any(Object)
+        );
+    });
+});

--- a/server/handlers/sharedmodels.test.ts
+++ b/server/handlers/sharedmodels.test.ts
@@ -1,12 +1,23 @@
+import { describe, it, expect, beforeEach, afterAll, jest } from '@jest/globals';
 import request from 'supertest';
 import express from 'express';
 import sharedModelsRouter from './sharedmodels';
+
+jest.mock('./crud', () => ({
+    buildCrudRouter: jest.fn(() => {
+        const router = express.Router();
+        router.post('/', (req, res) => {
+            res.status(200).json({ success: true, model: req.body.model });
+        });
+        return router;
+    }),
+}));
 
 const app = express();
 app.use(express.json());
 app.use('/sharedmodels', sharedModelsRouter);
 
-describe('SharedModels SSRF Prevention', () => {
+describe('SharedModels SSRF Prevention and Retrieval', () => {
     const originalFetch = (global as any).fetch;
 
     beforeEach(() => {
@@ -15,10 +26,11 @@ describe('SharedModels SSRF Prevention', () => {
 
     afterAll(() => {
         (global as any).fetch = originalFetch;
+        jest.restoreAllMocks();
     });
 
     it('should reject a transitive import from a non-allowlisted domain', async () => {
-        (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+        (global as any).fetch = jest.fn().mockImplementation(async (url: any): Promise<any> => {
             if (url === 'https://models.accordproject.org/safe.cto') {
                 return {
                     ok: true,
@@ -43,13 +55,40 @@ describe('SharedModels SSRF Prevention', () => {
 
         expect(response.status).toBe(400);
         expect(response.body.error).toBe('Failed to fetch or parse external model safely.');
-        
-        expect(response.body.details).toBe('SSRF Prevention: Transitive import domain or URL not allowed: https://evil-attacker.com/malicious.cto');
+        expect(response.body.details).toContain('SSRF Prevention: Transitive import domain or URL not allowed: https://evil-attacker.com/malicious.cto');
         
         expect((global as any).fetch).toHaveBeenCalledTimes(1); 
         expect((global as any).fetch).toHaveBeenCalledWith(
             'https://models.accordproject.org/safe.cto', 
             expect.any(Object)
         );
+    });
+
+    it('should fetch and insert a valid external model successfully', async () => {
+        const mockCtoText = `
+            namespace org.accordproject.valid@1.0.0
+            concept ValidConcept {
+                o String name
+            }
+        `;
+
+        (global as any).fetch = jest.fn().mockImplementation(async (url: any): Promise<any> => {
+            return {
+                ok: true,
+                headers: { get: (name: string): string | null => name === 'content-length' ? '100' : null },
+                text: async (): Promise<string> => mockCtoText
+            };
+        });
+
+        const response = await request(app)
+            .post('/sharedmodels')
+            .send({ uri: 'https://models.accordproject.org/valid.cto' });
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+        expect(response.body.model).toBeDefined();
+        expect(response.body.model.$class).toBe('org.accordproject.protocol@1.0.0.CtoModel');
+        expect(response.body.model.ctoFiles[0].filename).toBe('org.accordproject.valid@1.0.0.cto');
+        expect(response.body.model.ctoFiles[0].contents).toBe(mockCtoText);
     });
 });

--- a/server/handlers/sharedmodels.test.ts
+++ b/server/handlers/sharedmodels.test.ts
@@ -91,4 +91,14 @@ describe('SharedModels SSRF Prevention and Retrieval', () => {
         expect(response.body.model.ctoFiles[0].filename).toBe('org.accordproject.valid@1.0.0.cto');
         expect(response.body.model.ctoFiles[0].contents).toBe(mockCtoText);
     });
+
+    it('should reject URLs containing user credentials', async () => {
+        const response = await request(app)
+            .post('/sharedmodels')
+            .send({ uri: 'https://evil.com@models.accordproject.org/safe.cto' });
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe('Failed to fetch or parse external model safely.');
+        expect(response.body.details).toContain('SSRF Prevention: User credentials in URL are not allowed.');
+    });
 });

--- a/server/handlers/sharedmodels.ts
+++ b/server/handlers/sharedmodels.ts
@@ -8,15 +8,16 @@ import { HttpModelRetriever } from './retrievers/HttpModelRetriever';
 const router = express.Router();
 
 router.post('/', async (req, res, next) => {
-    const { uri } = req.body;
+    const uri: string | undefined = req.body?.uri;
+    const retriever = new HttpModelRetriever();
 
-    if (uri && (uri.startsWith('http://') || uri.startsWith('https://'))) {
+    if (uri && retriever.getURISchemes().some((scheme) => uri.startsWith(`${scheme}://`))) {
         try {
-            const retriever = new HttpModelRetriever();
             const ctoText = await retriever.fetchModel(uri);
 
-            const modelManager = new ModelManager();
-            const modelFile = modelManager.addCTOModel(ctoText, 'external.cto');
+            const modelManager = new ModelManager({ strict: true, addMetamodel: true });
+            const modelFile = modelManager.addCTOModel(ctoText, 'external.cto', true);
+            await modelManager.updateExternalModels();
             
             const namespace = modelFile.getNamespace() || 'external';
 

--- a/server/handlers/sharedmodels.ts
+++ b/server/handlers/sharedmodels.ts
@@ -1,9 +1,44 @@
-import express from 'express'
+import express from 'express';
 import { SharedModel, SharedModelInsertSchema } from '../db/schema';
 import { buildCrudRouter } from './crud';
 import { concertoValidation } from './concertovalidation';
+import { ModelManager } from '@accordproject/concerto-core';
+import { HttpModelRetriever } from './retrievers/HttpModelRetriever';
 
 const router = express.Router();
+
+router.post('/', async (req, res, next) => {
+    const { uri } = req.body;
+
+    if (uri && (uri.startsWith('http://') || uri.startsWith('https://'))) {
+        try {
+            const retriever = new HttpModelRetriever();
+            const ctoText = await retriever.fetchModel(uri);
+
+            const modelManager = new ModelManager();
+            const modelFile = modelManager.addCTOModel(ctoText, 'external.cto');
+            
+            const namespace = modelFile.getNamespace() || 'external';
+
+            req.body.model = {
+                $class: 'org.accordproject.protocol@1.0.0.CtoModel',
+                ctoFiles: [
+                    {
+                        filename: `${namespace}.cto`,
+                        contents: ctoText
+                    }
+                ]
+            };
+        } catch (error: any) {
+            return res.status(400).json({
+                error: 'Failed to fetch or parse external model',
+                details: error.message
+            });
+        }
+    }
+
+    next();
+});
 
 const crudRouter = buildCrudRouter({
     table: SharedModel,

--- a/server/handlers/sharedmodels.ts
+++ b/server/handlers/sharedmodels.ts
@@ -3,15 +3,55 @@ import { SharedModel, SharedModelInsertSchema } from '../db/schema';
 import { buildCrudRouter } from './crud';
 import { concertoValidation } from './concertovalidation';
 import { ModelManager } from '@accordproject/concerto-core';
-import { HttpModelRetriever } from './retrievers/HttpModelRetriever';
+import { HttpModelRetriever, assertAllowedUrl } from './retrievers/HttpModelRetriever';
 
 const router = express.Router();
 
-class SecureFileDownloader {
-    async getFile(url: string): Promise<string> {
-        const retriever = new HttpModelRetriever();
+class SecureFileLoader {
+    accepts(url: string): boolean {
+        try {
+            assertAllowedUrl(url);
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
 
+    async load(url: string, options: any): Promise<string> {
+        const retriever = new HttpModelRetriever();
         return await retriever.fetchModel(url);
+    }
+}
+
+class SecureDownloader {
+    private fileLoader = new SecureFileLoader();
+    private modelManager: ModelManager;
+
+    constructor(modelManager: ModelManager) {
+        this.modelManager = modelManager;
+    }
+
+    async downloadExternalDependencies(modelFiles: any[], options: any): Promise<any[]> {
+        const downloadedModels: any[] = [];
+        
+        for (const modelFile of modelFiles) {
+            const ast = modelFile.getAst ? modelFile.getAst() : { imports: [] };
+            const imports = ast.imports || [];
+            
+            for (const imp of imports) {
+                const uri = imp.uri;
+                if (typeof uri === 'string' && uri.startsWith('http')) {
+                    if (!this.fileLoader.accepts(uri)) {
+                        throw new Error(`SSRF Prevention: Transitive import domain or URL not allowed: ${uri}`);
+                    }
+                    const content = await this.fileLoader.load(uri, options);
+                    
+                    const parsedModel = this.modelManager.addCTOModel(content, 'transitive.cto', true);
+                    downloadedModels.push(parsedModel);
+                }
+            }
+        }
+        return downloadedModels;
     }
 }
 
@@ -23,10 +63,10 @@ router.post('/', async (req, res, next) => {
         try {
             const ctoText = await retriever.fetchModel(uri);
 
-            const modelManager = new ModelManager({ strict: true, addMetamodel: true });
+            const modelManager = new ModelManager({ addMetamodel: true });
             const modelFile = modelManager.addCTOModel(ctoText, 'external.cto', true);
             
-            const secureDownloader = new SecureFileDownloader();
+            const secureDownloader = new SecureDownloader(modelManager);
             await modelManager.updateExternalModels({}, secureDownloader as any);
             
             const namespace = modelFile.getNamespace() || 'external';

--- a/server/handlers/sharedmodels.ts
+++ b/server/handlers/sharedmodels.ts
@@ -7,6 +7,14 @@ import { HttpModelRetriever } from './retrievers/HttpModelRetriever';
 
 const router = express.Router();
 
+class SecureFileDownloader {
+    async getFile(url: string): Promise<string> {
+        const retriever = new HttpModelRetriever();
+
+        return await retriever.fetchModel(url);
+    }
+}
+
 router.post('/', async (req, res, next) => {
     const uri: string | undefined = req.body?.uri;
     const retriever = new HttpModelRetriever();
@@ -17,7 +25,9 @@ router.post('/', async (req, res, next) => {
 
             const modelManager = new ModelManager({ strict: true, addMetamodel: true });
             const modelFile = modelManager.addCTOModel(ctoText, 'external.cto', true);
-            await modelManager.updateExternalModels();
+            
+            const secureDownloader = new SecureFileDownloader();
+            await modelManager.updateExternalModels({}, secureDownloader as any);
             
             const namespace = modelFile.getNamespace() || 'external';
 
@@ -31,8 +41,9 @@ router.post('/', async (req, res, next) => {
                 ]
             };
         } catch (error: any) {
+            console.error(`[SharedModels Post Error]:`, error);
             return res.status(400).json({
-                error: 'Failed to fetch or parse external model',
+                error: 'Failed to fetch or parse external model safely.',
                 details: error.message
             });
         }

--- a/server/handlers/sharedmodels.ts
+++ b/server/handlers/sharedmodels.ts
@@ -3,57 +3,39 @@ import { SharedModel, SharedModelInsertSchema } from '../db/schema';
 import { buildCrudRouter } from './crud';
 import { concertoValidation } from './concertovalidation';
 import { ModelManager } from '@accordproject/concerto-core';
+import { FileDownloader } from '@accordproject/concerto-util';
 import { HttpModelRetriever, assertAllowedUrl } from './retrievers/HttpModelRetriever';
 
 const router = express.Router();
 
 class SecureFileLoader {
     accepts(url: string): boolean {
-        try {
-            assertAllowedUrl(url);
-            return true;
-        } catch (e) {
-            return false;
-        }
+        return url.startsWith('http://') || url.startsWith('https://');
     }
 
     async load(url: string, options: any): Promise<string> {
+        try {
+            assertAllowedUrl(url);
+        } catch (e) {
+            throw new Error(`SSRF Prevention: Transitive import domain or URL not allowed: ${url}`);
+        }
         const retriever = new HttpModelRetriever();
         return await retriever.fetchModel(url);
     }
 }
 
-class SecureDownloader {
-    private fileLoader = new SecureFileLoader();
-    private modelManager: ModelManager;
-
-    constructor(modelManager: ModelManager) {
-        this.modelManager = modelManager;
-    }
-
-    async downloadExternalDependencies(modelFiles: any[], options: any): Promise<any[]> {
-        const downloadedModels: any[] = [];
-        
-        for (const modelFile of modelFiles) {
-            const ast = modelFile.getAst ? modelFile.getAst() : { imports: [] };
-            const imports = ast.imports || [];
-            
-            for (const imp of imports) {
-                const uri = imp.uri;
-                if (typeof uri === 'string' && uri.startsWith('http')) {
-                    if (!this.fileLoader.accepts(uri)) {
-                        throw new Error(`SSRF Prevention: Transitive import domain or URL not allowed: ${uri}`);
-                    }
-                    const content = await this.fileLoader.load(uri, options);
-                    
-                    const parsedModel = this.modelManager.addCTOModel(content, 'transitive.cto', true);
-                    downloadedModels.push(parsedModel);
-                }
+const getExternalImports = (modelFile: any): Record<string, string> => {
+    const ast = modelFile.getAst ? modelFile.getAst() : modelFile.ast;
+    const imports: Record<string, string> = {};
+    if (ast && ast.imports) {
+        for (const imp of ast.imports) {
+            if (imp.uri && typeof imp.uri === 'string') {
+                imports[imp.namespace] = imp.uri;
             }
         }
-        return downloadedModels;
     }
-}
+    return imports;
+};
 
 router.post('/', async (req, res, next) => {
     const uri: string | undefined = req.body?.uri;
@@ -65,10 +47,10 @@ router.post('/', async (req, res, next) => {
 
             const modelManager = new ModelManager({ addMetamodel: true });
             const modelFile = modelManager.addCTOModel(ctoText, 'external.cto', true);
-            
-            const secureDownloader = new SecureDownloader(modelManager);
-            await modelManager.updateExternalModels({}, secureDownloader as any);
-            
+
+            const fileDownloader = new FileDownloader(new SecureFileLoader() as any, getExternalImports);
+            await modelManager.updateExternalModels({}, fileDownloader);
+
             const namespace = modelFile.getNamespace() || 'external';
 
             req.body.model = {
@@ -95,8 +77,6 @@ router.post('/', async (req, res, next) => {
 const crudRouter = buildCrudRouter({
     table: SharedModel,
     typeName: 'SharedModel',
-    // ponytail: cast schema to any due to zod v3 -> v4 upgrade depth-instantiation
-    // issue with drizzle-zod. Runtime unaffected.
     validateBody: { schema: SharedModelInsertSchema as any, custom: (body) => concertoValidation('SharedModel', body) }
 });
 


### PR DESCRIPTION
Hello @mttrbrts and @dselman, apologies for being missing in action, I had my end semester exams, followed by a vacation but I am back and plan to keep on contributing & learning here on! 


With this PR, I am continuing the work which I started with PRs #112 and #126



## Description

This PR introduces the ability to dynamically fetch and import external Shared Models (`.cto` files) via HTTP/HTTPS URIs, directly addressing the next phase of extensibility outlined in #60. 

This builds upon the pattern established in the external template retrieval feature, providing APAP with the capability to pull lightweight model dictionaries from external registries or public repositories prior to database insertion.

### Architectural Changes

* **Retriever Interfaces:** Established a new `IModelRetriever` interface to cleanly separate model-fetching logic from binary template-fetching logic (`ITemplateRetriever`).
* **HTTP Implementation:** Added `HttpModelRetriever` to securely handle network requests for external `.cto` text files, passing along `EXTERNAL_TEMPLATE_TOKEN` headers when present.
* **POST Route Interception:** Modified the `POST /` route in `server/handlers/sharedmodels.ts` to intercept requests containing external URIs.
* **Native Concerto Validation:** The intercepted raw `.cto` text is piped through `@accordproject/concerto-core`'s `ModelManager` to validate the syntax and extract the namespace.
* **Data Formatting:** Automatically wraps the validated external text into the `org.accordproject.protocol@1.0.0.CtoModel` JSON format expected by the APAP database schema, seamlessly handing off the payload to the existing `crudRouter`.

### Motivation and Context

As noted by @dselman in Issue #60, APAP requires extensibility for each core resource type (Agreements, Templates, and Shared Models). While previous PRs handled the binary `.cta` template archives, Shared Models require a distinct pipeline because they are fetched as raw text rather than zip buffers, and do not possess the embedded logic/grammar layers of a full template.

By parsing the external text through `ModelManager` prior to database insertion, we guarantee that only valid Concerto models enter the Postgres database, preventing corrupted states down the line. 

### Manual Verification Steps

1. Start the local APAP server.
2. Send a `POST` request to `/sharedmodels` with an external URI:
   ```json
   {
     "uri": "[https://models.accordproject.org/money@0.3.0.cto](https://models.accordproject.org/money@0.3.0.cto)"
   }


Fixes #60 (Partial - Extends external URI support to Shared Models)