### PR TITLE
fix(crud): reject non-strict-numeric :id up-front (closes #162)

### DIFF
--- a/server/handlers/crud.test.ts
+++ b/server/handlers/crud.test.ts
@@ -143,16 +143,18 @@ describe('PUT /:id validation', () => {
             error: { errors: [{ message: 'Custom validation failed' }] }
         });
 
-        // `DbTemplate` is a local alias in agreements.ts (import { Template as DbTemplate }),
-        // not a named export from db/schema. This block previously passed with `table:
-        // undefined` because the custom-validation short-circuit returned before any code
-        // touched `table`. The :id middleware added for #162 accesses `table.id.columnType`
-        // up-front, so the real export name is required now.
+        // `DbTemplate` is not a named export from db/schema. It's a local alias in
+        // agreements.ts (`import { Template as DbTemplate }`). Re-aliasing here keeps
+        // the reader-facing name consistent with agreements.ts while pulling the real
+        // export. The previous direct `DbTemplate` import resolved to `undefined` and
+        // the tests only passed because the custom-validation short-circuit returned
+        // before any code touched `table`. The :id middleware added for #162 accesses
+        // `table.id.columnType` up-front, so a real schema object is required now.
         const { buildCrudRouter } = require('./crud');
-        const { Template } = require('../db/schema');
+        const { Template: DbTemplate } = require('../db/schema');
 
         const testRouter = buildCrudRouter({
-            table: Template,
+            table: DbTemplate,
             validateBody: {
                 // no schema — only custom
                 custom: (body: any) => valModule.concertoValidation('Template', body)
@@ -337,11 +339,11 @@ describe('POST without validateBody', () => {
         });
 
         const { buildCrudRouter } = require('./crud');
-        const { Template } = require('../db/schema');
+        const { Template: DbTemplate } = require('../db/schema');
 
         // No validateBody at all
         const testRouter = buildCrudRouter({
-            table: Template,
+            table: DbTemplate,
             typeName: 'templates',
         });
 

--- a/server/handlers/crud.test.ts
+++ b/server/handlers/crud.test.ts
@@ -143,12 +143,16 @@ describe('PUT /:id validation', () => {
             error: { errors: [{ message: 'Custom validation failed' }] }
         });
 
-        // Import buildCrudRouter and DbTemplate directly
+        // `DbTemplate` is a local alias in agreements.ts (import { Template as DbTemplate }),
+        // not a named export from db/schema. This block previously passed with `table:
+        // undefined` because the custom-validation short-circuit returned before any code
+        // touched `table`. The :id middleware added for #162 accesses `table.id.columnType`
+        // up-front, so the real export name is required now.
         const { buildCrudRouter } = require('./crud');
-        const { DbTemplate } = require('../db/schema');
+        const { Template } = require('../db/schema');
 
         const testRouter = buildCrudRouter({
-            table: DbTemplate,
+            table: Template,
             validateBody: {
                 // no schema — only custom
                 custom: (body: any) => valModule.concertoValidation('Template', body)
@@ -229,6 +233,88 @@ describe('DELETE /:id', () => {
     });
 });
 
+describe('Route :id strict-numeric validation (#162)', () => {
+    // parseInt('1abc') returns 1, so before this guard PUT /templates/1abc with a valid body
+    // silently updated row 1, and DELETE /templates/1abc silently deleted row 1. The tests
+    // pin that the guard runs before any DB mutation and returns 404 for anything that is not
+    // a strict decimal integer. Regressions on the accepted numeric path are covered by the
+    // existing `DELETE /:id returns 200 when resource exists` case above.
+    let app: express.Application;
+    let dbMock: any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        dbMock = {
+            insert: jest.fn().mockReturnThis(),
+            values: jest.fn().mockReturnThis(),
+            returning: jest.fn<any>().mockResolvedValue([{ id: 1 }]),
+            update: jest.fn().mockReturnThis(),
+            set: jest.fn().mockReturnThis(),
+            delete: jest.fn().mockReturnThis(),
+            where: jest.fn().mockReturnThis(),
+            select: jest.fn().mockReturnThis(),
+            from: jest.fn().mockReturnThis(),
+            limit: jest.fn().mockReturnThis(),
+            offset: jest.fn().mockReturnThis(),
+            orderBy: jest.fn().mockReturnThis(),
+        };
+        app = express();
+        app.use(express.json());
+        app.use((req, res, next) => {
+            res.locals.db = dbMock;
+            next();
+        });
+        app.use('/templates', templatesRouter);
+    });
+
+    it('GET /:id rejects partial-numeric id 1abc with 404', async () => {
+        const res = await request(app).get('/templates/1abc');
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe('Not found');
+        expect(dbMock.select).not.toHaveBeenCalled();
+    });
+
+    it('PUT /:id rejects partial-numeric id 1abc with 404 before touching db', async () => {
+        // The data-corruption case from the issue: without the guard, a valid body sent to
+        // /templates/1abc silently updates row 1.
+        (mockedSchema.safeParse as any) = jest.fn().mockReturnValue({
+            success: true,
+            data: validTemplateBody
+        });
+        const res = await request(app)
+            .put('/templates/1abc')
+            .send(validTemplateBody);
+        expect(res.status).toBe(404);
+        expect(dbMock.update).not.toHaveBeenCalled();
+    });
+
+    it('DELETE /:id rejects partial-numeric id 1abc with 404 before touching db', async () => {
+        const res = await request(app).delete('/templates/1abc');
+        expect(res.status).toBe(404);
+        expect(dbMock.delete).not.toHaveBeenCalled();
+    });
+
+    it('rejects decimal id 1.5 with 404', async () => {
+        const res = await request(app).get('/templates/1.5');
+        expect(res.status).toBe(404);
+    });
+
+    it('rejects negative id -1 with 404', async () => {
+        const res = await request(app).get('/templates/-1');
+        expect(res.status).toBe(404);
+    });
+
+    it('rejects hex-form id 0x10 with 404', async () => {
+        const res = await request(app).get('/templates/0x10');
+        expect(res.status).toBe(404);
+    });
+
+    it('rejects scientific-form id 1e2 with 404', async () => {
+        const res = await request(app).get('/templates/1e2');
+        expect(res.status).toBe(404);
+    });
+});
+
 describe('POST without validateBody', () => {
     it('does not crash when validateBody is not provided', async () => {
         const noValidateApp = express();
@@ -251,11 +337,11 @@ describe('POST without validateBody', () => {
         });
 
         const { buildCrudRouter } = require('./crud');
-        const { DbTemplate } = require('../db/schema');
+        const { Template } = require('../db/schema');
 
         // No validateBody at all
         const testRouter = buildCrudRouter({
-            table: DbTemplate,
+            table: Template,
             typeName: 'templates',
         });
 

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -238,6 +238,20 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
         next();
     });
 
+    // Reject non-strict-numeric :id early for integer-keyed tables (#162). parseInt('1abc')
+    // returns 1, so without this guard PUT /agreements/1abc with a valid body silently updates
+    // row 1, and DELETE /templates/1abc silently deletes row 1. UUID-keyed tables keep the
+    // existing pass-through; the DB layer surfaces malformed UUIDs.
+    router.param('id', (req: Request, res: Response, next, rawId: string) => {
+        if (table.id.columnType === 'PgUUID') {
+            return next();
+        }
+        if (!/^\d+$/.test(rawId)) {
+            return res.status(404).json({ error: 'Not found' });
+        }
+        next();
+    });
+
     // GET with pagination, sorting, and filtering
     router.get('/',
         // authRequiredPermissions('read:' + typeName),


### PR DESCRIPTION
## Summary

Closes #162. `parseInt(req.params.id)` returns `1` for the string `'1abc'`, so before this guard:

- `PUT /agreements/1abc` with a valid body silently updated row `1`
- `DELETE /templates/1abc` silently deleted row `1`
- `GET /templates/1abc` silently returned row `1`

## What this PR does

Adds a route-level `router.param('id', ...)` middleware in `buildCrudRouter` that rejects anything that is not a strict decimal integer with `404` on integer-keyed tables. UUID-keyed tables keep the existing pass-through so the DB layer can surface malformed UUIDs.

The guard runs before any body validation, DB read, DB mutation, or side-effectful trigger, so a bad `:id` never touches the DB and never blocks on Concerto validation of the body.

## Tests

7 new cases appended to `crud.test.ts` covering GET, PUT, DELETE with:

- `1abc` (parseInt partial parse, the case from the issue)
- `1.5` (float)
- `-1` (negative)
- `0x10` (hex)
- `1e2` (scientific)

PUT and DELETE cases also assert that `dbMock.update` / `dbMock.delete` were never called, pinning the safety property that the guard runs before any DB mutation. The accepted-path regression is already covered by the existing `DELETE /:id returns 200 when resource exists` case.

## Also in this PR

Fixes a pre-existing test bug in `crud.test.ts` that imported `DbTemplate` from `../db/schema`. `DbTemplate` is a local alias in `agreements.ts` (`import { Template as DbTemplate }`), not a named export from the schema module, so the two tests that used it got `table: undefined`. They silently passed because the exercised code path never touched `table` before returning. The new `:id` middleware accesses `table.id.columnType` up-front, so the real export name is required now. This is a one-word fix (`DbTemplate` -> `Template`) with an inline comment explaining why.

## Validation

- `npm test` in `server/`: **98/98 passing** (16 in `crud.test.ts`)
- `npx tsc --noEmit` in `server/`: clean

## Non-goals

- UUID format validation is out of scope; the guard skips UUID tables and leaves DB-layer errors in place
- No changes to `parseInt` call sites inside handlers; the middleware guarantees strict-decimal input reaches them
- No overlap with #187 (`defaultWhereClause` SQL injection guard) or #177 (`parseQueryParams` hardening) — different functions in the same file

## Author Checklist

- [x] DCO sign-off provided
- [x] Tests added and passing
- [x] Typecheck clean