### PR TITLE
ci: soft-disable Publish to npm job (missing scripts, never worked)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,16 @@ jobs:
     needs:
       - build
     name: Publish to npm
-    if: ${{ success() && github.event_name == 'push' && github.repository_owner == 'accordproject' }}
+    # Soft-disabled: this job references `scripts/timestamp.js` and
+    # `scripts/bump_version.js` which do not exist in the repo (never have,
+    # per `git log --all`). It was previously blocked by the matrix failures
+    # #212 fixed, so its own missing-script failure never surfaced. Setting
+    # `if: false` keeps main green while the deployment story is figured out
+    # in a follow-up. To re-enable, restore the two scripts (or drop the
+    # timestamp + bump steps and rely on manual package.json versioning) and
+    # replace this line with the original guard, kept below for reference:
+    # if: ${{ success() && github.event_name == 'push' && github.repository_owner == 'accordproject' }}
+    if: false
     runs-on: ubuntu-latest
 
     outputs:


### PR DESCRIPTION
## Summary

The `Publish to npm` job in `.github/workflows/build.yml` references two scripts that do not exist in the repo:

- `./scripts/timestamp.js` (line 87)
- `./scripts/bump_version.js` (line 92)

`git log --all -- scripts/timestamp.js scripts/bump_version.js` returns nothing. Neither file has ever existed in this repo.

## Why the failure only just surfaced

The job never actually reached those steps before. `Publish to npm` is gated on `github.event_name == 'push' && github.repository_owner == 'accordproject'`, so PR runs always SKIPPED it. On push to main it did try to run, but the `Build` matrix job it depends on was failing silently on macos-24 / Windows-24 runners (jest binary path handling — the exact issue #212 and #215 fixed).

Now that main builds cleanly, `publish` proceeds to its first real step, hits the missing script, and the whole workflow goes red. Niall spotted this on the latest push.

## What this PR does

One change to `build.yml`: replace the guard on the `publish` job with `if: false`, and preserve the original guard as an inline comment above so re-enabling later is a one-line diff.

```yaml
publish:
  needs:
    - build
  name: Publish to npm
  # Soft-disabled: this job references `scripts/timestamp.js` and
  # `scripts/bump_version.js` which do not exist in the repo...
  # To re-enable, restore the two scripts (or drop the timestamp + bump
  # steps and rely on manual package.json versioning) and replace this
  # line with the original guard, kept below for reference:
  # if: ${{ success() && github.event_name == 'push' && github.repository_owner == 'accordproject' }}
  if: false
  runs-on: ubuntu-latest
```

No other steps, workflows, or scripts touched.

## Why soft-disable and not delete

- Deleting removes intent; someone may want to bring back the unstable-npm-publish pipeline
- Reconstructing the two scripts requires guessing at their exact intent (timestamp format, whether `NPM_TOKEN` is currently valid, workspace-level version-bump semantics). Guessing wrong risks accidentally publishing to npm on every push
- Soft-disable is a two-line, fully-reversible change that stops the red CI without changing publish behavior (which was always broken in practice)

## Follow-up

Worth a separate discussion / issue: whether the unstable-npm-publish pipeline is still wanted, and if so, what the scripts should do. This PR just makes main green.

## Author Checklist

- [x] DCO sign-off provided
- [x] One-file, one-line functional change (plus explanatory comments)
- [x] No other jobs, matrix cells, or scripts touched
- [x] Original guard preserved as a comment for easy revert