### PR TITLE
chore(deps): drop placeholder crypto npm package

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,7 +16,6 @@
         "@accordproject/template-engine": "2.7.1",
         "@modelcontextprotocol/sdk": "1.15.1",
         "adm-zip": "0.5.16",
-        "crypto": "1.0.1",
         "dotenv": "16.5.0",
         "drizzle-orm": "0.45.2",
         "drizzle-zod": "0.7.1",
@@ -7178,13 +7177,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
-      "license": "ISC"
     },
     "node_modules/crypto-js": {
       "version": "4.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,6 @@
     "@accordproject/template-engine": "2.7.1",
     "@modelcontextprotocol/sdk": "1.15.1",
     "adm-zip": "0.5.16",
-    "crypto": "1.0.1",
     "dotenv": "16.5.0",
     "drizzle-orm": "0.45.2",
     "drizzle-zod": "0.7.1",


### PR DESCRIPTION
## Summary

`server/package.json` listed `crypto@1.0.1` as a runtime dependency. That is not the Node builtin `crypto`; it is a registry stub that npm itself marks as `deprecated: "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."`.

## What this PR does

- Removes the `crypto: 1.0.1` line from `server/package.json`
- Regenerates `server/package-lock.json` (only the `node_modules/crypto` entry drops, no other deps bump)

## Why the stub is a no-op

Bare specifiers like `import * as crypto from 'crypto'` resolve to Node's builtin regardless of what is under `node_modules/`. Node builtins take precedence over installed packages, so the stub was doing nothing at runtime except wasting install-time bandwidth and confusing anyone reading the manifest.

## Validation

- The one existing `import * as crypto from 'crypto'` call site is `server/handlers/mcp.ts:7`, still resolves to the Node builtin after removal
- `npm test` in `server/`: 8/8 test suites pass (98 tests including the recently landed `handlers/mcp-session-cleanup.test.ts`, `handlers/crud.test.ts`, and `handlers/mcp.test.ts`)
- Lock-file diff is 9 lines removed, scoped to the `crypto` stub entry only. `crypto-js` (a legitimate different package) is untouched.

## Author Checklist

- [x] DCO sign-off provided
- [x] Tests passing
- [x] No other deps bumped in lock file