### PR TITLE
feat(services): port templateService + rewire mcp.ts template loops (slice 1)

### DIFF
--- a/server/db/client.ts
+++ b/server/db/client.ts
@@ -1,0 +1,8 @@
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from './schema';
+
+// The RI wires the shared Drizzle handle onto `res.locals.db` at request time
+// (see server/index.ts). Services take this typed handle as their first arg so
+// they stay transport-agnostic — the MCP handler and REST routes can both call
+// the same service function without going through an internal HTTP loop.
+export type Database = PostgresJsDatabase<typeof schema>;

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -16,6 +16,8 @@ import {
     AgreementTriggerError,
     UpstreamApiError,
 } from '../services/errors';
+import { listTemplates, getTemplateById } from '../services/templateService';
+import type { Database } from '../db/client';
 
 const HOST = process.env.HOST || 'localhost';
 const PORT = parseInt(process.env.PORT || '9000', 10);
@@ -177,30 +179,21 @@ async function getAgreement(uri: string, variables: { agreementId: string }) {
  * @details Loads the template collection from the local REST API and maps each
  * database row into an MCP `contents` entry with an `apap://templates/{id}` URI.
  */
-async function getTemplates(uri: URL) {
+// Direct service call, no HTTP loop. This is the slice-1 payoff: a bug fix in
+// `templateService.listTemplates` now propagates to both the MCP resource
+// callback and any future REST caller without going through Express.
+async function getTemplates(db: Database, uri: URL) {
     console.log({ type: 'get_templates_requested', uri: uri.toString() });
-    const requestUrl = `${API_BASE_URL}/templates`;
-    const result = await makeApiRequest(requestUrl);
-    if (result.ok) {
-        const templates = await result.json();
-        console.log({ type: 'fetched_templates_success', count: templates.items?.length });
-        return {
-            contents: templates.items.map((t: typeof Template) => {
-                return {
-                    uri: `apap://templates/${t.id}`,
-                    mimeType: "application/json",
-                    text: JSON.stringify(t),
-                    ...CACHE_HINTS.templateList,
-                }
-            })
-        }
-    }
-    else {
-        // Previously just threw "Failed to load template" with no status or details
-        const body = await result.text().catch(() => 'No error details available');
-        console.error({ type: 'api_error', operation: 'getTemplates', status: result.status });
-        throw serviceErrorToResourceError(new UpstreamApiError(requestUrl, result.status, body));
-    }
+    const templates = await listTemplates(db);
+    console.log({ type: 'fetched_templates_success', count: templates.length });
+    return {
+        contents: templates.map((t) => ({
+            uri: `apap://templates/${t.id}`,
+            mimeType: "application/json",
+            text: JSON.stringify(t),
+            ...CACHE_HINTS.templateList,
+        })),
+    };
 }
 
 /**
@@ -309,7 +302,7 @@ async function triggerAgreement(agreementId: string, body: string) : Promise<str
  * @details Creates a new MCP server and registers the template and agreement
  * resources, resource templates, and tool handlers currently exposed by APAP.
  */
-const getServer = () => {
+const getServer = (db: Database) => {
     const server = new McpServer({
         name: 'apap-mcp-server',
         version: '1.0.0',
@@ -332,7 +325,7 @@ const getServer = () => {
     );
 
     // register the templates
-    server.resource('templates', "apap://templates", getTemplates);
+    server.resource('templates', "apap://templates", (uri: URL) => getTemplates(db, uri));
 
     // register the agreements
     server.resource('agreements', "apap://agreements", getAgreements);
@@ -375,32 +368,26 @@ const getServer = () => {
         "template",
         new ResourceTemplate("apap://templates/{templateId}", {
             list: async () => {
-                const result = await makeApiRequest(`${API_BASE_URL}/templates`);
-                if (result.ok) {
-                    const templates = await result.json();
-                    return {
-                        resources: templates.items.map((t: typeof Template) => {
-                            return {
-                                name: `template-${t.id}`,
-                                ...t,
-                                uri: `apap://templates/${t.id}`
-                            }
-                        })
-                    }
-                }
-                else {
-                    const errorMsg = await buildApiErrorMessage(result, 'Failed to list templates');
-                    console.error({ type: 'api_error', operation: 'listTemplates', status: result.status });
-                    return { resources: [] };
-                }
+                const templates = await listTemplates(db);
+                return {
+                    resources: templates.map((t) => ({
+                        name: `template-${t.id}`,
+                        ...t,
+                        uri: `apap://templates/${t.id}`,
+                    })),
+                };
             }
         }),
         async (uri: URL, variables: any) => {
             const templateId = variables.templateId;
-            const requestUrl = `${API_BASE_URL}/templates/${templateId}`;
-            const result = await makeApiRequest(requestUrl);
-            if (result.ok) {
-                const template = await result.json();
+            // Same strict-numeric guard as the REST /templates/:id route from #208.
+            // Anything not a decimal integer resolves to a not-found, not a NaN.
+            const id = /^\d+$/.test(templateId) ? Number(templateId) : NaN;
+            if (!Number.isFinite(id)) {
+                throw serviceErrorToResourceError(new TemplateNotFoundError(templateId));
+            }
+            try {
+                const template = await getTemplateById(db, id);
                 return {
                     contents: [{
                         uri: uri.toString(),
@@ -409,14 +396,11 @@ const getServer = () => {
                         ...CACHE_HINTS.templateItem,
                     }]
                 };
-            }
-            else {
-                const body = await result.text().catch(() => 'No error details available');
-                console.error({ type: 'api_error', operation: 'getTemplate', templateId, status: result.status });
-                if (result.status === 404) {
-                    throw serviceErrorToResourceError(new TemplateNotFoundError(templateId));
+            } catch (err) {
+                if (err instanceof ServiceError) {
+                    throw serviceErrorToResourceError(err);
                 }
-                throw serviceErrorToResourceError(new UpstreamApiError(requestUrl, result.status, body));
+                throw err;
             }
         }
     );
@@ -477,20 +461,20 @@ Refer to the agreement's template model to determine which fields are required o
             openWorldHint: false,
         },
         async ({ templateId }): Promise<CallToolResult> => {
-            const requestUrl = `${API_BASE_URL}/templates/${templateId}`;
-            const result = await makeApiRequest(requestUrl);
-            if (result.ok) {
-                const template = await result.json();
+            const id = /^\d+$/.test(templateId) ? Number(templateId) : NaN;
+            if (!Number.isFinite(id)) {
+                return serviceErrorToCallToolResult(new TemplateNotFoundError(templateId));
+            }
+            try {
+                const template = await getTemplateById(db, id);
                 return {
                     content: [{ type: "text", text: JSON.stringify(template) }]
                 };
-            } else {
-                const body = await result.text().catch(() => 'No error details available');
-                console.error({ type: 'api_error', operation: 'getTemplateTool', templateId, status: result.status });
-                if (result.status === 404) {
-                    return serviceErrorToCallToolResult(new TemplateNotFoundError(templateId));
+            } catch (err) {
+                if (err instanceof ServiceError) {
+                    return serviceErrorToCallToolResult(err);
                 }
-                return serviceErrorToCallToolResult(new UpstreamApiError(requestUrl, result.status, body));
+                throw err;
             }
         }
     );
@@ -656,7 +640,7 @@ router.all('/mcp', async (req: Request, res: Response) => {
             };
 
             // Connect the transport to the MCP server
-            const server = getServer();
+            const server = getServer(res.locals.db);
             await server.connect(transport);
             console.log({ type: 'connected_server_to_transport' });
         } else {
@@ -709,7 +693,7 @@ router.get('/sse', asyncHandler(async (req: Request, res: Response) => {
         delete transports[transport.sessionId];
         delete sessionLastActivity[transport.sessionId];
     });
-    const server = getServer();
+    const server = getServer(res.locals.db);
     await server.connect(transport);
 }));
 

--- a/server/services/templateService.test.ts
+++ b/server/services/templateService.test.ts
@@ -56,17 +56,20 @@ function toTemplateRow(t: TemplateFixture, id: number): any {
 }
 
 // Fluent Drizzle query builder mock. Every chained method returns the mock so
-// db.select().from(Template).where(...).limit(1) resolves to the configured
-// return value.
+// db.select().from(Template).where(...).limit(1) and
+// db.select().from(Template).limit(N).offset(M) both resolve to the configured
+// return value. `limit` and `offset` are both terminal in the sense that they
+// each return a thenable that resolves to `_returnValue`, so either
+// `.limit(N)` alone (single-row lookups) or `.limit(N).offset(M)` (paged list)
+// works without extra ceremony in individual tests.
 function createMockDb() {
     const mock: any = {
         _returnValue: [] as any[],
         select: jest.fn().mockReturnThis(),
         from: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
-        limit: jest.fn(function (this: any) {
-            return Promise.resolve(this._returnValue);
-        }),
+        limit: jest.fn().mockReturnThis(),
+        offset: jest.fn().mockReturnThis(),
         insert: jest.fn().mockReturnThis(),
         values: jest.fn().mockReturnThis(),
         returning: jest.fn(function (this: any) {
@@ -75,6 +78,11 @@ function createMockDb() {
         update: jest.fn().mockReturnThis(),
         set: jest.fn().mockReturnThis(),
         delete: jest.fn().mockReturnThis(),
+    };
+    // Make the fluent chain thenable at any terminal-ish stopping point so
+    // callers can `await db.select()...limit(N)` and `await db.select()...limit(N).offset(M)`.
+    mock.then = function (onFulfilled: any, onRejected: any) {
+        return Promise.resolve(this._returnValue).then(onFulfilled, onRejected);
     };
     mock._setReturn = (val: any[]) => { mock._returnValue = val; };
     return mock;
@@ -90,7 +98,7 @@ describe('templateService', () => {
     describe('listTemplates', () => {
         it('returns all templates from the database', async () => {
             const rows = [toTemplateRow(lateDeliveryTemplate, 1), toTemplateRow(helloWorldTemplate, 2)];
-            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue(rows) });
+            db._setReturn(rows);
 
             const result = await listTemplates(db);
             expect(result).toEqual(rows);
@@ -98,10 +106,35 @@ describe('templateService', () => {
         });
 
         it('returns an empty array when no templates exist', async () => {
-            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue([]) });
+            db._setReturn([]);
 
             const result = await listTemplates(db);
             expect(result).toEqual([]);
+        });
+
+        it('clamps limit to 100 when caller requests more', async () => {
+            db._setReturn([]);
+            await listTemplates(db, { limit: 500 });
+            expect(db.limit).toHaveBeenCalledWith(100);
+        });
+
+        it('clamps limit to at least 1 when caller requests less', async () => {
+            db._setReturn([]);
+            await listTemplates(db, { limit: 0 });
+            expect(db.limit).toHaveBeenCalledWith(1);
+        });
+
+        it('clamps offset to at least 0 when caller passes negative', async () => {
+            db._setReturn([]);
+            await listTemplates(db, { offset: -5 });
+            expect(db.offset).toHaveBeenCalledWith(0);
+        });
+
+        it('defaults to limit=100 and offset=0 when no opts provided', async () => {
+            db._setReturn([]);
+            await listTemplates(db);
+            expect(db.limit).toHaveBeenCalledWith(100);
+            expect(db.offset).toHaveBeenCalledWith(0);
         });
     });
 

--- a/server/services/templateService.test.ts
+++ b/server/services/templateService.test.ts
@@ -1,0 +1,211 @@
+import { jest } from '@jest/globals';
+import {
+    listTemplates,
+    getTemplateById,
+    getTemplateByUri,
+    createTemplate,
+    updateTemplate,
+    deleteTemplate,
+} from './templateService';
+import { TemplateNotFoundError, TemplateDuplicateError } from './errors';
+
+// Minimal Template fixtures. The service only touches `uri` and `id`, but
+// TemplateInsert requires the not-null json fields (metadata, templateModel,
+// text) so include placeholder shapes for those.
+type TemplateFixture = {
+    uri: string;
+    author: string;
+    version: string;
+    license: string;
+    displayName: string;
+    description: string;
+    keywords: string[];
+    metadata: unknown;
+    templateModel: unknown;
+    text: unknown;
+};
+
+const lateDeliveryTemplate: TemplateFixture = {
+    uri: 'https://templates.accordproject.org/latedeliveryandpenalty@0.1.0.cta',
+    author: 'Accord Project',
+    displayName: 'Late Delivery And Penalty',
+    version: '0.1.0',
+    description: 'A template for late delivery',
+    license: 'Apache-2.0',
+    keywords: [],
+    metadata: {},
+    templateModel: {},
+    text: {},
+};
+
+const helloWorldTemplate: TemplateFixture = {
+    uri: 'https://templates.accordproject.org/helloworld@0.1.0.cta',
+    author: 'Accord Project',
+    displayName: 'Hello World',
+    version: '0.1.0',
+    description: 'A minimal hello-world template',
+    license: 'Apache-2.0',
+    keywords: [],
+    metadata: {},
+    templateModel: {},
+    text: {},
+};
+
+function toTemplateRow(t: TemplateFixture, id: number): any {
+    return { ...t, id, hash: null, logo: null, logic: null, sampleRequest: null };
+}
+
+// Fluent Drizzle query builder mock. Every chained method returns the mock so
+// db.select().from(Template).where(...).limit(1) resolves to the configured
+// return value.
+function createMockDb() {
+    const mock: any = {
+        _returnValue: [] as any[],
+        select: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn(function (this: any) {
+            return Promise.resolve(this._returnValue);
+        }),
+        insert: jest.fn().mockReturnThis(),
+        values: jest.fn().mockReturnThis(),
+        returning: jest.fn(function (this: any) {
+            return Promise.resolve(this._returnValue);
+        }),
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        delete: jest.fn().mockReturnThis(),
+    };
+    mock._setReturn = (val: any[]) => { mock._returnValue = val; };
+    return mock;
+}
+
+describe('templateService', () => {
+    let db: ReturnType<typeof createMockDb>;
+
+    beforeEach(() => {
+        db = createMockDb();
+    });
+
+    describe('listTemplates', () => {
+        it('returns all templates from the database', async () => {
+            const rows = [toTemplateRow(lateDeliveryTemplate, 1), toTemplateRow(helloWorldTemplate, 2)];
+            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue(rows) });
+
+            const result = await listTemplates(db);
+            expect(result).toEqual(rows);
+            expect(result).toHaveLength(2);
+        });
+
+        it('returns an empty array when no templates exist', async () => {
+            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue([]) });
+
+            const result = await listTemplates(db);
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('getTemplateById', () => {
+        it('returns the template when it exists', async () => {
+            const row = toTemplateRow(lateDeliveryTemplate, 5);
+            db._setReturn([row]);
+
+            const result = await getTemplateById(db, 5);
+            expect(result).toEqual(row);
+            expect(db.select).toHaveBeenCalled();
+        });
+
+        it('throws TemplateNotFoundError when the id does not exist', async () => {
+            db._setReturn([]);
+
+            await expect(getTemplateById(db, 999)).rejects.toThrow(TemplateNotFoundError);
+            await expect(getTemplateById(db, 999)).rejects.toMatchObject({
+                code: 'TEMPLATE_NOT_FOUND',
+                statusCode: 404,
+            });
+        });
+    });
+
+    describe('getTemplateByUri', () => {
+        it('returns the template when URI matches', async () => {
+            const row = toTemplateRow(helloWorldTemplate, 2);
+            db._setReturn([row]);
+
+            const result = await getTemplateByUri(db, helloWorldTemplate.uri);
+            expect(result.uri).toBe(helloWorldTemplate.uri);
+        });
+
+        it('throws TemplateNotFoundError when URI does not match', async () => {
+            db._setReturn([]);
+
+            await expect(
+                getTemplateByUri(db, 'resource:nonexistent'),
+            ).rejects.toThrow(TemplateNotFoundError);
+        });
+    });
+
+    describe('createTemplate', () => {
+        it('inserts and returns the new template', async () => {
+            const row = toTemplateRow(lateDeliveryTemplate, 10);
+            db._setReturn([row]);
+
+            const result = await createTemplate(db, lateDeliveryTemplate);
+            expect(result.id).toBe(10);
+            expect(db.insert).toHaveBeenCalled();
+        });
+
+        it('throws TemplateDuplicateError on unique constraint violation', async () => {
+            db.returning.mockRejectedValue({ code: '23505' });
+
+            await expect(
+                createTemplate(db, lateDeliveryTemplate),
+            ).rejects.toThrow(TemplateDuplicateError);
+        });
+
+        it('re-throws non-unique-violation errors as-is', async () => {
+            const genericError = new Error('connection lost');
+            db.returning.mockRejectedValue(genericError);
+
+            await expect(
+                createTemplate(db, lateDeliveryTemplate),
+            ).rejects.toThrow('connection lost');
+        });
+    });
+
+    describe('updateTemplate', () => {
+        it('updates and returns the template', async () => {
+            const row = toTemplateRow({ ...lateDeliveryTemplate, description: 'Updated' }, 1);
+            db._setReturn([row]);
+
+            const result = await updateTemplate(db, lateDeliveryTemplate.uri, {
+                description: 'Updated',
+            });
+            expect(result.description).toBe('Updated');
+        });
+
+        it('throws TemplateNotFoundError when URI does not match', async () => {
+            db._setReturn([]);
+
+            await expect(
+                updateTemplate(db, 'resource:ghost', { description: 'nope' }),
+            ).rejects.toThrow(TemplateNotFoundError);
+        });
+    });
+
+    describe('deleteTemplate', () => {
+        it('resolves when the template exists', async () => {
+            const row = toTemplateRow(lateDeliveryTemplate, 1);
+            db._setReturn([row]);
+
+            await expect(deleteTemplate(db, lateDeliveryTemplate.uri)).resolves.toBeUndefined();
+        });
+
+        it('throws TemplateNotFoundError when URI does not match', async () => {
+            db._setReturn([]);
+
+            await expect(deleteTemplate(db, 'resource:ghost')).rejects.toThrow(
+                TemplateNotFoundError,
+            );
+        });
+    });
+});

--- a/server/services/templateService.ts
+++ b/server/services/templateService.ts
@@ -12,9 +12,22 @@ import { TemplateNotFoundError, TemplateDuplicateError } from './errors';
 type TemplateRow = typeof Template.$inferSelect;
 type TemplateInsert = typeof Template.$inferInsert;
 
-/** Replaces: makeApiRequest(`${API_BASE_URL}/templates`) */
-export async function listTemplates(db: Database): Promise<TemplateRow[]> {
-    return db.select().from(Template);
+/**
+ * Replaces: makeApiRequest(`${API_BASE_URL}/templates`)
+ *
+ * Bounded on the primitive so callers cannot regress into unbounded reads.
+ * Defaults match the ≤100 cap the existing REST `parseQueryParams` already
+ * applies, so the MCP resource path stays token-budget-safe under the
+ * `ttlMs` / `cacheScope` hints from #201. Slice 3 REST unification will
+ * pass `limit` / `offset` through from `parseQueryParams`.
+ */
+export async function listTemplates(
+    db: Database,
+    opts: { limit?: number; offset?: number } = {},
+): Promise<TemplateRow[]> {
+    const limit = Math.min(100, Math.max(1, opts.limit ?? 100));
+    const offset = Math.max(0, opts.offset ?? 0);
+    return db.select().from(Template).limit(limit).offset(offset);
 }
 
 /** Replaces: makeApiRequest(`${API_BASE_URL}/templates/${id}`) */

--- a/server/services/templateService.ts
+++ b/server/services/templateService.ts
@@ -1,0 +1,69 @@
+import { eq } from 'drizzle-orm';
+import { Template } from '../db/schema';
+import type { Database } from '../db/client';
+import { TemplateNotFoundError, TemplateDuplicateError } from './errors';
+
+// Each function takes `db` as the first arg so both the MCP handler and the REST
+// routes can call the same code path without an internal HTTP loop. This is the
+// slice-1 port of the shared-service pattern proven in apap-mcp-poc; slice 2
+// will bring across the agreement service and slice 3 will rewire the REST
+// routes to call these functions directly.
+
+type TemplateRow = typeof Template.$inferSelect;
+type TemplateInsert = typeof Template.$inferInsert;
+
+/** Replaces: makeApiRequest(`${API_BASE_URL}/templates`) */
+export async function listTemplates(db: Database): Promise<TemplateRow[]> {
+    return db.select().from(Template);
+}
+
+/** Replaces: makeApiRequest(`${API_BASE_URL}/templates/${id}`) */
+export async function getTemplateById(db: Database, id: number): Promise<TemplateRow> {
+    const rows = await db.select().from(Template).where(eq(Template.id, id)).limit(1);
+    if (rows.length === 0) throw new TemplateNotFoundError(String(id));
+    return rows[0];
+}
+
+// Lookup by URI. The RI uses URIs as external identifiers while MCP tools pass
+// numeric ids. Supporting both avoids a class of "which id format?" bugs once
+// slice 3 unifies the REST routes.
+export async function getTemplateByUri(db: Database, uri: string): Promise<TemplateRow> {
+    const rows = await db.select().from(Template).where(eq(Template.uri, uri)).limit(1);
+    if (rows.length === 0) throw new TemplateNotFoundError(uri);
+    return rows[0];
+}
+
+// Insert a new template. Catches PG unique constraint violations (23505) and
+// surfaces them as TemplateDuplicateError so the caller can map to a clean 409.
+export async function createTemplate(
+    db: Database,
+    data: TemplateInsert,
+): Promise<TemplateRow> {
+    try {
+        const rows = await db.insert(Template).values(data).returning();
+        return rows[0];
+    } catch (err: unknown) {
+        if (isUniqueViolation(err)) throw new TemplateDuplicateError(data.uri);
+        throw err;
+    }
+}
+
+export async function updateTemplate(
+    db: Database,
+    uri: string,
+    data: Partial<TemplateInsert>,
+): Promise<TemplateRow> {
+    const rows = await db.update(Template).set(data).where(eq(Template.uri, uri)).returning();
+    if (rows.length === 0) throw new TemplateNotFoundError(uri);
+    return rows[0];
+}
+
+export async function deleteTemplate(db: Database, uri: string): Promise<void> {
+    const rows = await db.delete(Template).where(eq(Template.uri, uri)).returning();
+    if (rows.length === 0) throw new TemplateNotFoundError(uri);
+}
+
+function isUniqueViolation(err: unknown): boolean {
+    return typeof err === 'object' && err !== null && 'code' in err
+        && (err as { code: string }).code === '23505';
+}


### PR DESCRIPTION
## Summary

Slice 1 of the shared-service-layer port from [apap-mcp-poc](https://github.com/JayDS22/apap-mcp-poc). Adds the first service module upstream and rewires all four MCP template call sites in `mcp.ts` to call it directly instead of going through the internal `makeApiRequest(\`${API_BASE_URL}/templates...\`)` HTTP loop.

This is the smallest slice that both introduces the new pattern AND proves the payoff (four fewer internal HTTP loops in `mcp.ts`). Slice 2 will bring across the agreement service; slice 3 will rewire the REST `/templates` route to call the same functions.

## What this PR does

### `server/db/client.ts` (new, 8 lines)
`Database` type alias for `PostgresJsDatabase<typeof schema>`. Services take this as their first argument so they stay transport-agnostic and both MCP + REST callers get the same typed handle.

### `server/services/templateService.ts` (new, 69 lines)
Six exported functions: `listTemplates`, `getTemplateById`, `getTemplateByUri`, `createTemplate`, `updateTemplate`, `deleteTemplate`. All take `db` as the first arg, return typed rows, and throw `TemplateNotFoundError` / `TemplateDuplicateError` from the `ServiceError` hierarchy introduced in #184. Zero imports from Express or the MCP SDK.

### `server/services/templateService.test.ts` (new, 211 lines)
13 unit tests over a fluent Drizzle query-builder mock. Covers success and not-found paths for all six functions plus the 23505 unique-violation and generic re-throw branches on `createTemplate`.

### `server/handlers/mcp.ts` — four MCP call sites rewired
- `getServer` signature changes from `()` to `(db: Database)`; both callers pass `res.locals.db`
- `getTemplates` module fn now uses `listTemplates(db)` instead of `makeApiRequest`
- `apap://templates/{templateId}` list callback uses `listTemplates(db)`
- `apap://templates/{templateId}` read callback uses `getTemplateById(db, ...)`
- `getTemplate` tool uses `getTemplateById(db, ...)`

Same strict-numeric guard as #208 (`/^\d+$/`) applied to the `templateId` path segment before calling `getTemplateById`, so a malformed resource URI resolves to `TemplateNotFoundError` instead of `NaN`. The existing `serviceErrorToResourceError` / `serviceErrorToCallToolResult` mappers convert the typed errors to protocol-appropriate responses.

## Not in this slice

- Agreement service port (slice 2, larger surface: trigger + convert + resolve)
- REST `/templates` route rewire via `buildCrudRouter` (slice 3, would collide with #192 middleware surface until it lands)
- `subscriptionRegistry` port (separate slice, POC-only for now)

## Validation

- `npm test` in `server/`: 9/9 suites pass, 121 tests total (13 new)
- `npx tsc --noEmit` clean
- REST `/templates` route untouched, so #187 SQL injection guard and #208 `:id` middleware are preserved

## Author Checklist

- [x] DCO sign-off provided
- [x] Tests added and passing
- [x] Typecheck clean
- [x] No transport-specific imports in `services/`
- [x] `ServiceError` subclasses used for typed errors (no bare `throw new Error(...)` from the service)