### PR TITLE
feat(services): port agreementService CRUD half + rewire mcp.ts agreement lookups (slice 2)

### DIFF
--- a/server/db/client.ts
+++ b/server/db/client.ts
@@ -1,0 +1,8 @@
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from './schema';
+
+// The RI wires the shared Drizzle handle onto `res.locals.db` at request time
+// (see server/index.ts). Services take this typed handle as their first arg so
+// they stay transport-agnostic — the MCP handler and REST routes can both call
+// the same service function without going through an internal HTTP loop.
+export type Database = PostgresJsDatabase<typeof schema>;

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -17,6 +17,7 @@ import {
     UpstreamApiError,
 } from '../services/errors';
 import { listTemplates, getTemplateById } from '../services/templateService';
+import { listAgreements, getAgreementById } from '../services/agreementService';
 import type { Database } from '../db/client';
 
 const HOST = process.env.HOST || 'localhost';
@@ -143,14 +144,17 @@ export function serviceErrorToResourceError(error: ServiceError): McpError {
  * @details Resolves a single agreement by calling the local REST API and converts
  * the REST response into the `contents` structure expected by the MCP SDK.
  */
-async function getAgreement(uri: string, variables: { agreementId: string }) {
+async function getAgreement(db: Database, uri: string, variables: { agreementId: string }) {
     const { agreementId } = variables;
     console.log({ type: 'fetching_agreement', agreementId });
     const url = new URL(uri);
-    const requestUrl = `${API_BASE_URL}/agreements/${agreementId}`;
-    const result = await makeApiRequest(requestUrl);
-    if (result.ok) {
-        const agreement = await result.json();
+    // Same strict-numeric guard as the REST /agreements/:id route from #208.
+    const id = /^\d+$/.test(agreementId) ? Number(agreementId) : NaN;
+    if (!Number.isFinite(id)) {
+        throw serviceErrorToResourceError(new AgreementNotFoundError(agreementId));
+    }
+    try {
+        const agreement = await getAgreementById(db, id);
         console.log({ type: 'fetched_agreement_success', agreementId });
         return {
             contents: [{
@@ -160,16 +164,11 @@ async function getAgreement(uri: string, variables: { agreementId: string }) {
                 ...CACHE_HINTS.agreementItem,
             }]
         };
-    }
-    else {
-        // Surface the actual status code and API response so the client knows what went wrong
-        const body = await result.text().catch(() => 'No error details available');
-        const errorMsg = `Failed to load agreement '${agreementId}' (HTTP ${result.status}): ${body}`;
-        console.error({ type: 'api_error', operation: 'getAgreement', agreementId, status: result.status });
-        if (result.status === 404) {
-            throw serviceErrorToResourceError(new AgreementNotFoundError(agreementId));
+    } catch (err) {
+        if (err instanceof ServiceError) {
+            throw serviceErrorToResourceError(err);
         }
-        throw serviceErrorToResourceError(new UpstreamApiError(requestUrl, result.status, body));
+        throw err;
     }
 }
 
@@ -202,40 +201,29 @@ async function getTemplates(db: Database, uri: URL) {
  * @details Loads the agreement collection from the local REST API and serializes
  * each item into the MCP resource format expected by agreement resources.
  */
-async function getAgreements(uri: URL) {
+async function getAgreements(db: Database, uri: URL) {
     console.log({ type: 'get_agreements_requested', uri: uri.toString() });
-    const requestUrl = `${API_BASE_URL}/agreements`;
-    const result = await makeApiRequest(requestUrl);
-    if (result.ok) {
-        const agreements = await result.json();
-        console.log({ type: 'fetched_agreements_success', count: agreements.items?.length });
-        return {
-            // FIX for issue #128: The previous version spread the full agreement object
-            // (...a) after setting the uri field. Because the Agreement row from the
-            // database carries its own `uri` property (e.g. "resource:org.accordproject..."),
-            // the spread overwrote the MCP resource URI ("apap://agreements/{id}") with the
-            // agreement's data URI. MCP clients then failed to resolve the resource because
-            // they tried to use the wrong URI scheme.
-            //
-            // The ReadResourceResult `contents` array only needs { uri, mimeType, text },
-            // so spreading the entire row object onto it was also polluting the content
-            // with unrelated database fields. The agreement payload is already serialized
-            // inside the `text` property as JSON, which is where MCP clients read it from.
-            contents: agreements.items.map((a: typeof Agreement) => {
-                return {
-                    mimeType: "application/json",
-                    text: JSON.stringify({ ...a.data, $identifier: a.id }, null, 2),
-                    uri: `apap://agreements/${a.id}`,
-                    ...CACHE_HINTS.agreementList,
-                }
-            })
-        }
-    }
-    else {
-        const body = await result.text().catch(() => 'No error details available');
-        console.error({ type: 'api_error', operation: 'getAgreements', status: result.status });
-        throw serviceErrorToResourceError(new UpstreamApiError(requestUrl, result.status, body));
-    }
+    const agreements = await listAgreements(db);
+    console.log({ type: 'fetched_agreements_success', count: agreements.length });
+    return {
+        // FIX for issue #128: The previous version spread the full agreement object
+        // (...a) after setting the uri field. Because the Agreement row from the
+        // database carries its own `uri` property (e.g. "resource:org.accordproject..."),
+        // the spread overwrote the MCP resource URI ("apap://agreements/{id}") with the
+        // agreement's data URI. MCP clients then failed to resolve the resource because
+        // they tried to use the wrong URI scheme.
+        //
+        // The ReadResourceResult `contents` array only needs { uri, mimeType, text },
+        // so spreading the entire row object onto it was also polluting the content
+        // with unrelated database fields. The agreement payload is already serialized
+        // inside the `text` property as JSON, which is where MCP clients read it from.
+        contents: agreements.map((a) => ({
+            mimeType: "application/json",
+            text: JSON.stringify({ ...(a.data as Record<string, unknown> ?? {}), $identifier: a.id }, null, 2),
+            uri: `apap://agreements/${a.id}`,
+            ...CACHE_HINTS.agreementList,
+        })),
+    };
 }
 
 /**
@@ -328,38 +316,26 @@ const getServer = (db: Database) => {
     server.resource('templates', "apap://templates", (uri: URL) => getTemplates(db, uri));
 
     // register the agreements
-    server.resource('agreements', "apap://agreements", getAgreements);
+    server.resource('agreements', "apap://agreements", (uri: URL) => getAgreements(db, uri));
 
     // register resource template for agreements
     server.resource(
         "agreement",
         new ResourceTemplate("apap://agreements/{agreementId}", {
             list: async () => {
-                const result = await makeApiRequest(`${API_BASE_URL}/agreements`);
-                if (result.ok) {
-                    const agreements = await result.json();
-                    return {
-                        resources: agreements.items.map((a: typeof Agreement) => {
-                            return {
-                                name: `agreement-${a.id}`,
-                                ...a,
-                                uri: `apap://agreements/${a.id}`
-                            }
-                        })
-                    }
-                }
-                else {
-                    // List operations return empty rather than throwing, but we still log
-                    // the actual error for debugging
-                    const errorMsg = await buildApiErrorMessage(result, 'Failed to list agreements');
-                    console.error({ type: 'api_error', operation: 'listAgreements', status: result.status });
-                    return { resources: [] };
-                }
+                const agreements = await listAgreements(db);
+                return {
+                    resources: agreements.map((a) => ({
+                        name: `agreement-${a.id}`,
+                        ...a,
+                        uri: `apap://agreements/${a.id}`,
+                    })),
+                };
             }
         }),
         async (uri: URL, variables: any) => {
             const agreementId = variables.agreementId;
-            return await getAgreement(uri.toString(), { agreementId });
+            return await getAgreement(db, uri.toString(), { agreementId });
         }
     );
 
@@ -493,20 +469,20 @@ Refer to the agreement's template model to determine which fields are required o
             openWorldHint: false,
         },
         async ({ agreementId }): Promise<CallToolResult> => {
-            const requestUrl = `${API_BASE_URL}/agreements/${agreementId}`;
-            const result = await makeApiRequest(requestUrl);
-            if (result.ok) {
-                const agreement = await result.json();
+            const id = /^\d+$/.test(agreementId) ? Number(agreementId) : NaN;
+            if (!Number.isFinite(id)) {
+                return serviceErrorToCallToolResult(new AgreementNotFoundError(agreementId));
+            }
+            try {
+                const agreement = await getAgreementById(db, id);
                 return {
                     content: [{ type: "text", text: JSON.stringify(agreement) }]
                 };
-            } else {
-                const body = await result.text().catch(() => 'No error details available');
-                console.error({ type: 'api_error', operation: 'getAgreementTool', agreementId, status: result.status });
-                if (result.status === 404) {
-                    return serviceErrorToCallToolResult(new AgreementNotFoundError(agreementId));
+            } catch (err) {
+                if (err instanceof ServiceError) {
+                    return serviceErrorToCallToolResult(err);
                 }
-                return serviceErrorToCallToolResult(new UpstreamApiError(requestUrl, result.status, body));
+                throw err;
             }
         }
     );

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -16,6 +16,8 @@ import {
     AgreementTriggerError,
     UpstreamApiError,
 } from '../services/errors';
+import { listTemplates, getTemplateById } from '../services/templateService';
+import type { Database } from '../db/client';
 
 const HOST = process.env.HOST || 'localhost';
 const PORT = parseInt(process.env.PORT || '9000', 10);
@@ -177,30 +179,21 @@ async function getAgreement(uri: string, variables: { agreementId: string }) {
  * @details Loads the template collection from the local REST API and maps each
  * database row into an MCP `contents` entry with an `apap://templates/{id}` URI.
  */
-async function getTemplates(uri: URL) {
+// Direct service call, no HTTP loop. This is the slice-1 payoff: a bug fix in
+// `templateService.listTemplates` now propagates to both the MCP resource
+// callback and any future REST caller without going through Express.
+async function getTemplates(db: Database, uri: URL) {
     console.log({ type: 'get_templates_requested', uri: uri.toString() });
-    const requestUrl = `${API_BASE_URL}/templates`;
-    const result = await makeApiRequest(requestUrl);
-    if (result.ok) {
-        const templates = await result.json();
-        console.log({ type: 'fetched_templates_success', count: templates.items?.length });
-        return {
-            contents: templates.items.map((t: typeof Template) => {
-                return {
-                    uri: `apap://templates/${t.id}`,
-                    mimeType: "application/json",
-                    text: JSON.stringify(t),
-                    ...CACHE_HINTS.templateList,
-                }
-            })
-        }
-    }
-    else {
-        // Previously just threw "Failed to load template" with no status or details
-        const body = await result.text().catch(() => 'No error details available');
-        console.error({ type: 'api_error', operation: 'getTemplates', status: result.status });
-        throw serviceErrorToResourceError(new UpstreamApiError(requestUrl, result.status, body));
-    }
+    const templates = await listTemplates(db);
+    console.log({ type: 'fetched_templates_success', count: templates.length });
+    return {
+        contents: templates.map((t) => ({
+            uri: `apap://templates/${t.id}`,
+            mimeType: "application/json",
+            text: JSON.stringify(t),
+            ...CACHE_HINTS.templateList,
+        })),
+    };
 }
 
 /**
@@ -309,7 +302,7 @@ async function triggerAgreement(agreementId: string, body: string) : Promise<str
  * @details Creates a new MCP server and registers the template and agreement
  * resources, resource templates, and tool handlers currently exposed by APAP.
  */
-const getServer = () => {
+const getServer = (db: Database) => {
     const server = new McpServer({
         name: 'apap-mcp-server',
         version: '1.0.0',
@@ -332,7 +325,7 @@ const getServer = () => {
     );
 
     // register the templates
-    server.resource('templates', "apap://templates", getTemplates);
+    server.resource('templates', "apap://templates", (uri: URL) => getTemplates(db, uri));
 
     // register the agreements
     server.resource('agreements', "apap://agreements", getAgreements);
@@ -375,32 +368,26 @@ const getServer = () => {
         "template",
         new ResourceTemplate("apap://templates/{templateId}", {
             list: async () => {
-                const result = await makeApiRequest(`${API_BASE_URL}/templates`);
-                if (result.ok) {
-                    const templates = await result.json();
-                    return {
-                        resources: templates.items.map((t: typeof Template) => {
-                            return {
-                                name: `template-${t.id}`,
-                                ...t,
-                                uri: `apap://templates/${t.id}`
-                            }
-                        })
-                    }
-                }
-                else {
-                    const errorMsg = await buildApiErrorMessage(result, 'Failed to list templates');
-                    console.error({ type: 'api_error', operation: 'listTemplates', status: result.status });
-                    return { resources: [] };
-                }
+                const templates = await listTemplates(db);
+                return {
+                    resources: templates.map((t) => ({
+                        name: `template-${t.id}`,
+                        ...t,
+                        uri: `apap://templates/${t.id}`,
+                    })),
+                };
             }
         }),
         async (uri: URL, variables: any) => {
             const templateId = variables.templateId;
-            const requestUrl = `${API_BASE_URL}/templates/${templateId}`;
-            const result = await makeApiRequest(requestUrl);
-            if (result.ok) {
-                const template = await result.json();
+            // Same strict-numeric guard as the REST /templates/:id route from #208.
+            // Anything not a decimal integer resolves to a not-found, not a NaN.
+            const id = /^\d+$/.test(templateId) ? Number(templateId) : NaN;
+            if (!Number.isFinite(id)) {
+                throw serviceErrorToResourceError(new TemplateNotFoundError(templateId));
+            }
+            try {
+                const template = await getTemplateById(db, id);
                 return {
                     contents: [{
                         uri: uri.toString(),
@@ -409,14 +396,11 @@ const getServer = () => {
                         ...CACHE_HINTS.templateItem,
                     }]
                 };
-            }
-            else {
-                const body = await result.text().catch(() => 'No error details available');
-                console.error({ type: 'api_error', operation: 'getTemplate', templateId, status: result.status });
-                if (result.status === 404) {
-                    throw serviceErrorToResourceError(new TemplateNotFoundError(templateId));
+            } catch (err) {
+                if (err instanceof ServiceError) {
+                    throw serviceErrorToResourceError(err);
                 }
-                throw serviceErrorToResourceError(new UpstreamApiError(requestUrl, result.status, body));
+                throw err;
             }
         }
     );
@@ -477,20 +461,20 @@ Refer to the agreement's template model to determine which fields are required o
             openWorldHint: false,
         },
         async ({ templateId }): Promise<CallToolResult> => {
-            const requestUrl = `${API_BASE_URL}/templates/${templateId}`;
-            const result = await makeApiRequest(requestUrl);
-            if (result.ok) {
-                const template = await result.json();
+            const id = /^\d+$/.test(templateId) ? Number(templateId) : NaN;
+            if (!Number.isFinite(id)) {
+                return serviceErrorToCallToolResult(new TemplateNotFoundError(templateId));
+            }
+            try {
+                const template = await getTemplateById(db, id);
                 return {
                     content: [{ type: "text", text: JSON.stringify(template) }]
                 };
-            } else {
-                const body = await result.text().catch(() => 'No error details available');
-                console.error({ type: 'api_error', operation: 'getTemplateTool', templateId, status: result.status });
-                if (result.status === 404) {
-                    return serviceErrorToCallToolResult(new TemplateNotFoundError(templateId));
+            } catch (err) {
+                if (err instanceof ServiceError) {
+                    return serviceErrorToCallToolResult(err);
                 }
-                return serviceErrorToCallToolResult(new UpstreamApiError(requestUrl, result.status, body));
+                throw err;
             }
         }
     );
@@ -656,7 +640,7 @@ router.all('/mcp', async (req: Request, res: Response) => {
             };
 
             // Connect the transport to the MCP server
-            const server = getServer();
+            const server = getServer(res.locals.db);
             await server.connect(transport);
             console.log({ type: 'connected_server_to_transport' });
         } else {
@@ -709,7 +693,7 @@ router.get('/sse', asyncHandler(async (req: Request, res: Response) => {
         delete transports[transport.sessionId];
         delete sessionLastActivity[transport.sessionId];
     });
-    const server = getServer();
+    const server = getServer(res.locals.db);
     await server.connect(transport);
 }));
 

--- a/server/services/agreementService.test.ts
+++ b/server/services/agreementService.test.ts
@@ -1,0 +1,85 @@
+import { jest } from '@jest/globals';
+import { listAgreements, getAgreementById } from './agreementService';
+import { AgreementNotFoundError } from './errors';
+
+// Same Drizzle-mock pattern as templateService.test.ts (see slice 1). The
+// service touches only the fluent select/from/where/limit chain, so a shared
+// mock shape is enough.
+function createMockDb() {
+    const mock: any = {
+        _returnValue: [] as any[],
+        select: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn(function (this: any) {
+            return Promise.resolve(this._returnValue);
+        }),
+    };
+    mock._setReturn = (val: any[]) => { mock._returnValue = val; };
+    return mock;
+}
+
+function agreementRow(id: number, overrides: Record<string, unknown> = {}): any {
+    return {
+        id,
+        uri: `apap://agreements/${id}`,
+        data: {},
+        template: 'https://templates.accordproject.org/latedeliveryandpenalty@0.1.0.cta',
+        state: null,
+        agreementStatus: 'DRAFT',
+        agreementParties: null,
+        signatures: null,
+        historyEntries: null,
+        attachments: null,
+        references: null,
+        metadata: null,
+        ...overrides,
+    };
+}
+
+describe('agreementService', () => {
+    let db: ReturnType<typeof createMockDb>;
+
+    beforeEach(() => {
+        db = createMockDb();
+    });
+
+    describe('listAgreements', () => {
+        it('returns all agreements from the database', async () => {
+            const rows = [agreementRow(1), agreementRow(2)];
+            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue(rows) });
+
+            const result = await listAgreements(db);
+            expect(result).toEqual(rows);
+            expect(result).toHaveLength(2);
+        });
+
+        it('returns an empty array when no agreements exist', async () => {
+            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue([]) });
+
+            const result = await listAgreements(db);
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('getAgreementById', () => {
+        it('returns the agreement when it exists', async () => {
+            const row = agreementRow(5, { agreementStatus: 'SIGNNG' });
+            db._setReturn([row]);
+
+            const result = await getAgreementById(db, 5);
+            expect(result).toEqual(row);
+            expect(db.select).toHaveBeenCalled();
+        });
+
+        it('throws AgreementNotFoundError when the id does not exist', async () => {
+            db._setReturn([]);
+
+            await expect(getAgreementById(db, 999)).rejects.toThrow(AgreementNotFoundError);
+            await expect(getAgreementById(db, 999)).rejects.toMatchObject({
+                code: 'AGREEMENT_NOT_FOUND',
+                statusCode: 404,
+            });
+        });
+    });
+});

--- a/server/services/agreementService.test.ts
+++ b/server/services/agreementService.test.ts
@@ -3,17 +3,20 @@ import { listAgreements, getAgreementById } from './agreementService';
 import { AgreementNotFoundError } from './errors';
 
 // Same Drizzle-mock pattern as templateService.test.ts (see slice 1). The
-// service touches only the fluent select/from/where/limit chain, so a shared
-// mock shape is enough.
+// service touches only the fluent select/from/where/limit(/offset) chain,
+// so a shared mock shape is enough. Both `.limit(N).offset(M)` (paged list)
+// and `.limit(1)` (single-row lookup) resolve via the top-level `then`.
 function createMockDb() {
     const mock: any = {
         _returnValue: [] as any[],
         select: jest.fn().mockReturnThis(),
         from: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
-        limit: jest.fn(function (this: any) {
-            return Promise.resolve(this._returnValue);
-        }),
+        limit: jest.fn().mockReturnThis(),
+        offset: jest.fn().mockReturnThis(),
+    };
+    mock.then = function (onFulfilled: any, onRejected: any) {
+        return Promise.resolve(this._returnValue).then(onFulfilled, onRejected);
     };
     mock._setReturn = (val: any[]) => { mock._returnValue = val; };
     return mock;
@@ -47,15 +50,40 @@ describe('agreementService', () => {
     describe('listAgreements', () => {
         it('returns all agreements from the database', async () => {
             const rows = [agreementRow(1), agreementRow(2)];
-            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue(rows) });
+            db._setReturn(rows);
 
             const result = await listAgreements(db);
             expect(result).toEqual(rows);
             expect(result).toHaveLength(2);
         });
 
+        it('clamps limit to 100 when caller requests more', async () => {
+            db._setReturn([]);
+            await listAgreements(db, { limit: 500 });
+            expect(db.limit).toHaveBeenCalledWith(100);
+        });
+
+        it('clamps limit to at least 1 when caller requests less', async () => {
+            db._setReturn([]);
+            await listAgreements(db, { limit: 0 });
+            expect(db.limit).toHaveBeenCalledWith(1);
+        });
+
+        it('clamps offset to at least 0 when caller passes negative', async () => {
+            db._setReturn([]);
+            await listAgreements(db, { offset: -5 });
+            expect(db.offset).toHaveBeenCalledWith(0);
+        });
+
+        it('defaults to limit=100 and offset=0 when no opts provided', async () => {
+            db._setReturn([]);
+            await listAgreements(db);
+            expect(db.limit).toHaveBeenCalledWith(100);
+            expect(db.offset).toHaveBeenCalledWith(0);
+        });
+
         it('returns an empty array when no agreements exist', async () => {
-            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue([]) });
+            db._setReturn([]);
 
             const result = await listAgreements(db);
             expect(result).toEqual([]);

--- a/server/services/agreementService.test.ts
+++ b/server/services/agreementService.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { listAgreements, getAgreementById } from './agreementService';
+import { listAgreements, getAgreementById, getAgreementByUri } from './agreementService';
 import { AgreementNotFoundError } from './errors';
 
 // Same Drizzle-mock pattern as templateService.test.ts (see slice 1). The
@@ -108,6 +108,24 @@ describe('agreementService', () => {
                 code: 'AGREEMENT_NOT_FOUND',
                 statusCode: 404,
             });
+        });
+    });
+
+    describe('getAgreementByUri', () => {
+        it('returns the agreement when the URI matches', async () => {
+            const row = agreementRow(2, { uri: 'apap://agreements/2' });
+            db._setReturn([row]);
+
+            const result = await getAgreementByUri(db, 'apap://agreements/2');
+            expect(result).toEqual(row);
+        });
+
+        it('throws AgreementNotFoundError when the URI does not match', async () => {
+            db._setReturn([]);
+
+            await expect(
+                getAgreementByUri(db, 'apap://agreements/ghost'),
+            ).rejects.toThrow(AgreementNotFoundError);
         });
     });
 });

--- a/server/services/agreementService.ts
+++ b/server/services/agreementService.ts
@@ -1,0 +1,25 @@
+import { eq } from 'drizzle-orm';
+import { Agreement } from '../db/schema';
+import type { Database } from '../db/client';
+import { AgreementNotFoundError } from './errors';
+
+// Slice 2 ports only the CRUD lookup half of the POC's agreementService. The
+// POC's `convertAgreement` and `triggerAgreement` are stubs; the RI's REST
+// route at `server/handlers/agreements.ts` already runs the real
+// `TemplateArchiveProcessor` from @accordproject/template-engine for those
+// paths. Porting those upstream deserves its own slice (2b) that wraps the
+// real engine rather than replacing it with a POC stub.
+
+type AgreementRow = typeof Agreement.$inferSelect;
+
+/** Replaces: makeApiRequest(`${API_BASE_URL}/agreements`) */
+export async function listAgreements(db: Database): Promise<AgreementRow[]> {
+    return db.select().from(Agreement);
+}
+
+/** Replaces: makeApiRequest(`${API_BASE_URL}/agreements/${id}`) */
+export async function getAgreementById(db: Database, id: number): Promise<AgreementRow> {
+    const rows = await db.select().from(Agreement).where(eq(Agreement.id, id)).limit(1);
+    if (rows.length === 0) throw new AgreementNotFoundError(String(id));
+    return rows[0];
+}

--- a/server/services/agreementService.ts
+++ b/server/services/agreementService.ts
@@ -36,3 +36,14 @@ export async function getAgreementById(db: Database, id: number): Promise<Agreem
     if (rows.length === 0) throw new AgreementNotFoundError(String(id));
     return rows[0];
 }
+
+/**
+ * Lookup by URI. Mirrors the getTemplateByUri surface from slice 1 so callers
+ * that hold a resource URI (e.g. `apap://agreements/{id}` clients or a future
+ * REST resource-URI route) do not have to reconstruct the numeric id first.
+ */
+export async function getAgreementByUri(db: Database, uri: string): Promise<AgreementRow> {
+    const rows = await db.select().from(Agreement).where(eq(Agreement.uri, uri)).limit(1);
+    if (rows.length === 0) throw new AgreementNotFoundError(uri);
+    return rows[0];
+}

--- a/server/services/agreementService.ts
+++ b/server/services/agreementService.ts
@@ -12,9 +12,22 @@ import { AgreementNotFoundError } from './errors';
 
 type AgreementRow = typeof Agreement.$inferSelect;
 
-/** Replaces: makeApiRequest(`${API_BASE_URL}/agreements`) */
-export async function listAgreements(db: Database): Promise<AgreementRow[]> {
-    return db.select().from(Agreement);
+/**
+ * Replaces: makeApiRequest(`${API_BASE_URL}/agreements`)
+ *
+ * Bounded on the primitive so callers cannot regress into unbounded reads.
+ * Defaults match the ≤100 cap the existing REST `parseQueryParams` already
+ * applies, so the `apap://agreements` MCP resource path stays token-budget-
+ * safe under the `ttlMs` / `cacheScope` hints from #201. Slice 3 REST
+ * unification will pass `limit` / `offset` through from `parseQueryParams`.
+ */
+export async function listAgreements(
+    db: Database,
+    opts: { limit?: number; offset?: number } = {},
+): Promise<AgreementRow[]> {
+    const limit = Math.min(100, Math.max(1, opts.limit ?? 100));
+    const offset = Math.max(0, opts.offset ?? 0);
+    return db.select().from(Agreement).limit(limit).offset(offset);
 }
 
 /** Replaces: makeApiRequest(`${API_BASE_URL}/agreements/${id}`) */

--- a/server/services/templateService.test.ts
+++ b/server/services/templateService.test.ts
@@ -56,17 +56,20 @@ function toTemplateRow(t: TemplateFixture, id: number): any {
 }
 
 // Fluent Drizzle query builder mock. Every chained method returns the mock so
-// db.select().from(Template).where(...).limit(1) resolves to the configured
-// return value.
+// db.select().from(Template).where(...).limit(1) and
+// db.select().from(Template).limit(N).offset(M) both resolve to the configured
+// return value. `limit` and `offset` are both terminal in the sense that they
+// each return a thenable that resolves to `_returnValue`, so either
+// `.limit(N)` alone (single-row lookups) or `.limit(N).offset(M)` (paged list)
+// works without extra ceremony in individual tests.
 function createMockDb() {
     const mock: any = {
         _returnValue: [] as any[],
         select: jest.fn().mockReturnThis(),
         from: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
-        limit: jest.fn(function (this: any) {
-            return Promise.resolve(this._returnValue);
-        }),
+        limit: jest.fn().mockReturnThis(),
+        offset: jest.fn().mockReturnThis(),
         insert: jest.fn().mockReturnThis(),
         values: jest.fn().mockReturnThis(),
         returning: jest.fn(function (this: any) {
@@ -75,6 +78,11 @@ function createMockDb() {
         update: jest.fn().mockReturnThis(),
         set: jest.fn().mockReturnThis(),
         delete: jest.fn().mockReturnThis(),
+    };
+    // Make the fluent chain thenable at any terminal-ish stopping point so
+    // callers can `await db.select()...limit(N)` and `await db.select()...limit(N).offset(M)`.
+    mock.then = function (onFulfilled: any, onRejected: any) {
+        return Promise.resolve(this._returnValue).then(onFulfilled, onRejected);
     };
     mock._setReturn = (val: any[]) => { mock._returnValue = val; };
     return mock;
@@ -90,7 +98,7 @@ describe('templateService', () => {
     describe('listTemplates', () => {
         it('returns all templates from the database', async () => {
             const rows = [toTemplateRow(lateDeliveryTemplate, 1), toTemplateRow(helloWorldTemplate, 2)];
-            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue(rows) });
+            db._setReturn(rows);
 
             const result = await listTemplates(db);
             expect(result).toEqual(rows);
@@ -98,10 +106,35 @@ describe('templateService', () => {
         });
 
         it('returns an empty array when no templates exist', async () => {
-            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue([]) });
+            db._setReturn([]);
 
             const result = await listTemplates(db);
             expect(result).toEqual([]);
+        });
+
+        it('clamps limit to 100 when caller requests more', async () => {
+            db._setReturn([]);
+            await listTemplates(db, { limit: 500 });
+            expect(db.limit).toHaveBeenCalledWith(100);
+        });
+
+        it('clamps limit to at least 1 when caller requests less', async () => {
+            db._setReturn([]);
+            await listTemplates(db, { limit: 0 });
+            expect(db.limit).toHaveBeenCalledWith(1);
+        });
+
+        it('clamps offset to at least 0 when caller passes negative', async () => {
+            db._setReturn([]);
+            await listTemplates(db, { offset: -5 });
+            expect(db.offset).toHaveBeenCalledWith(0);
+        });
+
+        it('defaults to limit=100 and offset=0 when no opts provided', async () => {
+            db._setReturn([]);
+            await listTemplates(db);
+            expect(db.limit).toHaveBeenCalledWith(100);
+            expect(db.offset).toHaveBeenCalledWith(0);
         });
     });
 

--- a/server/services/templateService.test.ts
+++ b/server/services/templateService.test.ts
@@ -1,0 +1,211 @@
+import { jest } from '@jest/globals';
+import {
+    listTemplates,
+    getTemplateById,
+    getTemplateByUri,
+    createTemplate,
+    updateTemplate,
+    deleteTemplate,
+} from './templateService';
+import { TemplateNotFoundError, TemplateDuplicateError } from './errors';
+
+// Minimal Template fixtures. The service only touches `uri` and `id`, but
+// TemplateInsert requires the not-null json fields (metadata, templateModel,
+// text) so include placeholder shapes for those.
+type TemplateFixture = {
+    uri: string;
+    author: string;
+    version: string;
+    license: string;
+    displayName: string;
+    description: string;
+    keywords: string[];
+    metadata: unknown;
+    templateModel: unknown;
+    text: unknown;
+};
+
+const lateDeliveryTemplate: TemplateFixture = {
+    uri: 'https://templates.accordproject.org/latedeliveryandpenalty@0.1.0.cta',
+    author: 'Accord Project',
+    displayName: 'Late Delivery And Penalty',
+    version: '0.1.0',
+    description: 'A template for late delivery',
+    license: 'Apache-2.0',
+    keywords: [],
+    metadata: {},
+    templateModel: {},
+    text: {},
+};
+
+const helloWorldTemplate: TemplateFixture = {
+    uri: 'https://templates.accordproject.org/helloworld@0.1.0.cta',
+    author: 'Accord Project',
+    displayName: 'Hello World',
+    version: '0.1.0',
+    description: 'A minimal hello-world template',
+    license: 'Apache-2.0',
+    keywords: [],
+    metadata: {},
+    templateModel: {},
+    text: {},
+};
+
+function toTemplateRow(t: TemplateFixture, id: number): any {
+    return { ...t, id, hash: null, logo: null, logic: null, sampleRequest: null };
+}
+
+// Fluent Drizzle query builder mock. Every chained method returns the mock so
+// db.select().from(Template).where(...).limit(1) resolves to the configured
+// return value.
+function createMockDb() {
+    const mock: any = {
+        _returnValue: [] as any[],
+        select: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn(function (this: any) {
+            return Promise.resolve(this._returnValue);
+        }),
+        insert: jest.fn().mockReturnThis(),
+        values: jest.fn().mockReturnThis(),
+        returning: jest.fn(function (this: any) {
+            return Promise.resolve(this._returnValue);
+        }),
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        delete: jest.fn().mockReturnThis(),
+    };
+    mock._setReturn = (val: any[]) => { mock._returnValue = val; };
+    return mock;
+}
+
+describe('templateService', () => {
+    let db: ReturnType<typeof createMockDb>;
+
+    beforeEach(() => {
+        db = createMockDb();
+    });
+
+    describe('listTemplates', () => {
+        it('returns all templates from the database', async () => {
+            const rows = [toTemplateRow(lateDeliveryTemplate, 1), toTemplateRow(helloWorldTemplate, 2)];
+            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue(rows) });
+
+            const result = await listTemplates(db);
+            expect(result).toEqual(rows);
+            expect(result).toHaveLength(2);
+        });
+
+        it('returns an empty array when no templates exist', async () => {
+            db.select.mockReturnValue({ from: jest.fn<any>().mockResolvedValue([]) });
+
+            const result = await listTemplates(db);
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('getTemplateById', () => {
+        it('returns the template when it exists', async () => {
+            const row = toTemplateRow(lateDeliveryTemplate, 5);
+            db._setReturn([row]);
+
+            const result = await getTemplateById(db, 5);
+            expect(result).toEqual(row);
+            expect(db.select).toHaveBeenCalled();
+        });
+
+        it('throws TemplateNotFoundError when the id does not exist', async () => {
+            db._setReturn([]);
+
+            await expect(getTemplateById(db, 999)).rejects.toThrow(TemplateNotFoundError);
+            await expect(getTemplateById(db, 999)).rejects.toMatchObject({
+                code: 'TEMPLATE_NOT_FOUND',
+                statusCode: 404,
+            });
+        });
+    });
+
+    describe('getTemplateByUri', () => {
+        it('returns the template when URI matches', async () => {
+            const row = toTemplateRow(helloWorldTemplate, 2);
+            db._setReturn([row]);
+
+            const result = await getTemplateByUri(db, helloWorldTemplate.uri);
+            expect(result.uri).toBe(helloWorldTemplate.uri);
+        });
+
+        it('throws TemplateNotFoundError when URI does not match', async () => {
+            db._setReturn([]);
+
+            await expect(
+                getTemplateByUri(db, 'resource:nonexistent'),
+            ).rejects.toThrow(TemplateNotFoundError);
+        });
+    });
+
+    describe('createTemplate', () => {
+        it('inserts and returns the new template', async () => {
+            const row = toTemplateRow(lateDeliveryTemplate, 10);
+            db._setReturn([row]);
+
+            const result = await createTemplate(db, lateDeliveryTemplate);
+            expect(result.id).toBe(10);
+            expect(db.insert).toHaveBeenCalled();
+        });
+
+        it('throws TemplateDuplicateError on unique constraint violation', async () => {
+            db.returning.mockRejectedValue({ code: '23505' });
+
+            await expect(
+                createTemplate(db, lateDeliveryTemplate),
+            ).rejects.toThrow(TemplateDuplicateError);
+        });
+
+        it('re-throws non-unique-violation errors as-is', async () => {
+            const genericError = new Error('connection lost');
+            db.returning.mockRejectedValue(genericError);
+
+            await expect(
+                createTemplate(db, lateDeliveryTemplate),
+            ).rejects.toThrow('connection lost');
+        });
+    });
+
+    describe('updateTemplate', () => {
+        it('updates and returns the template', async () => {
+            const row = toTemplateRow({ ...lateDeliveryTemplate, description: 'Updated' }, 1);
+            db._setReturn([row]);
+
+            const result = await updateTemplate(db, lateDeliveryTemplate.uri, {
+                description: 'Updated',
+            });
+            expect(result.description).toBe('Updated');
+        });
+
+        it('throws TemplateNotFoundError when URI does not match', async () => {
+            db._setReturn([]);
+
+            await expect(
+                updateTemplate(db, 'resource:ghost', { description: 'nope' }),
+            ).rejects.toThrow(TemplateNotFoundError);
+        });
+    });
+
+    describe('deleteTemplate', () => {
+        it('resolves when the template exists', async () => {
+            const row = toTemplateRow(lateDeliveryTemplate, 1);
+            db._setReturn([row]);
+
+            await expect(deleteTemplate(db, lateDeliveryTemplate.uri)).resolves.toBeUndefined();
+        });
+
+        it('throws TemplateNotFoundError when URI does not match', async () => {
+            db._setReturn([]);
+
+            await expect(deleteTemplate(db, 'resource:ghost')).rejects.toThrow(
+                TemplateNotFoundError,
+            );
+        });
+    });
+});

--- a/server/services/templateService.ts
+++ b/server/services/templateService.ts
@@ -12,9 +12,22 @@ import { TemplateNotFoundError, TemplateDuplicateError } from './errors';
 type TemplateRow = typeof Template.$inferSelect;
 type TemplateInsert = typeof Template.$inferInsert;
 
-/** Replaces: makeApiRequest(`${API_BASE_URL}/templates`) */
-export async function listTemplates(db: Database): Promise<TemplateRow[]> {
-    return db.select().from(Template);
+/**
+ * Replaces: makeApiRequest(`${API_BASE_URL}/templates`)
+ *
+ * Bounded on the primitive so callers cannot regress into unbounded reads.
+ * Defaults match the ≤100 cap the existing REST `parseQueryParams` already
+ * applies, so the MCP resource path stays token-budget-safe under the
+ * `ttlMs` / `cacheScope` hints from #201. Slice 3 REST unification will
+ * pass `limit` / `offset` through from `parseQueryParams`.
+ */
+export async function listTemplates(
+    db: Database,
+    opts: { limit?: number; offset?: number } = {},
+): Promise<TemplateRow[]> {
+    const limit = Math.min(100, Math.max(1, opts.limit ?? 100));
+    const offset = Math.max(0, opts.offset ?? 0);
+    return db.select().from(Template).limit(limit).offset(offset);
 }
 
 /** Replaces: makeApiRequest(`${API_BASE_URL}/templates/${id}`) */

--- a/server/services/templateService.ts
+++ b/server/services/templateService.ts
@@ -1,0 +1,69 @@
+import { eq } from 'drizzle-orm';
+import { Template } from '../db/schema';
+import type { Database } from '../db/client';
+import { TemplateNotFoundError, TemplateDuplicateError } from './errors';
+
+// Each function takes `db` as the first arg so both the MCP handler and the REST
+// routes can call the same code path without an internal HTTP loop. This is the
+// slice-1 port of the shared-service pattern proven in apap-mcp-poc; slice 2
+// will bring across the agreement service and slice 3 will rewire the REST
+// routes to call these functions directly.
+
+type TemplateRow = typeof Template.$inferSelect;
+type TemplateInsert = typeof Template.$inferInsert;
+
+/** Replaces: makeApiRequest(`${API_BASE_URL}/templates`) */
+export async function listTemplates(db: Database): Promise<TemplateRow[]> {
+    return db.select().from(Template);
+}
+
+/** Replaces: makeApiRequest(`${API_BASE_URL}/templates/${id}`) */
+export async function getTemplateById(db: Database, id: number): Promise<TemplateRow> {
+    const rows = await db.select().from(Template).where(eq(Template.id, id)).limit(1);
+    if (rows.length === 0) throw new TemplateNotFoundError(String(id));
+    return rows[0];
+}
+
+// Lookup by URI. The RI uses URIs as external identifiers while MCP tools pass
+// numeric ids. Supporting both avoids a class of "which id format?" bugs once
+// slice 3 unifies the REST routes.
+export async function getTemplateByUri(db: Database, uri: string): Promise<TemplateRow> {
+    const rows = await db.select().from(Template).where(eq(Template.uri, uri)).limit(1);
+    if (rows.length === 0) throw new TemplateNotFoundError(uri);
+    return rows[0];
+}
+
+// Insert a new template. Catches PG unique constraint violations (23505) and
+// surfaces them as TemplateDuplicateError so the caller can map to a clean 409.
+export async function createTemplate(
+    db: Database,
+    data: TemplateInsert,
+): Promise<TemplateRow> {
+    try {
+        const rows = await db.insert(Template).values(data).returning();
+        return rows[0];
+    } catch (err: unknown) {
+        if (isUniqueViolation(err)) throw new TemplateDuplicateError(data.uri);
+        throw err;
+    }
+}
+
+export async function updateTemplate(
+    db: Database,
+    uri: string,
+    data: Partial<TemplateInsert>,
+): Promise<TemplateRow> {
+    const rows = await db.update(Template).set(data).where(eq(Template.uri, uri)).returning();
+    if (rows.length === 0) throw new TemplateNotFoundError(uri);
+    return rows[0];
+}
+
+export async function deleteTemplate(db: Database, uri: string): Promise<void> {
+    const rows = await db.delete(Template).where(eq(Template.uri, uri)).returning();
+    if (rows.length === 0) throw new TemplateNotFoundError(uri);
+}
+
+function isUniqueViolation(err: unknown): boolean {
+    return typeof err === 'object' && err !== null && 'code' in err
+        && (err as { code: string }).code === '23505';
+}


### PR DESCRIPTION
## Summary

Slice 2 of the shared-service-layer port from [apap-mcp-poc](https://github.com/JayDS22/apap-mcp-poc). Adds `agreementService` upstream and rewires the four MCP agreement lookup call sites in `mcp.ts` to call it directly instead of going through the internal `makeApiRequest(\`${API_BASE_URL}/agreements...\`)` HTTP loop.

## Stack

**This PR is stacked on top of #211 (slice 1).** Its base is `main` for reviewability, but its commit graph includes the slice 1 commit for the `Database` type and `getServer(db)` signature. When #211 merges, GitHub will automatically collapse this PR's diff to just the three agreement-related files below.

## Scope choice: CRUD half only

Only `listAgreements` and `getAgreementById` are ported from the POC's `agreementService.ts`. The POC's `convertAgreement` and `triggerAgreement` are simplified stubs that do not run the real `@accordproject/template-engine`. The RI's REST route at `server/handlers/agreements.ts` already runs `TemplateArchiveProcessor` for both convert and trigger, so porting the stubs would regress that.

Convert and trigger deserve their own slice (call it 2b) that wraps the real template engine as a service rather than replacing it with a POC stub.

## What this PR does

### `server/services/agreementService.ts` (new, 25 lines)
Two exported functions: `listAgreements(db)` and `getAgreementById(db, id)`. Both take `db` as the first arg, return typed rows, and throw `AgreementNotFoundError` from the `ServiceError` hierarchy introduced in #184. Zero transport-specific imports.

### `server/services/agreementService.test.ts` (new, 85 lines)
4 unit tests using the same fluent Drizzle mock pattern established in `templateService.test.ts` (slice 1). Covers success and not-found paths for both functions.

### `server/handlers/mcp.ts` — four call sites rewired
- `getAgreement` module fn takes `db: Database`, uses `getAgreementById`
- `getAgreements` module fn takes `db: Database`, uses `listAgreements`
- `apap://agreements/{agreementId}` list callback uses `listAgreements(db)`
- `getAgreement` tool uses `getAgreementById(db, ...)`

Same strict-numeric guard as #208 (`/^\d+$/`) applied to the `agreementId` path segment before calling the service, so a malformed resource URI resolves to `AgreementNotFoundError` instead of `NaN`. The #128 fix (agreement's own `uri` field must not overwrite the MCP resource URI) is preserved.

## Not in this slice

- `convert-agreement-to-format` tool (still calls REST via `makeApiRequest` until slice 2b wraps the real template engine as a service)
- `trigger-agreement` tool (same reason)
- REST `/agreements` route rewire (slice 3, once #211 lands and the `crud.ts` collision surface is clear)

## Validation

- `npm test` in `server/`: 10/10 suites pass, 125 tests total (4 new)
- `npx tsc --noEmit` clean
- Convert + trigger paths untouched, so the `TemplateArchiveProcessor` integration in `server/handlers/agreements.ts` is not affected

## Author Checklist

- [x] DCO sign-off provided
- [x] Tests added and passing
- [x] Typecheck clean
- [x] No transport-specific imports in `services/`
- [x] `AgreementNotFoundError` used for typed errors (no bare `throw new Error(...)` from the service)