### PR TITLE
chore(deps): security-only bumps split from dependabot #219

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "dotenv": "17.2.3"
       },
       "devDependencies": {
-        "@accordproject/concerto-cli": "3.18.0",
+        "@accordproject/concerto-cli": "3.19.0",
         "@ibm-cloud/openapi-ruleset": "1.33.3",
         "@types/dotenv": "6.1.1",
         "ibm-openapi-validator": "1.37.6",
@@ -175,13 +175,13 @@
       }
     },
     "node_modules/@accordproject/concerto-analysis": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.23.0.tgz",
-      "integrity": "sha512-43JFp937RXuoOvXO5ynk+r8tofVCVivkUpv8OonuqOaXcx3zKqalQZQ1WSzbRq881t1duHUrmTKTubxvVC90LA==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-3.26.0.tgz",
+      "integrity": "sha512-ZjmOQWM9yUa4R0gmYKi0tBJQjWymziLM4i15UIeN/ES8VJQ3esTbdoQ3tD4NI+eHUoiBCmvJpaE94ui9LJ5NEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.23.0",
+        "@accordproject/concerto-core": "3.26.0",
         "semver": "7.6.3"
       },
       "engines": {
@@ -203,21 +203,22 @@
       }
     },
     "node_modules/@accordproject/concerto-cli": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cli/-/concerto-cli-3.18.0.tgz",
-      "integrity": "sha512-CvfxX9P7ibDc5Ze0266iqfk6VB/OqQG0Et1/hoq/dv5CoINJLQ2kwVhC9sAvak45DyYUwvmSubqIXeegA5fHDQ==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cli/-/concerto-cli-3.19.0.tgz",
+      "integrity": "sha512-1pK86jqrEcHbSH1L9YRwEdErv4fUT9TG7QDjAjmcwuvrYbyywsXW29UaxIGIoy1DaM9tD/vqyxSvW9qp+Gduuw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-analysis": "3.23.0",
-        "@accordproject/concerto-codegen": "3.30.5",
-        "@accordproject/concerto-core": "3.23.0",
-        "@accordproject/concerto-cto": "3.23.0",
-        "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.23.0",
+        "@accordproject/concerto-analysis": "3.26.0",
+        "@accordproject/concerto-codegen": "3.32.1",
+        "@accordproject/concerto-core": "3.26.0",
+        "@accordproject/concerto-cto": "3.26.0",
+        "@accordproject/concerto-linter": "3.26.0",
+        "@accordproject/concerto-metamodel": "3.12.9",
+        "@accordproject/concerto-util": "3.26.0",
         "ansi-colors": "4.1.3",
-        "glob": "^7.2.3",
-        "randexp": "^0.5.3",
+        "glob": "7.2.3",
+        "randexp": "0.5.3",
         "semver": "7.5.2",
         "yargs": "17.3.1"
       },
@@ -225,21 +226,22 @@
         "concerto": "index.js"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6"
+        "node": ">=18",
+        "npm": ">=10"
       }
     },
     "node_modules/@accordproject/concerto-codegen": {
-      "version": "3.30.5",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-3.30.5.tgz",
-      "integrity": "sha512-iw0RkQmD+oqpwLMs3iZVSG9GtHXhcfqhvqcQwthByYNBW9L3zxYNwM2WE6WnAfkbwF5tH4uBOARSpfbRHlOO6g==",
+      "version": "3.32.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-3.32.1.tgz",
+      "integrity": "sha512-nVFCTUk/i37dm5zdfteZtCf/okinVFEX/+V6lO3Jsc7NIWrU9CPP8KAqhG1nB+3Rsqmg3qt7BQT0xe5dMyFnHQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.20.3",
-        "@accordproject/concerto-util": "3.20.3",
-        "@accordproject/concerto-vocabulary": "3.20.3",
-        "@openapi-contrib/openapi-schema-to-json-schema": "5.1.0",
+        "@accordproject/concerto-core": "3.25.0",
+        "@accordproject/concerto-util": "3.25.0",
+        "@accordproject/concerto-vocabulary": "3.25.0",
+        "@openapi-contrib/openapi-schema-to-json-schema": "4.0.0",
+        "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "camelcase": "6.3.0",
         "debug": "4.3.4",
@@ -253,22 +255,24 @@
       }
     },
     "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-core": {
-      "version": "3.20.3",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.20.3.tgz",
-      "integrity": "sha512-x2JsQ/s46QWsrh67Ngjrk1TJ2w4DAgTLNZ1n5gZ7L4shawzarlzbEcTePBuFWmnbzbbP1kSdJ9WVT4o1HRcydw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.0.tgz",
+      "integrity": "sha512-A/Zr4bFTYjWkVEVZCvQadLk08sT5oAx3ED/674lq89vC6Ml/mwopym8JKKszIF5oq8TOMzLhRrxpdLfI3rIQSg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.20.3",
-        "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.20.3",
+        "@accordproject/concerto-cto": "3.25.0",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.0",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
         "randexp": "0.5.3",
+        "rfdc": "1.4.1",
         "semver": "7.6.3",
         "urijs": "1.19.11",
-        "uuid": "11.0.3"
+        "uuid": "11.0.3",
+        "yaml": "^2.8.0"
       },
       "engines": {
         "node": ">=18",
@@ -294,24 +298,35 @@
       }
     },
     "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-cto": {
-      "version": "3.20.3",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.20.3.tgz",
-      "integrity": "sha512-oLbvR9PsoaH1lMammJaOBC3wycq2htT0AKcUXL+lyFGZ8PpHiWVZLOYDZcAuOGYfLbmOoqZeRNDdGjhOHAQszQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.25.0.tgz",
+      "integrity": "sha512-WVPyHYBEg1vwVCH6lOu+7BfNSeRuuV/Tli5CLZI9NPCcI2i/QWWBm6aEs02KnNiC++YTpGK6huvL6n6rz/0Wmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.20.3"
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.0"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=10"
       }
     },
+    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
+      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
     "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-util": {
-      "version": "3.20.3",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.20.3.tgz",
-      "integrity": "sha512-kiqej8od2TMb8HhJyECX2UeLEcPvDiLucZLf4mqhVm7k1mJtMx6to2sTKKki9kreqIjTXmVbZ/lkQZZMgRxy3Q==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.0.tgz",
+      "integrity": "sha512-TNUcM+Tb+J26K6FZDC44WOUt1S7e17fn6oVe4UaYpaZPY4kg64YbHg1sUkIioiDFtamOMoJDyBeKoPLMi1BDOQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -363,15 +378,15 @@
       }
     },
     "node_modules/@accordproject/concerto-core": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.23.0.tgz",
-      "integrity": "sha512-W0gEnwQnG6mODtEMHjsvKIy3FoyloZRMZhgMnbghX+mu9ZmLd5wjcFTJ1h97qJuFn3+P069LDtbu9mz+tt6Y+A==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.26.0.tgz",
+      "integrity": "sha512-S86PtH4ZEiRZ6MGnmjDX8/j6/1XHKTm3/CgOX+y4pWUpuxYLu9c3zvEvDtwCky5NIPh6TsrrSZ/S0QfAyWRhng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.23.0",
-        "@accordproject/concerto-metamodel": "^3.12.4",
-        "@accordproject/concerto-util": "3.23.0",
+        "@accordproject/concerto-cto": "3.26.0",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.26.0",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
@@ -380,7 +395,7 @@
         "semver": "7.6.3",
         "urijs": "1.19.11",
         "uuid": "11.0.3",
-        "yaml": "^2.8.0"
+        "yaml": "2.8.0"
       },
       "engines": {
         "node": ">=18",
@@ -388,9 +403,9 @@
       }
     },
     "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.4.tgz",
-      "integrity": "sha512-7EmrdRc+ocX1Km5TMfNWfNzAvE901BV6NYmCEPf+H8MjHgnJWz6LFbQ3D5ppF3ar8325FM40mMKiDUuSTFXvTQ==",
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
+      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -437,14 +452,14 @@
       }
     },
     "node_modules/@accordproject/concerto-cto": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.23.0.tgz",
-      "integrity": "sha512-O2GlY2iU8jSyO98QLEiD8cDusrkcSEV0m4XEkFmRDz0H+O+nS1veRTND36j1ZtvK0UwOlc49Z5aqM7CDWrniug==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.26.0.tgz",
+      "integrity": "sha512-alxDRpSnA55g88mbwkYLFrja4OPiFLyws/HfNf44GMxSuB84qlCBZYQMg4eXGJ0IeI+n68QdlS7B080+IzVuwg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-metamodel": "3.12.4",
-        "@accordproject/concerto-util": "3.23.0"
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.26.0"
       },
       "engines": {
         "node": ">=18",
@@ -452,9 +467,9 @@
       }
     },
     "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.4.tgz",
-      "integrity": "sha512-7EmrdRc+ocX1Km5TMfNWfNzAvE901BV6NYmCEPf+H8MjHgnJWz6LFbQ3D5ppF3ar8325FM40mMKiDUuSTFXvTQ==",
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
+      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -462,10 +477,46 @@
         "npm": ">=6"
       }
     },
+    "node_modules/@accordproject/concerto-linter": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-linter/-/concerto-linter-3.26.0.tgz",
+      "integrity": "sha512-y2kFYYvxwhYntoHtwAdXr/CMHMRjaghN2NmvscuAJMb8u2oDu8cXwZra3BPWJKFALGap3bZviO4R3zpGKSgv+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.26.0",
+        "@accordproject/concerto-linter-default-ruleset": "3.26.0",
+        "@stoplight/spectral-cli": "6.15.0",
+        "@stoplight/spectral-core": "1.20.0",
+        "@stoplight/spectral-parsers": "1.0.5",
+        "find-up": "5.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-linter-default-ruleset": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-linter-default-ruleset/-/concerto-linter-default-ruleset-3.26.0.tgz",
+      "integrity": "sha512-NEDft9+iix0ID4ajqTxanw4oBKX0DfH8DR26wj4HCZldRZL+Gs5oLRLW9/Ls7Y1XlOdTeGovNkx5t9Vj72uTOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.26.0",
+        "@stoplight/spectral-core": "1.20.0",
+        "@stoplight/spectral-functions": "1.10.1",
+        "@stoplight/spectral-parsers": "1.0.5"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
     "node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.11.0.tgz",
-      "integrity": "sha512-fEihaIrOlxtrVejPAX26OHcDdgasGLQo/Xwt89i36gM70B8B77jShLZqbvgBj97sC5YaqRVfRH9xlec7Yfqdqg==",
+      "version": "3.12.9",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.9.tgz",
+      "integrity": "sha512-VKkJIcl2d7Fvkp6F9XDMy3oKvLxFJMYpTOKYaYXl+C7DSjnBl+T74DC0Vr9EOzCs/UQ2JNRqJJ20b9pN48patg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -474,14 +525,15 @@
       }
     },
     "node_modules/@accordproject/concerto-util": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.23.0.tgz",
-      "integrity": "sha512-q9BIu2ww14Y0bxlgkDiZBzyR1V21miMT84ykN+FObo+S0rhY3Uxcgspvz8VZqfzV7PJBqrX+9Uz+WTaSAMgtGw==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.26.0.tgz",
+      "integrity": "sha512-llXagYAhCwwijRKxS2Q0AXxTCga850AHtXrsn/FAcv0hs0B3oD9LCfK+sFKoCHsPGwed6mLU69WBeVG4gVg0Wg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",
         "debug": "4.3.7",
+        "n2words": "1.13.0",
         "slash": "3.0.0"
       },
       "engines": {
@@ -515,18 +567,29 @@
       "license": "MIT"
     },
     "node_modules/@accordproject/concerto-vocabulary": {
-      "version": "3.20.3",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-3.20.3.tgz",
-      "integrity": "sha512-tzKk0HUP8JlBN/3ZQWu+8/3viPu3Z/NgTuC1qOa4nRSOwm3WTw6caVp7c6PzgOR/AZ3184VOd+qaihzkK7TQcA==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-3.25.0.tgz",
+      "integrity": "sha512-WrnSMSQAFuJhFpH6h+4oN1UOcBbZEl8zXpugkHUYG5EMeQWu41g1M3OAqYzr8oVQV7bUEH05EDcgBClzAUJuPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-metamodel": "3.11.0",
+        "@accordproject/concerto-metamodel": "3.12.6",
         "yaml": "2.6.1"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
+      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
       }
     },
     "node_modules/@accordproject/concerto-vocabulary/node_modules/yaml": {
@@ -681,16 +744,6 @@
       "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/@ibm-cloud/openapi-ruleset": {
       "version": "1.33.3",
@@ -934,106 +987,13 @@
       "license": "MIT"
     },
     "node_modules/@openapi-contrib/openapi-schema-to-json-schema": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-5.1.0.tgz",
-      "integrity": "sha512-MJnq+CxD8JAufiJoa8RK6D/8P45MEBe0teUi30TNoHRrI6MZRNgetK2Y2IfDXWGLTHMopb1d9GHonqlV2Yvztg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-4.0.0.tgz",
+      "integrity": "sha512-HRLG6NCHbdjCv3hacJKhZe5Al3QCig90SCvcXAS+JLb85ypuwFqcVSDnGzBqaithlUibq9UyPwQH0ATitvBBTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/json-schema": "^7.0.12",
-        "@types/lodash": "^4.14.195",
-        "@types/node": "^20.4.1",
-        "fast-deep-equal": "^3.1.3",
-        "lodash": "^4.17.21",
-        "openapi-typescript": "^5.4.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "openapi-schema-to-json-schema": "dist/bin.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@openapi-contrib/openapi-schema-to-json-schema/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@openapi-contrib/openapi-schema-to-json-schema/node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@openapi-contrib/openapi-schema-to-json-schema/node_modules/openapi-typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-5.4.2.tgz",
-      "integrity": "sha512-tHeRv39Yh7brqJpbUntdjtUaXrTHmC4saoyTLU/0J2I8LEFQYDXRLgnmWTMiMOB2GXugJiqHa5n9sAyd6BRqiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^4.1.0",
-        "mime": "^3.0.0",
-        "prettier": "^2.6.2",
-        "tiny-glob": "^0.2.9",
-        "undici": "^5.4.0",
-        "yargs-parser": "^21.0.1"
-      },
-      "bin": {
-        "openapi-typescript": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@openapi-contrib/openapi-schema-to-json-schema/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@openapi-contrib/openapi-schema-to-json-schema/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -2100,13 +2060,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/markdown-escape": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@types/markdown-escape/-/markdown-escape-1.1.3.tgz",
@@ -2213,9 +2166,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4784,13 +4737,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globalyzer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -4811,13 +4757,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -7203,6 +7142,13 @@
         "npm": ">=1.4.0"
       }
     },
+    "node_modules/n2words": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/n2words/-/n2words-1.13.0.tgz",
+      "integrity": "sha512-EYs3bIegsh2IixV0iy2FtjVSfEM5h5hQrTXfSvsf24YqFK8rJa0DOCoucYsUW2ZoZxv48iOcDZfMtM1jetwRLA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -8263,22 +8209,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty": {
@@ -10413,17 +10343,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/tiny-glob": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
-      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globalyzer": "0.1.0",
-        "globrex": "^0.1.2"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -11452,9 +11371,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@accordproject/concerto-cli": "3.18.0",
+    "@accordproject/concerto-cli": "3.19.0",
     "@ibm-cloud/openapi-ruleset": "1.33.3",
     "@types/dotenv": "6.1.1",
     "ibm-openapi-validator": "1.37.6",

--- a/server/.snyk
+++ b/server/.snyk
@@ -1,0 +1,22 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-AXIOS-18060804:
+    - '*':
+        reason: |
+          Medium-severity "Allocation of Resources Without Limits or Throttling"
+          in axios@1.13.6, introduced transitively via
+          @accordproject/cicero-core@0.25.2 > axios@1.13.6. Fixed upstream in
+          axios@1.18.0, but @accordproject/cicero-core has not yet bumped its
+          axios pin.
+
+          axios in this chain is doc-processing only (template-engine's
+          markdown/PDF pipeline), not on the REST or MCP request hot path.
+          Ignoring keeps the security-only bump PR (net -3 advisories) landable
+          while we wait for cicero-core to update. Revisit when cicero-core
+          pins axios@1.18.0+, or fold into the template-engine 2.9 migration PR.
+        expires: '2026-10-22T00:00:00.000Z'
+        created: '2026-07-24T00:00:00.000Z'
+# patches apply the minimum changes required to fix a vulnerability
+patch: {}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2",
       "dependencies": {
-        "@accordproject/cicero-core": "0.25.1-20250328175253",
+        "@accordproject/cicero-core": "0.25.2",
         "@accordproject/concerto-core": "3.21.0",
         "@accordproject/concerto-util": "3.20.4",
         "@accordproject/template-engine": "2.7.1",
@@ -21,7 +21,7 @@
         "drizzle-zod": "0.7.1",
         "express": "4.22.0",
         "express-oauth-server": "2.0.0",
-        "morgan": "1.9.1",
+        "morgan": "1.11.0",
         "openapi-backend": "5.12.0",
         "postgres": "3.4.5",
         "source-map-support": "0.5.10",
@@ -52,24 +52,24 @@
       }
     },
     "node_modules/@accordproject/cicero-core": {
-      "version": "0.25.1-20250328175253",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.25.1-20250328175253.tgz",
-      "integrity": "sha512-K0hEiSlx12k65lCIdAcSHG3Rz4yo83ejIxO4oOhKRLE9LFWi9j/cNPPqKCNUtOAI8zOFVimR5TGknjjn+qwoqQ==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.25.2.tgz",
+      "integrity": "sha512-mx8moSOcJl+CWs8fXEIzGRM8sbw+heClWa3Zf6SCroTpidT7iZFhSehfq1LMTIgzadEc78Rcd+PWs9n9wdaafw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.20.4",
-        "@accordproject/markdown-cicero": "0.16.25",
-        "@accordproject/markdown-common": "0.16.25",
-        "@accordproject/markdown-template": "0.16.25",
-        "@accordproject/markdown-transform": "^0.16.25",
+        "@accordproject/concerto-core": "3.25.7",
+        "@accordproject/concerto-util": "3.25.7",
+        "@accordproject/markdown-cicero": "0.17.2",
+        "@accordproject/markdown-common": "0.17.2",
+        "@accordproject/markdown-template": "0.17.2",
+        "@accordproject/markdown-transform": "0.17.2",
         "@types/node": "^22.13.13",
-        "axios": "1.4.0",
+        "axios": "1.13.6",
         "debug": "4.3.4",
         "ietf-language-tag-regex": "0.0.5",
         "json-stable-stringify": "1.0.2",
         "jszip": "3.10.1",
         "node-cache": "5.1.2",
-        "request": "2.88.0",
         "semver": "7.5.3",
         "slash": "3.0.0",
         "xregexp": "5.1.1"
@@ -80,21 +80,23 @@
       }
     },
     "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-core": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.20.4.tgz",
-      "integrity": "sha512-ebKNJxpMOf+mygUq66+eQWBjd9xIL+xovlpztbREfhDkLd3GrfYM6t+rUxUeIplSc5zzY9K+nyQyVWWKa9qCZw==",
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
+      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.20.4",
-        "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.20.4",
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.7",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
         "randexp": "0.5.3",
+        "rfdc": "1.4.1",
         "semver": "7.6.3",
         "urijs": "1.19.11",
-        "uuid": "11.0.3"
+        "uuid": "11.0.3",
+        "yaml": "2.8.0"
       },
       "engines": {
         "node": ">=18",
@@ -136,6 +138,88 @@
         "node": ">=10"
       }
     },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
+      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-util": {
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
+      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "debug": "4.3.7",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-util/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-util/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/markdown-common": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.17.2.tgz",
+      "integrity": "sha512-OmpPp7uDLSO5odjhhTThjJjK7zCB2uuR/bGnalWLJwhfJrITo8JyvAYS+61DfHocuxVH1sHQg5NVnsEoqwIdeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-core": "3.25.7",
+        "@xmldom/xmldom": "^0.9.5",
+        "markdown-it": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=15",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/markdown-template": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.17.2.tgz",
+      "integrity": "sha512-N7zFBCixTgUD/ZRz581pF00HfLcSK17YNvv864RRsmQyM4VFIgD56Us9G6JuHXaHy+gdr7fkWT/gjhCmbHH5vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-core": "3.25.7",
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/markdown-cicero": "0.17.2",
+        "@accordproject/markdown-common": "0.17.2",
+        "@accordproject/markdown-it-template": "0.17.2",
+        "dayjs": "1.11.13",
+        "markdown-it": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
     "node_modules/@accordproject/cicero-core/node_modules/@types/node": {
       "version": "22.19.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
@@ -145,14 +229,29 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@accordproject/cicero-core/node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/@accordproject/cicero-core/node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -173,20 +272,51 @@
         }
       }
     },
+    "node_modules/@accordproject/cicero-core/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/@accordproject/cicero-core/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/@accordproject/cicero-core/node_modules/lru-cache": {
@@ -200,6 +330,39 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "license": "MIT"
     },
     "node_modules/@accordproject/cicero-core/node_modules/ms": {
       "version": "2.1.2",
@@ -222,6 +385,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/@accordproject/cicero-core/node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/@accordproject/cicero-core/node_modules/uuid": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
@@ -240,6 +409,18 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/@accordproject/concerto-codegen": {
       "version": "3.30.6-20250327205534",
@@ -539,18 +720,66 @@
       }
     },
     "node_modules/@accordproject/concerto-cto": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.20.4.tgz",
-      "integrity": "sha512-Rdn8AgfAW8h8A3onqBduSvD/NioyG8xZtnPWd1qIvytXs4wyQiCnghulJulvIBUiDoOY97Im7RhknU6Tn3YwjQ==",
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.25.7.tgz",
+      "integrity": "sha512-99VUBCW8ye/wMNukmt5PHcCC3zG6RTwHAcVixLjVO/RJFiMDXZMdfYiH750dxyGfb3sbTK36pZn3Bu809o9ISw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.20.4"
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.7"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=10"
       }
+    },
+    "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
+      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-util": {
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
+      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "debug": "4.3.7",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-cto/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/concerto-cto/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/@accordproject/concerto-metamodel": {
       "version": "3.11.0",
@@ -615,16 +844,17 @@
       }
     },
     "node_modules/@accordproject/markdown-cicero": {
-      "version": "0.16.25",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.16.25.tgz",
-      "integrity": "sha512-gaQJgHga97LQ+HzUOb2JftmtXhPKfCWUBCsCrzhYxOFAIhzJR+5ZC6ytQkx4AAz/Zw/cW3EJy48Sozj5OvYAqA==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.17.2.tgz",
+      "integrity": "sha512-SL/D5s0a5thydsHX/0hfrZqxgh1/R3ikJD+LcH7iRy2DcMFCKh2N74LcGleLdsCB78aT8aDkgFA/F01NAx5t6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.19.2",
-        "@accordproject/markdown-common": "*",
-        "@accordproject/markdown-it-cicero": "*",
-        "markdown-it": "^13.0.1",
-        "winston": "3.2.1"
+        "@accordproject/concerto-core": "3.25.7",
+        "@accordproject/markdown-common": "0.17.2",
+        "@accordproject/markdown-it-cicero": "0.17.2",
+        "markdown-it": "^14.1.0",
+        "semver": "7.6.3",
+        "winston": "3.17.0"
       },
       "engines": {
         "node": ">=18",
@@ -632,177 +862,97 @@
       }
     },
     "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-core": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.19.2.tgz",
-      "integrity": "sha512-wfpIiMaRUr6NMCVmuomPxjswN6trvxY0lEvlQhTDF5Y2hOz4PYnHniPbMT8WjN9cjaCnFk8DjrQgryQUnuMbUA==",
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
+      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.19.1",
-        "@accordproject/concerto-metamodel": "3.10.1",
-        "@accordproject/concerto-util": "3.19.1",
-        "dayjs": "1.11.10",
-        "debug": "4.3.4",
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.7",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
         "randexp": "0.5.3",
-        "semver": "7.5.4",
-        "slash": "3.0.0",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
         "urijs": "1.19.11",
-        "uuid": "9.0.1"
+        "uuid": "11.0.3",
+        "yaml": "2.8.0"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=10"
       }
     },
-    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-cto": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.19.1.tgz",
-      "integrity": "sha512-GfJsyrwNB1JhctMVwrxKJC5Ga3t24H9NrgEaK+BG+wxD5rih6JiI9H5dQBGXS9cQYymmuWeX+Me+vgWfwpJx4A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "3.10.0",
-        "@accordproject/concerto-util": "3.19.1",
-        "path-browserify": "1.0.1"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.10.0.tgz",
-      "integrity": "sha512-xgBLwQGAHYeswIK3DlpvquT1NpTii9ETGQLqG4wpN3Ez/m8ymZXpTMFwS+pPu+pKDlX+T4+cZacewX60IecHmw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-util": "3.16.9",
-        "@types/node": "20.7.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-      "version": "3.16.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.16.9.tgz",
-      "integrity": "sha512-Q62s7a0zMCZMbOIybe20mnauB5+oqkwEeKlsrvg2QrkK0q3o7XvWkr3Zot2AncSwkQC3U6+rfuGiBvdyJNJ7Hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "axios": "1.6.8",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "json-colorizer": "2.2.2",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-cto/node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.10.1.tgz",
-      "integrity": "sha512-I3yQeyBCZbJADDfYaTPw7lL2k4nZnhVDgRRv7hW/gBbHNSxX7vwFRypoteclQDTIGXbZDlV3FntBOo55rFPhjQ==",
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
+      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-util": "3.16.9",
-        "@types/node": "20.7.0"
-      },
       "engines": {
         "node": ">=14",
         "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-      "version": "3.16.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.16.9.tgz",
-      "integrity": "sha512-Q62s7a0zMCZMbOIybe20mnauB5+oqkwEeKlsrvg2QrkK0q3o7XvWkr3Zot2AncSwkQC3U6+rfuGiBvdyJNJ7Hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "axios": "1.6.8",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "json-colorizer": "2.2.2",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-metamodel/node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-util": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.19.1.tgz",
-      "integrity": "sha512-Cp3XKjoE5+yRzyJDL/ycMBfAtMjEd5B0GJAPt72/tNAO2TDUFBexyjrUhpVjUWhHRVxQMFKuXQfgG6WMaL7g/A==",
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
+      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",
-        "axios": "1.7.4",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "json-colorizer": "2.2.2",
+        "debug": "4.3.7",
         "slash": "3.0.0"
       },
       "engines": {
-        "node": ">=16",
-        "npm": ">=8"
+        "node": ">=18",
+        "npm": ">=10"
       }
     },
-    "node_modules/@accordproject/markdown-cicero/node_modules/@types/node": {
-      "version": "20.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.0.tgz",
-      "integrity": "sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "license": "MIT",
+    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/markdown-common": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.17.2.tgz",
+      "integrity": "sha512-OmpPp7uDLSO5odjhhTThjJjK7zCB2uuR/bGnalWLJwhfJrITo8JyvAYS+61DfHocuxVH1sHQg5NVnsEoqwIdeg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "@accordproject/concerto-core": "3.25.7",
+        "@xmldom/xmldom": "^0.9.5",
+        "markdown-it": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=15",
+        "npm": ">=9"
       }
     },
-    "node_modules/@accordproject/markdown-cicero/node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
+    "node_modules/@accordproject/markdown-cicero/node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@accordproject/markdown-cicero/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@accordproject/markdown-cicero/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
     "node_modules/@accordproject/markdown-cicero/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -813,48 +963,90 @@
         }
       }
     },
-    "node_modules/@accordproject/markdown-cicero/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+    "node_modules/@accordproject/markdown-cicero/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@accordproject/markdown-cicero/node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
+        "uc.micro": "^2.0.0"
       }
     },
-    "node_modules/@accordproject/markdown-cicero/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
+    "node_modules/@accordproject/markdown-cicero/node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
-      "engines": {
-        "node": ">=10"
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
-    "node_modules/@accordproject/markdown-cicero/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+    "node_modules/@accordproject/markdown-cicero/node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "license": "MIT"
     },
-    "node_modules/@accordproject/markdown-cicero/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "license": "ISC",
+    "node_modules/@accordproject/markdown-cicero/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/markdown-cicero/node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
       "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/@accordproject/markdown-cicero/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -862,24 +1054,58 @@
         "node": ">=10"
       }
     },
+    "node_modules/@accordproject/markdown-cicero/node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/@accordproject/markdown-cicero/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
-    "node_modules/@accordproject/markdown-cicero/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+    "node_modules/@accordproject/markdown-cicero/node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@accordproject/markdown-cicero/node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/@accordproject/markdown-common": {
       "version": "0.16.25",
@@ -1202,20 +1428,6 @@
         "npm": ">=10"
       }
     },
-    "node_modules/@accordproject/markdown-html/node_modules/@accordproject/concerto-cto": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.25.7.tgz",
-      "integrity": "sha512-99VUBCW8ye/wMNukmt5PHcCC3zG6RTwHAcVixLjVO/RJFiMDXZMdfYiH750dxyGfb3sbTK36pZn3Bu809o9ISw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.7"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
     "node_modules/@accordproject/markdown-html/node_modules/@accordproject/concerto-metamodel": {
       "version": "3.12.6",
       "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
@@ -1239,24 +1451,6 @@
       "engines": {
         "node": ">=18",
         "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-html/node_modules/@accordproject/markdown-cicero": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.17.2.tgz",
-      "integrity": "sha512-SL/D5s0a5thydsHX/0hfrZqxgh1/R3ikJD+LcH7iRy2DcMFCKh2N74LcGleLdsCB78aT8aDkgFA/F01NAx5t6w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@accordproject/markdown-common": "0.17.2",
-        "@accordproject/markdown-it-cicero": "0.17.2",
-        "markdown-it": "^14.1.0",
-        "semver": "7.6.3",
-        "winston": "3.17.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
       }
     },
     "node_modules/@accordproject/markdown-html/node_modules/@accordproject/markdown-common": {
@@ -1289,12 +1483,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/@accordproject/markdown-html/node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
     "node_modules/@accordproject/markdown-html/node_modules/debug": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -1325,23 +1513,43 @@
       }
     },
     "node_modules/@accordproject/markdown-html/node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
     },
     "node_modules/@accordproject/markdown-html/node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -1351,9 +1559,9 @@
       }
     },
     "node_modules/@accordproject/markdown-html/node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "license": "MIT"
     },
     "node_modules/@accordproject/markdown-html/node_modules/ms": {
@@ -1361,15 +1569,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/@accordproject/markdown-html/node_modules/one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "license": "MIT",
-      "dependencies": {
-        "fn.name": "1.x.x"
-      }
     },
     "node_modules/@accordproject/markdown-html/node_modules/semver": {
       "version": "7.6.3",
@@ -1400,28 +1599,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/@accordproject/markdown-html/node_modules/winston": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
-      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.7.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.9.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/@accordproject/markdown-html/node_modules/yaml": {
@@ -1506,17 +1683,93 @@
       "license": "MIT"
     },
     "node_modules/@accordproject/markdown-it-template": {
-      "version": "0.16.25",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.16.25.tgz",
-      "integrity": "sha512-8yoFQINgyqdAPxh3gws73lBBM2mlwZJPz03zBQSke802ieU+QPCkI0Xf9/I0r+CIUneDRMy20fiKhZMgBnnMZQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.17.2.tgz",
+      "integrity": "sha512-3BANEXlGaRUpo/FoTPmD9uhdmcGRS6dkkJTw02iiuiokCoiz5uwbo+HWqsQO9HUS2ucVn2CXYM+GjgaNQRPAMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "markdown-it": "^13.0.1"
+        "markdown-it": "^14.1.0"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=9"
       }
+    },
+    "node_modules/@accordproject/markdown-it-template/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@accordproject/markdown-it-template/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@accordproject/markdown-it-template/node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/@accordproject/markdown-it-template/node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/@accordproject/markdown-it-template/node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/markdown-it-template/node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/@accordproject/markdown-pdf": {
       "version": "0.16.25",
@@ -1907,21 +2160,17 @@
       "license": "ISC"
     },
     "node_modules/@accordproject/markdown-transform": {
-      "version": "0.16.25",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.16.25.tgz",
-      "integrity": "sha512-z3ox0KWNryyrLxb9IMzv7LUsZFSo43FYDu1krsNyfZqR4kJR09skuXv+zITiDAJ/q1V4FW/+etyiUA4ziRUW/Q==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.17.2.tgz",
+      "integrity": "sha512-6cjrwwJI/oiIiP4Q6WfjZBaVIuh0qmDIJs0Y5zDLBzcDvPRJvJM2ete9DwjZVYx6Dd9hW4a0A60lu2wuLk+Yng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.19.2",
-        "@accordproject/markdown-cicero": "*",
-        "@accordproject/markdown-common": "*",
-        "@accordproject/markdown-docx": "*",
-        "@accordproject/markdown-html": "*",
-        "@accordproject/markdown-pdf": "*",
-        "@accordproject/markdown-slate": "*",
-        "@accordproject/markdown-template": "*",
-        "dijkstrajs": "^1.0.2",
-        "html-to-docx": "^1.8.0",
+        "@accordproject/concerto-core": "3.25.7",
+        "@accordproject/markdown-cicero": "0.17.2",
+        "@accordproject/markdown-common": "0.17.2",
+        "@accordproject/markdown-html": "0.17.2",
+        "@accordproject/markdown-template": "0.17.2",
+        "dijkstrajs": "^1.0.3",
         "jszip": "^3.10.1"
       },
       "engines": {
@@ -1930,177 +2179,110 @@
       }
     },
     "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-core": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.19.2.tgz",
-      "integrity": "sha512-wfpIiMaRUr6NMCVmuomPxjswN6trvxY0lEvlQhTDF5Y2hOz4PYnHniPbMT8WjN9cjaCnFk8DjrQgryQUnuMbUA==",
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
+      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.19.1",
-        "@accordproject/concerto-metamodel": "3.10.1",
-        "@accordproject/concerto-util": "3.19.1",
-        "dayjs": "1.11.10",
-        "debug": "4.3.4",
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.7",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
         "randexp": "0.5.3",
-        "semver": "7.5.4",
-        "slash": "3.0.0",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
         "urijs": "1.19.11",
-        "uuid": "9.0.1"
+        "uuid": "11.0.3",
+        "yaml": "2.8.0"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=10"
       }
     },
-    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-cto": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.19.1.tgz",
-      "integrity": "sha512-GfJsyrwNB1JhctMVwrxKJC5Ga3t24H9NrgEaK+BG+wxD5rih6JiI9H5dQBGXS9cQYymmuWeX+Me+vgWfwpJx4A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "3.10.0",
-        "@accordproject/concerto-util": "3.19.1",
-        "path-browserify": "1.0.1"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.10.0.tgz",
-      "integrity": "sha512-xgBLwQGAHYeswIK3DlpvquT1NpTii9ETGQLqG4wpN3Ez/m8ymZXpTMFwS+pPu+pKDlX+T4+cZacewX60IecHmw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-util": "3.16.9",
-        "@types/node": "20.7.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-      "version": "3.16.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.16.9.tgz",
-      "integrity": "sha512-Q62s7a0zMCZMbOIybe20mnauB5+oqkwEeKlsrvg2QrkK0q3o7XvWkr3Zot2AncSwkQC3U6+rfuGiBvdyJNJ7Hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "axios": "1.6.8",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "json-colorizer": "2.2.2",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-cto/node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.10.1.tgz",
-      "integrity": "sha512-I3yQeyBCZbJADDfYaTPw7lL2k4nZnhVDgRRv7hW/gBbHNSxX7vwFRypoteclQDTIGXbZDlV3FntBOo55rFPhjQ==",
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
+      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-util": "3.16.9",
-        "@types/node": "20.7.0"
-      },
       "engines": {
         "node": ">=14",
         "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
-      "version": "3.16.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.16.9.tgz",
-      "integrity": "sha512-Q62s7a0zMCZMbOIybe20mnauB5+oqkwEeKlsrvg2QrkK0q3o7XvWkr3Zot2AncSwkQC3U6+rfuGiBvdyJNJ7Hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "axios": "1.6.8",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "json-colorizer": "2.2.2",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-metamodel/node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-util": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.19.1.tgz",
-      "integrity": "sha512-Cp3XKjoE5+yRzyJDL/ycMBfAtMjEd5B0GJAPt72/tNAO2TDUFBexyjrUhpVjUWhHRVxQMFKuXQfgG6WMaL7g/A==",
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
+      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",
-        "axios": "1.7.4",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "json-colorizer": "2.2.2",
+        "debug": "4.3.7",
         "slash": "3.0.0"
       },
       "engines": {
-        "node": ">=16",
-        "npm": ">=8"
+        "node": ">=18",
+        "npm": ">=10"
       }
     },
-    "node_modules/@accordproject/markdown-transform/node_modules/@types/node": {
-      "version": "20.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.0.tgz",
-      "integrity": "sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "license": "MIT",
+    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/markdown-common": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.17.2.tgz",
+      "integrity": "sha512-OmpPp7uDLSO5odjhhTThjJjK7zCB2uuR/bGnalWLJwhfJrITo8JyvAYS+61DfHocuxVH1sHQg5NVnsEoqwIdeg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "@accordproject/concerto-core": "3.25.7",
+        "@xmldom/xmldom": "^0.9.5",
+        "markdown-it": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=15",
+        "npm": ">=9"
       }
     },
-    "node_modules/@accordproject/markdown-transform/node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
-      "license": "MIT"
+    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/markdown-template": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.17.2.tgz",
+      "integrity": "sha512-N7zFBCixTgUD/ZRz581pF00HfLcSK17YNvv864RRsmQyM4VFIgD56Us9G6JuHXaHy+gdr7fkWT/gjhCmbHH5vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-core": "3.25.7",
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/markdown-cicero": "0.17.2",
+        "@accordproject/markdown-common": "0.17.2",
+        "@accordproject/markdown-it-template": "0.17.2",
+        "dayjs": "1.11.13",
+        "markdown-it": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/markdown-transform/node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@accordproject/markdown-transform/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/@accordproject/markdown-transform/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2111,48 +2293,81 @@
         }
       }
     },
-    "node_modules/@accordproject/markdown-transform/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+    "node_modules/@accordproject/markdown-transform/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@accordproject/markdown-transform/node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
+        "uc.micro": "^2.0.0"
       }
     },
-    "node_modules/@accordproject/markdown-transform/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
+    "node_modules/@accordproject/markdown-transform/node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
-      "engines": {
-        "node": ">=10"
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/@accordproject/markdown-transform/node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "license": "MIT"
     },
     "node_modules/@accordproject/markdown-transform/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/@accordproject/markdown-transform/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2160,24 +2375,36 @@
         "node": ">=10"
       }
     },
+    "node_modules/@accordproject/markdown-transform/node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/@accordproject/markdown-transform/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
-    "node_modules/@accordproject/markdown-transform/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+    "node_modules/@accordproject/markdown-transform/node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/@accordproject/template-engine": {
       "version": "2.7.1",
@@ -2207,6 +2434,638 @@
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.38.0"
       }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/cicero-core": {
+      "version": "0.25.1-20250328175253",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.25.1-20250328175253.tgz",
+      "integrity": "sha512-K0hEiSlx12k65lCIdAcSHG3Rz4yo83ejIxO4oOhKRLE9LFWi9j/cNPPqKCNUtOAI8zOFVimR5TGknjjn+qwoqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-core": "3.20.4",
+        "@accordproject/markdown-cicero": "0.16.25",
+        "@accordproject/markdown-common": "0.16.25",
+        "@accordproject/markdown-template": "0.16.25",
+        "@accordproject/markdown-transform": "^0.16.25",
+        "@types/node": "^22.13.13",
+        "axios": "1.4.0",
+        "debug": "4.3.4",
+        "ietf-language-tag-regex": "0.0.5",
+        "json-stable-stringify": "1.0.2",
+        "jszip": "3.10.1",
+        "node-cache": "5.1.2",
+        "request": "2.88.0",
+        "semver": "7.5.3",
+        "slash": "3.0.0",
+        "xregexp": "5.1.1"
+      },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-core": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.20.4.tgz",
+      "integrity": "sha512-ebKNJxpMOf+mygUq66+eQWBjd9xIL+xovlpztbREfhDkLd3GrfYM6t+rUxUeIplSc5zzY9K+nyQyVWWKa9qCZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.20.4",
+        "@accordproject/concerto-metamodel": "3.11.0",
+        "@accordproject/concerto-util": "3.20.4",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-core/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-core/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-cto": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.20.4.tgz",
+      "integrity": "sha512-Rdn8AgfAW8h8A3onqBduSvD/NioyG8xZtnPWd1qIvytXs4wyQiCnghulJulvIBUiDoOY97Im7RhknU6Tn3YwjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "3.11.0",
+        "@accordproject/concerto-util": "3.20.4"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero": {
+      "version": "0.16.25",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.16.25.tgz",
+      "integrity": "sha512-gaQJgHga97LQ+HzUOb2JftmtXhPKfCWUBCsCrzhYxOFAIhzJR+5ZC6ytQkx4AAz/Zw/cW3EJy48Sozj5OvYAqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-core": "3.19.2",
+        "@accordproject/markdown-common": "*",
+        "@accordproject/markdown-it-cicero": "*",
+        "markdown-it": "^13.0.1",
+        "winston": "3.2.1"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-core": {
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.19.2.tgz",
+      "integrity": "sha512-wfpIiMaRUr6NMCVmuomPxjswN6trvxY0lEvlQhTDF5Y2hOz4PYnHniPbMT8WjN9cjaCnFk8DjrQgryQUnuMbUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.19.1",
+        "@accordproject/concerto-metamodel": "3.10.1",
+        "@accordproject/concerto-util": "3.19.1",
+        "dayjs": "1.11.10",
+        "debug": "4.3.4",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "semver": "7.5.4",
+        "slash": "3.0.0",
+        "urijs": "1.19.11",
+        "uuid": "9.0.1"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-cto": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.19.1.tgz",
+      "integrity": "sha512-GfJsyrwNB1JhctMVwrxKJC5Ga3t24H9NrgEaK+BG+wxD5rih6JiI9H5dQBGXS9cQYymmuWeX+Me+vgWfwpJx4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "3.10.0",
+        "@accordproject/concerto-util": "3.19.1",
+        "path-browserify": "1.0.1"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.10.0.tgz",
+      "integrity": "sha512-xgBLwQGAHYeswIK3DlpvquT1NpTii9ETGQLqG4wpN3Ez/m8ymZXpTMFwS+pPu+pKDlX+T4+cZacewX60IecHmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-util": "3.16.9",
+        "@types/node": "20.7.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
+      "version": "3.16.9",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.16.9.tgz",
+      "integrity": "sha512-Q62s7a0zMCZMbOIybe20mnauB5+oqkwEeKlsrvg2QrkK0q3o7XvWkr3Zot2AncSwkQC3U6+rfuGiBvdyJNJ7Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "1.6.8",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-cto/node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.10.1.tgz",
+      "integrity": "sha512-I3yQeyBCZbJADDfYaTPw7lL2k4nZnhVDgRRv7hW/gBbHNSxX7vwFRypoteclQDTIGXbZDlV3FntBOo55rFPhjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-util": "3.16.9",
+        "@types/node": "20.7.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
+      "version": "3.16.9",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.16.9.tgz",
+      "integrity": "sha512-Q62s7a0zMCZMbOIybe20mnauB5+oqkwEeKlsrvg2QrkK0q3o7XvWkr3Zot2AncSwkQC3U6+rfuGiBvdyJNJ7Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "1.6.8",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-metamodel/node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-util": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.19.1.tgz",
+      "integrity": "sha512-Cp3XKjoE5+yRzyJDL/ycMBfAtMjEd5B0GJAPt72/tNAO2TDUFBexyjrUhpVjUWhHRVxQMFKuXQfgG6WMaL7g/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "1.7.4",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/@types/node": {
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.0.tgz",
+      "integrity": "sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/axios": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform": {
+      "version": "0.16.25",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.16.25.tgz",
+      "integrity": "sha512-z3ox0KWNryyrLxb9IMzv7LUsZFSo43FYDu1krsNyfZqR4kJR09skuXv+zITiDAJ/q1V4FW/+etyiUA4ziRUW/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-core": "3.19.2",
+        "@accordproject/markdown-cicero": "*",
+        "@accordproject/markdown-common": "*",
+        "@accordproject/markdown-docx": "*",
+        "@accordproject/markdown-html": "*",
+        "@accordproject/markdown-pdf": "*",
+        "@accordproject/markdown-slate": "*",
+        "@accordproject/markdown-template": "*",
+        "dijkstrajs": "^1.0.2",
+        "html-to-docx": "^1.8.0",
+        "jszip": "^3.10.1"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-core": {
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.19.2.tgz",
+      "integrity": "sha512-wfpIiMaRUr6NMCVmuomPxjswN6trvxY0lEvlQhTDF5Y2hOz4PYnHniPbMT8WjN9cjaCnFk8DjrQgryQUnuMbUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.19.1",
+        "@accordproject/concerto-metamodel": "3.10.1",
+        "@accordproject/concerto-util": "3.19.1",
+        "dayjs": "1.11.10",
+        "debug": "4.3.4",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "semver": "7.5.4",
+        "slash": "3.0.0",
+        "urijs": "1.19.11",
+        "uuid": "9.0.1"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-cto": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.19.1.tgz",
+      "integrity": "sha512-GfJsyrwNB1JhctMVwrxKJC5Ga3t24H9NrgEaK+BG+wxD5rih6JiI9H5dQBGXS9cQYymmuWeX+Me+vgWfwpJx4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "3.10.0",
+        "@accordproject/concerto-util": "3.19.1",
+        "path-browserify": "1.0.1"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.10.0.tgz",
+      "integrity": "sha512-xgBLwQGAHYeswIK3DlpvquT1NpTii9ETGQLqG4wpN3Ez/m8ymZXpTMFwS+pPu+pKDlX+T4+cZacewX60IecHmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-util": "3.16.9",
+        "@types/node": "20.7.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
+      "version": "3.16.9",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.16.9.tgz",
+      "integrity": "sha512-Q62s7a0zMCZMbOIybe20mnauB5+oqkwEeKlsrvg2QrkK0q3o7XvWkr3Zot2AncSwkQC3U6+rfuGiBvdyJNJ7Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "1.6.8",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-cto/node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.10.1.tgz",
+      "integrity": "sha512-I3yQeyBCZbJADDfYaTPw7lL2k4nZnhVDgRRv7hW/gBbHNSxX7vwFRypoteclQDTIGXbZDlV3FntBOo55rFPhjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-util": "3.16.9",
+        "@types/node": "20.7.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
+      "version": "3.16.9",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.16.9.tgz",
+      "integrity": "sha512-Q62s7a0zMCZMbOIybe20mnauB5+oqkwEeKlsrvg2QrkK0q3o7XvWkr3Zot2AncSwkQC3U6+rfuGiBvdyJNJ7Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "1.6.8",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-metamodel/node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-util": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.19.1.tgz",
+      "integrity": "sha512-Cp3XKjoE5+yRzyJDL/ycMBfAtMjEd5B0GJAPt72/tNAO2TDUFBexyjrUhpVjUWhHRVxQMFKuXQfgG6WMaL7g/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "axios": "1.7.4",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "json-colorizer": "2.2.2",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/@types/node": {
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.0.tgz",
+      "integrity": "sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/axios": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/template-engine/node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -4855,9 +5714,9 @@
       }
     },
     "node_modules/@so-ric/colorspace/node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
@@ -6224,6 +7083,15 @@
       "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.1.tgz",
       "integrity": "sha512-JhvgRb2ihQhsljNda3BI8/UcRHVzrVwo3Q+P8vDtSiyobXuFpuZ9mq+MbRGMnC22CjW3RrfXdg6j6ITX8M+7Ow==",
       "license": "MIT"
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.24.5",
@@ -7890,10 +8758,16 @@
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "license": "BSD-2-Clause"
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/env-variable": {
       "version": "0.0.6",
@@ -9244,9 +10118,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -9352,6 +10226,12 @@
         "inherits": "^2.0.1",
         "readable-stream": "^3.1.1"
       }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -11033,6 +11913,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
       "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -11102,16 +11983,16 @@
       }
     },
     "node_modules/jsdom/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -11600,9 +12481,9 @@
       }
     },
     "node_modules/mammoth": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.11.0.tgz",
-      "integrity": "sha512-BcEqqY/BOwIcI1iR5tqyVlqc3KIaMRa4egSoK83YAVrBf6+yqdAAbtUcFDCWX8Zef8/fgNZ6rl4VUv+vVX8ddQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.6",
@@ -11872,39 +12753,23 @@
       }
     },
     "node_modules/morgan": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
-      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+      "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
       "license": "MIT",
       "dependencies": {
-        "basic-auth": "~2.0.0",
+        "basic-auth": "~2.0.1",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.1"
+        "depd": "~2.0.0",
+        "on-finished": "~2.4.1",
+        "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/morgan/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "dependencies": {
-        "ee-first": "1.1.1"
       },
-      "engines": {
-        "node": ">= 0.8"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ms": {
@@ -11921,9 +12786,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -12250,9 +13115,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "license": "MIT"
     },
     "node_modules/oauth-sign": {
@@ -12456,9 +13321,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -12729,18 +13594,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -12835,30 +13688,34 @@
       }
     },
     "node_modules/pdfmake": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.20.tgz",
-      "integrity": "sha512-bGbxbGFP5p8PWNT3Phsu1ZcRLnRfF6jmnuKTkgmt6i5PZzSdX6JaB+NeTz9q+aocfW8SE9GUjL3o/5GroBqGcQ==",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.23.tgz",
+      "integrity": "sha512-A/IksoKb/ikOZH1edSDJ/2zBbqJKDghD4+fXn3rT7quvCJDlsZMs3NmIB3eajLMMFU9Bd3bZPVvlUMXhvFI+bQ==",
       "license": "MIT",
       "dependencies": {
         "@foliojs-fork/linebreak": "^1.1.2",
         "@foliojs-fork/pdfkit": "^0.15.3",
-        "iconv-lite": "^0.6.3",
-        "xmldoc": "^2.0.1"
+        "iconv-lite": "^0.7.1",
+        "xmldoc": "^2.0.3"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/pdfmake/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/performance-now": {
@@ -12936,9 +13793,12 @@
       }
     },
     "node_modules/png-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
-      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
@@ -13971,10 +14831,13 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sax": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-      "license": "BlueOak-1.0.0"
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -15720,9 +16583,9 @@
       "dev": true
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undici": {
@@ -16517,9 +17380,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -16628,12 +17491,12 @@
       "license": "MIT"
     },
     "node_modules/xmldoc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.2.tgz",
-      "integrity": "sha512-UiRwoSStEXS3R+YE8OqYv3jebza8cBBAI2y8g3B15XFkn3SbEOyyLnmPHjLBPZANrPJKEzxxB7A3XwcLikQVlQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
+      "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
       "license": "MIT",
       "dependencies": {
-        "sax": "^1.2.4"
+        "sax": "^1.4.3"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,7 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
-    "@accordproject/cicero-core": "0.25.1-20250328175253",
+    "@accordproject/cicero-core": "0.25.2",
     "@accordproject/concerto-core": "3.21.0",
     "@accordproject/concerto-util": "3.20.4",
     "@accordproject/template-engine": "2.7.1",
@@ -35,7 +35,7 @@
     "drizzle-zod": "0.7.1",
     "express": "4.22.0",
     "express-oauth-server": "2.0.0",
-    "morgan": "1.9.1",
+    "morgan": "1.11.0",
     "openapi-backend": "5.12.0",
     "postgres": "3.4.5",
     "source-map-support": "0.5.10",


### PR DESCRIPTION
## Summary

Split of #219 that lands only the low-risk security bumps and defers the SDK / template-engine major-adjacent bumps to a separate migration PR. Rationale: #219 tangled security patches with an SDK bump that breaks compile (TS2589 on the tightened `.tool()` generics), which made the whole thing un-mergeable as one unit. This PR takes the safe half now so the security fixes are not held hostage by the migration work.

## What this PR does

Bumps three low-risk deps and regenerates both lockfiles:

- `@accordproject/concerto-cli` `3.18.0` -> `3.19.0` (root; devDep, doc build tooling)
- `@accordproject/cicero-core` `0.25.1-20250328175253` -> `0.25.2` (server; drops the dated pre-release for a stable tag)
- `morgan` `1.9.1` -> `1.11.0` (server; addresses transitive advisories)

No production code changed. No behaviour change expected.

## Deferred (tracked for follow-up PRs)

- `@modelcontextprotocol/sdk` `1.15.1` -> `1.29.x`: trips TS2589 on `z.enum([...])` inside `.tool()` calls in `handlers/mcp.ts`. Fix requires either narrowing the schemas or opting into the v2 beta line for the 2026-07-28 RC. Will land as a separate migration PR.
- `@accordproject/template-engine` `2.7.1` -> `2.9.x`: minor API shift, needs test updates.
- `nodemon` 1.x -> 3.x major (dev-only), `wait-on` 3.x -> 9.x major (dev-only): follow-up cleanup, not gating anything.

Once this lands, #219 can be closed in favour of the split PRs.

## Validation

- `npm install --package-lock-only --ignore-scripts` clean at root and in `server/`
- `npm run build` clean in `server/` (tsc passes)
- `npm test` in `server/`: 10 suites, 151 tests, all pass

## Author Checklist

- [x] DCO sign-off on the commit
- [x] No em-dashes in commit message or PR body
- [x] No production code touched
- [x] Both lockfiles regenerated together (root + server)
- [x] Test suite green after bumps