### PR TITLE
ci: install server/ dependencies before running npm test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,11 @@ jobs:
       - name: Install global tools for strict dependency linting
         run: npm install -g lockfile-lint syncpack
 
-      - run: npm ci
+      - name: Install dependencies (root + server)
+        shell: bash
+        run: |
+          npm ci
+          cd server && npm ci
       - run: npm run build --if-present
       - name: Run tests
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,10 @@ jobs:
       with:
         node-version: 24.x
 
-    - name: Install dependencies
-      run: npm ci
+    - name: Install dependencies (root + server)
+      run: |
+        npm ci
+        cd server && npm ci
 
     - name: Run tests
       run: npm test || echo "No tests configured"


### PR DESCRIPTION
## Summary

Fixes the silent Build-matrix failure on `main` that was hidden by `npm test || echo \"No tests configured\"` and is now blocking #212.

`server/package.json` already declares jest 29.7.0 and the other test deps in devDependencies. The problem is that the Build (`build.yml`) and CI (`main.yml`) workflows only ran `npm ci` at the repo root. Root `npm test` delegates to `cd server && npm run test`, which exec's `node_modules/.bin/jest` inside `server/`. But `server/node_modules/` was never populated on the runner, so jest was missing at test time.

This has been failing on `Unit Tests (24.x, macos-latest)` on `main` for the last 12+ days. The `|| echo` fallback (removed in #212) made the test step exit 0 despite jest failing to resolve, so no cell ever went red.

## Precedent

`.github/workflows/pr_request.yml` already does the two-step install for its `test` job:

```yaml
run: |
  npm ci
  cd server
  npm ci
  cd ../
```

That job passes on every PR. This PR ports the same pattern to the two workflows that were silently failing.

## What this PR does

- `.github/workflows/build.yml` line 40: replace bare `- run: npm ci` with a shell step that installs at both root and `server/`
- `.github/workflows/main.yml` line 22: same pattern

Publish job in `build.yml` is unchanged: it only runs `npm run build --if-present` and does not exercise the server test suite.

## Effect

- Root `npm ci` continues to install root dev/prod deps
- Now followed by `cd server && npm ci` which populates `server/node_modules/` including jest, ts-jest, @types/jest, supertest, and the other test deps already declared in `server/package.json`
- `npm test` at root can now find jest and run the 125-test suite
- Unblocks #212

## Validation

- Local `npm test` in `server/` continues to pass 125/125 tests unchanged (this PR does not touch any code, only the CI install step)
- No package.json / package-lock.json changes needed: the deps were already declared, they just were not being installed on the CI runner

## Author Checklist

- [x] DCO sign-off provided
- [x] Workflow-only change, no code touched
- [x] Same pattern as the passing `pr_request.yml` test job