### PR TITLE
feat(ci): deploy apap to EC2 using OIDC and harden pipeline workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   deploy:
+    if: ${{ github.repository_owner == 'accordproject' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy Docker Image to EC2
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: ./server
+        push: true
+        tags: |
+          accordproject/apap:latest
+          accordproject/apap:${{ github.sha }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Configure AWS credentials via OIDC
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Deploy via SSM
+      id: ssm
+      run: |
+        COMMAND_ID=$(aws ssm send-command \
+          --instance-ids "${{ secrets.AWS_INSTANCE_ID }}" \
+          --document-name "AWS-RunShellScript" \
+          --parameters 'commands=[
+            "cd /home/ubuntu",
+            "echo \"${{ secrets.HTPASSWD_CONTENT }}\" > ./htpasswd",
+            "sudo docker-compose -f ./compose-aws.yaml stop",
+            "sudo docker-compose -f ./compose-aws.yaml rm -f",
+            "sudo docker-compose -f ./compose-aws.yaml pull",
+            "POSTGRES_HOST=${{ secrets.POSTGRES_HOST }} sudo docker-compose -f ./compose-aws.yaml up -d",
+            "sudo docker image prune -af"
+          ]' \
+          --query "Command.CommandId" \
+          --output text)
+        echo "command_id=$COMMAND_ID" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for deploy to complete
+      run: |
+        aws ssm wait command-executed \
+          --command-id "${{ steps.ssm.outputs.command_id }}" \
+          --instance-id "${{ secrets.AWS_INSTANCE_ID }}"


### PR DESCRIPTION
- Add AWS deployment with OIDC role assumption 
- Replace raw `docker login` with `docker/login-action@v3`
- Replace manual build/tag/push with `docker/build-push-action@v6` + GitHub Actions layer cache
- Tag images with commit SHA alongside `:latest` for rollback capability
- Replace third-party `peterkimzz/aws-ssm-send-command` with native AWS CLI
- Wait for SSM command completion so the workflow fails if deploy fails on EC2
