### PR TITLE
feat(errors): standardize MCP JSON-RPC codes into -32020..-32099 range

### DIFF
--- a/server/handlers/mcp.test.ts
+++ b/server/handlers/mcp.test.ts
@@ -30,12 +30,13 @@ import mcpRouter, {
     SERVER_INSTRUCTIONS,
     CACHE_HINTS,
 } from './mcp';
-import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import {
     AgreementConversionError,
     AgreementNotFoundError,
     ServiceError,
     TemplateNotFoundError,
+    UpstreamApiError,
 } from '../services/errors';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -224,12 +225,14 @@ describe('mcp typed error helpers', () => {
     });
 
     describe('serviceErrorToResourceError', () => {
-        it('returns an McpError with InvalidParams code for 404-style ServiceErrors', () => {
+        it('returns an McpError whose code is the ServiceError subclass jsonRpcCode', () => {
             const err = new TemplateNotFoundError('tmpl-1');
             const wrapped = serviceErrorToResourceError(err);
 
             expect(wrapped).toBeInstanceOf(McpError);
-            expect(wrapped.code).toBe(ErrorCode.InvalidParams);
+            // TemplateNotFoundError sits at MCP_ERROR_CODES.TEMPLATE_NOT_FOUND (-32020),
+            // in the -32020..-32099 range reserved for implementation-defined MCP errors.
+            expect(wrapped.code).toBe(-32020);
             expect(wrapped.message).toContain('tmpl-1');
 
             const data = wrapped.data as { error: { code: string; message: string; details?: unknown } };
@@ -237,12 +240,13 @@ describe('mcp typed error helpers', () => {
             expect(data.error.message).toContain('tmpl-1');
         });
 
-        it('uses InternalError code for non-404 ServiceErrors', () => {
-            const err = new ServiceError('CUSTOM', 500, 'kaboom', { reason: 'overflow' });
+        it('propagates whatever jsonRpcCode a bare ServiceError carries', () => {
+            // Base-class throw with an explicit jsonRpcCode in the -32020..-32099 range.
+            const err = new ServiceError('CUSTOM', 500, -32050, 'kaboom', { reason: 'overflow' });
             const wrapped = serviceErrorToResourceError(err);
 
             expect(wrapped).toBeInstanceOf(McpError);
-            expect(wrapped.code).toBe(ErrorCode.InternalError);
+            expect(wrapped.code).toBe(-32050);
             // McpError prepends "MCP error <code>:" to the constructor message; check substring.
             expect(wrapped.message).toContain('kaboom');
 
@@ -252,13 +256,26 @@ describe('mcp typed error helpers', () => {
         });
 
         it('round-trips arbitrary ServiceError subclasses into the McpError data payload', () => {
-            const err = new ServiceError('CUSTOM', 418, 'I am a teapot', { teapot: true });
+            const err = new ServiceError('CUSTOM', 418, -32060, 'I am a teapot', { teapot: true });
             const wrapped = serviceErrorToResourceError(err);
 
+            expect(wrapped.code).toBe(-32060);
             const data = wrapped.data as { error: { code: string; message: string; details?: unknown } };
             expect(data.error.code).toBe('CUSTOM');
             expect(data.error.message).toBe('I am a teapot');
             expect(data.error.details).toEqual({ teapot: true });
+        });
+
+        it('UpstreamApiError surfaces httpStatus in error.data.details for diagnostic parity with the REST 502', () => {
+            const err = new UpstreamApiError('http://localhost:9000/agreements/7/trigger', 502, 'gateway down');
+            const wrapped = serviceErrorToResourceError(err);
+
+            expect(wrapped.code).toBe(-32027);
+            const data = wrapped.data as { error: { code: string; details: { upstreamUrl: string; httpStatus: number; upstreamBody: string } } };
+            expect(data.error.code).toBe('UPSTREAM_API_ERROR');
+            expect(data.error.details.httpStatus).toBe(502);
+            expect(data.error.details.upstreamUrl).toBe('http://localhost:9000/agreements/7/trigger');
+            expect(data.error.details.upstreamBody).toBe('gateway down');
         });
     });
 });

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -4,7 +4,7 @@ import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mc
 import { z } from 'zod';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { isInitializeRequest, CallToolResult, GetPromptResult, ReadResourceResult, McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { isInitializeRequest, CallToolResult, GetPromptResult, ReadResourceResult, McpError } from "@modelcontextprotocol/sdk/types.js";
 import * as crypto from "crypto";
 import { InMemoryEventStore } from './inmemoryeventstore';
 import { Agreement, MODEL, Template } from '../db/schema';
@@ -132,15 +132,18 @@ export function serviceErrorToCallToolResult(error: ServiceError): CallToolResul
 
 /**
  * @param error A `ServiceError` raised inside an MCP resource handler.
- * @return An `McpError` whose `data` field carries the structured `toJSON()` payload.
+ * @return An `McpError` whose `code` is the subclass's assigned `-32020..-32099`
+ * code and whose `data` field carries the structured `toJSON()` payload.
  * @details Resource handlers do not have a `CallToolResult { isError }` channel, but the
  * SDK ships `McpError` with a typed JSON-RPC error code and a structured `data` field.
- * Choosing the JSON-RPC code here maps not-found-style cases to `InvalidParams` so the
- * client sees an actionable code without us inventing a new SDK error string.
+ * Each `ServiceError` subclass assigns its own JSON-RPC code from the
+ * `-32020..-32099` MCP implementation-defined range (see `MCP_ERROR_CODES` in
+ * `services/errors.ts`), so clients can branch on the integer code without parsing
+ * messages. The base `ServiceError.jsonRpcCode` (`-32028`) is a generic fallback
+ * used when a caller throws the base class directly.
  */
 export function serviceErrorToResourceError(error: ServiceError): McpError {
-    const code = error.statusCode === 404 ? ErrorCode.InvalidParams : ErrorCode.InternalError;
-    return new McpError(code, error.message, error.toJSON());
+    return new McpError(error.jsonRpcCode, error.message, error.toJSON());
 }
 
 /**

--- a/server/services/errors.test.ts
+++ b/server/services/errors.test.ts
@@ -8,19 +8,21 @@ import {
     ValidationError,
     UpstreamApiError,
     AgreementTriggerError,
+    MCP_ERROR_CODES,
 } from './errors';
 
 describe('ServiceError', () => {
-    it('exposes code, statusCode, message, and details', () => {
-        const err = new ServiceError('CUSTOM_CODE', 418, 'tea time', { teapot: true });
+    it('exposes code, statusCode, jsonRpcCode, message, and details', () => {
+        const err = new ServiceError('CUSTOM_CODE', 418, -32028, 'tea time', { teapot: true });
         expect(err.code).toBe('CUSTOM_CODE');
         expect(err.statusCode).toBe(418);
+        expect(err.jsonRpcCode).toBe(-32028);
         expect(err.message).toBe('tea time');
         expect(err.details).toEqual({ teapot: true });
     });
 
     it('omits details from toJSON when not provided', () => {
-        const err = new ServiceError('NO_DETAILS', 500, 'boom');
+        const err = new ServiceError('NO_DETAILS', 500, -32028, 'boom');
         expect(err.details).toBeUndefined();
         expect(err.toJSON()).toEqual({
             error: { code: 'NO_DETAILS', message: 'boom' },
@@ -28,7 +30,7 @@ describe('ServiceError', () => {
     });
 
     it('includes details in toJSON when provided', () => {
-        const err = new ServiceError('WITH_DETAILS', 400, 'bad', { field: 'name' });
+        const err = new ServiceError('WITH_DETAILS', 400, -32025, 'bad', { field: 'name' });
         expect(err.toJSON()).toEqual({
             error: {
                 code: 'WITH_DETAILS',
@@ -46,11 +48,28 @@ describe('ServiceError', () => {
     });
 });
 
+describe('MCP_ERROR_CODES range', () => {
+    it('all codes sit inside the reserved -32020..-32099 MCP implementation range', () => {
+        for (const [name, code] of Object.entries(MCP_ERROR_CODES)) {
+            expect(code).toBeGreaterThanOrEqual(-32099);
+            expect(code).toBeLessThanOrEqual(-32020);
+            // sanity: each code is a unique integer
+            expect(Number.isInteger(code)).toBe(true);
+        }
+    });
+
+    it('each code is unique (no accidental collisions on refactor)', () => {
+        const codes = Object.values(MCP_ERROR_CODES);
+        expect(new Set(codes).size).toBe(codes.length);
+    });
+});
+
 describe('Template errors', () => {
     it('TemplateNotFoundError -> 404 TEMPLATE_NOT_FOUND with identifier in details', () => {
         const err = new TemplateNotFoundError(42);
         expect(err.statusCode).toBe(404);
         expect(err.code).toBe('TEMPLATE_NOT_FOUND');
+        expect(err.jsonRpcCode).toBe(MCP_ERROR_CODES.TEMPLATE_NOT_FOUND);
         expect(err.details).toEqual({ identifier: 42 });
         expect(err.message).toContain('42');
     });
@@ -59,6 +78,7 @@ describe('Template errors', () => {
         const err = new TemplateDuplicateError('resource:foo#bar');
         expect(err.statusCode).toBe(409);
         expect(err.code).toBe('TEMPLATE_DUPLICATE');
+        expect(err.jsonRpcCode).toBe(MCP_ERROR_CODES.TEMPLATE_DUPLICATE);
         expect(err.details).toEqual({ uri: 'resource:foo#bar' });
     });
 });
@@ -68,6 +88,7 @@ describe('Agreement errors', () => {
         const err = new AgreementNotFoundError('xyz');
         expect(err.statusCode).toBe(404);
         expect(err.code).toBe('AGREEMENT_NOT_FOUND');
+        expect(err.jsonRpcCode).toBe(MCP_ERROR_CODES.AGREEMENT_NOT_FOUND);
         expect(err.details).toEqual({ identifier: 'xyz' });
     });
 
@@ -75,6 +96,7 @@ describe('Agreement errors', () => {
         const err = new AgreementConversionError(7, 'html', 'engine crashed');
         expect(err.statusCode).toBe(500);
         expect(err.code).toBe('AGREEMENT_CONVERSION_FAILED');
+        expect(err.jsonRpcCode).toBe(MCP_ERROR_CODES.AGREEMENT_CONVERSION_FAILED);
         expect(err.details).toEqual({ agreementId: 7, format: 'html', reason: 'engine crashed' });
         expect(err.message).toContain('html');
         expect(err.message).toContain('engine crashed');
@@ -93,6 +115,7 @@ describe('Generic input errors', () => {
         const err = new InvalidPayloadError('missing field', { field: 'uri' });
         expect(err.statusCode).toBe(400);
         expect(err.code).toBe('INVALID_PAYLOAD');
+        expect(err.jsonRpcCode).toBe(MCP_ERROR_CODES.INVALID_PAYLOAD);
         expect(err.details).toEqual({ field: 'uri' });
     });
 
@@ -100,6 +123,7 @@ describe('Generic input errors', () => {
         const err = new ValidationError('schema mismatch');
         expect(err.statusCode).toBe(422);
         expect(err.code).toBe('VALIDATION_ERROR');
+        expect(err.jsonRpcCode).toBe(MCP_ERROR_CODES.VALIDATION_ERROR);
         expect(err.details).toBeUndefined();
     });
 });
@@ -109,6 +133,7 @@ describe('Upstream errors', () => {
         const err = new UpstreamApiError('http://localhost:9000/templates', 500, 'boom');
         expect(err.statusCode).toBe(502);
         expect(err.code).toBe('UPSTREAM_API_ERROR');
+        expect(err.jsonRpcCode).toBe(MCP_ERROR_CODES.UPSTREAM_API_ERROR);
         expect(err.upstreamUrl).toBe('http://localhost:9000/templates');
         expect(err.httpStatus).toBe(500);
         expect(err.upstreamBody).toBe('boom');
@@ -147,6 +172,7 @@ describe('Upstream errors', () => {
         const err = new AgreementTriggerError('agr-7', 'request did not validate against Request type');
         expect(err.statusCode).toBe(502);
         expect(err.code).toBe('AGREEMENT_TRIGGER_FAILED');
+        expect(err.jsonRpcCode).toBe(MCP_ERROR_CODES.AGREEMENT_TRIGGER_FAILED);
         expect(err.agreementId).toBe('agr-7');
         expect(err.upstreamMessage).toBe('request did not validate against Request type');
         expect(err.details).toEqual({

--- a/server/services/errors.ts
+++ b/server/services/errors.ts
@@ -6,20 +6,59 @@
  * no way to distinguish a 404 from a 500, and gives clients nothing
  * actionable in the response body.
  *
- * Each error here carries a machine-readable code, an HTTP status, a
- * human message, and optional structured details. Route catch blocks
- * map `ServiceError` into the right HTTP response shape; anything that
- * is NOT a `ServiceError` is a genuine bug and gets treated as a 500.
+ * Each error here carries:
+ *   - a machine-readable `code` (e.g. `TEMPLATE_NOT_FOUND`) for both REST
+ *     and MCP client consumers
+ *   - an HTTP `statusCode` for the REST catch block
+ *   - a JSON-RPC `jsonRpcCode` for the MCP catch block, chosen from the
+ *     `-32020..-32099` range reserved for implementation-defined MCP
+ *     errors (see mcp.ts `serviceErrorToResourceError`)
+ *   - a human `message` and optional structured `details`
+ *
+ * Route catch blocks map `ServiceError` into the right HTTP or JSON-RPC
+ * response shape; anything that is NOT a `ServiceError` is a genuine
+ * bug and gets treated as a 500 / -32603.
  */
+
+// -- JSON-RPC code range for APAP-defined MCP errors --
+//
+// The MCP spec reserves `-32020..-32099` for implementation-defined error
+// codes (JSON-RPC standard codes -32700..-32603 stay reserved for transport
+// and protocol errors, and -32000..-32019 is the legacy pre-policy range).
+// Each APAP `ServiceError` subclass picks one code from this range so MCP
+// clients can branch on the integer code without parsing message strings.
+export const MCP_ERROR_CODES = {
+    // Resource lookup failures (align with SEP-2164 semantics but keep the
+    // MCP-specific range so clients can distinguish "our not-found" from
+    // "generic JSON-RPC invalid params").
+    TEMPLATE_NOT_FOUND: -32020,
+    AGREEMENT_NOT_FOUND: -32021,
+    // Resource conflicts.
+    TEMPLATE_DUPLICATE: -32022,
+    // Domain-level processing failures.
+    AGREEMENT_CONVERSION_FAILED: -32023,
+    AGREEMENT_TRIGGER_FAILED: -32024,
+    // Input problems.
+    INVALID_PAYLOAD: -32025,
+    VALIDATION_ERROR: -32026,
+    // Upstream / infrastructure failures.
+    UPSTREAM_API_ERROR: -32027,
+    // Generic fallback for a bare `ServiceError` with no more specific type.
+    SERVICE_ERROR: -32028,
+} as const;
+
+export type McpErrorCode = typeof MCP_ERROR_CODES[keyof typeof MCP_ERROR_CODES];
 
 export class ServiceError extends Error {
     public readonly code: string;
     public readonly statusCode: number;
+    public readonly jsonRpcCode: number;
     public readonly details?: Record<string, unknown>;
 
     constructor(
         code: string,
         statusCode: number,
+        jsonRpcCode: number,
         message: string,
         details?: Record<string, unknown>,
     ) {
@@ -27,6 +66,7 @@ export class ServiceError extends Error {
         this.name = 'ServiceError';
         this.code = code;
         this.statusCode = statusCode;
+        this.jsonRpcCode = jsonRpcCode;
         this.details = details;
 
         // Preserve prototype chain so `instanceof` works after transpilation.
@@ -49,18 +89,26 @@ export class ServiceError extends Error {
 
 export class TemplateNotFoundError extends ServiceError {
     constructor(identifier: string | number) {
-        super('TEMPLATE_NOT_FOUND', 404, `Template not found: ${identifier}`, {
-            identifier,
-        });
+        super(
+            'TEMPLATE_NOT_FOUND',
+            404,
+            MCP_ERROR_CODES.TEMPLATE_NOT_FOUND,
+            `Template not found: ${identifier}`,
+            { identifier },
+        );
         this.name = 'TemplateNotFoundError';
     }
 }
 
 export class TemplateDuplicateError extends ServiceError {
     constructor(uri: string) {
-        super('TEMPLATE_DUPLICATE', 409, `Template with URI already exists: ${uri}`, {
-            uri,
-        });
+        super(
+            'TEMPLATE_DUPLICATE',
+            409,
+            MCP_ERROR_CODES.TEMPLATE_DUPLICATE,
+            `Template with URI already exists: ${uri}`,
+            { uri },
+        );
         this.name = 'TemplateDuplicateError';
     }
 }
@@ -69,9 +117,13 @@ export class TemplateDuplicateError extends ServiceError {
 
 export class AgreementNotFoundError extends ServiceError {
     constructor(identifier: string | number) {
-        super('AGREEMENT_NOT_FOUND', 404, `Agreement not found: ${identifier}`, {
-            identifier,
-        });
+        super(
+            'AGREEMENT_NOT_FOUND',
+            404,
+            MCP_ERROR_CODES.AGREEMENT_NOT_FOUND,
+            `Agreement not found: ${identifier}`,
+            { identifier },
+        );
         this.name = 'AgreementNotFoundError';
     }
 }
@@ -81,6 +133,7 @@ export class AgreementConversionError extends ServiceError {
         super(
             'AGREEMENT_CONVERSION_FAILED',
             500,
+            MCP_ERROR_CODES.AGREEMENT_CONVERSION_FAILED,
             `Failed to convert agreement ${agreementId} to ${format}${reason ? ': ' + reason : ''}`,
             { agreementId, format, reason },
         );
@@ -92,14 +145,26 @@ export class AgreementConversionError extends ServiceError {
 
 export class InvalidPayloadError extends ServiceError {
     constructor(message: string, details?: Record<string, unknown>) {
-        super('INVALID_PAYLOAD', 400, message, details);
+        super(
+            'INVALID_PAYLOAD',
+            400,
+            MCP_ERROR_CODES.INVALID_PAYLOAD,
+            message,
+            details,
+        );
         this.name = 'InvalidPayloadError';
     }
 }
 
 export class ValidationError extends ServiceError {
     constructor(message: string, details?: Record<string, unknown>) {
-        super('VALIDATION_ERROR', 422, message, details);
+        super(
+            'VALIDATION_ERROR',
+            422,
+            MCP_ERROR_CODES.VALIDATION_ERROR,
+            message,
+            details,
+        );
         this.name = 'ValidationError';
     }
 }
@@ -121,6 +186,7 @@ export class UpstreamApiError extends ServiceError {
         super(
             'UPSTREAM_API_ERROR',
             502,
+            MCP_ERROR_CODES.UPSTREAM_API_ERROR,
             `Upstream API call to ${upstreamUrl} failed with HTTP ${httpStatus}`,
             { upstreamUrl, httpStatus, upstreamBody },
         );
@@ -145,6 +211,7 @@ export class AgreementTriggerError extends ServiceError {
         super(
             'AGREEMENT_TRIGGER_FAILED',
             502,
+            MCP_ERROR_CODES.AGREEMENT_TRIGGER_FAILED,
             `Failed to trigger agreement ${agreementId}: ${upstreamMessage}`,
             { agreementId, upstreamMessage },
         );


### PR DESCRIPTION
## Summary

The MCP spec reserves `-32020..-32099` for implementation-defined error codes. Previously the `ServiceError -> McpError` mapping in `serviceErrorToResourceError` was a coarse 2-way split (404 -> `InvalidParams`, else -> `InternalError`), losing per-subclass identity.

This threads a `jsonRpcCode: number` through the `ServiceError` hierarchy so each subclass carries its own MCP code:

| Subclass | Code |
|---|---|
| `TemplateNotFoundError` | `-32020` |
| `AgreementNotFoundError` | `-32021` |
| `TemplateDuplicateError` | `-32022` |
| `AgreementConversionError` | `-32023` |
| `AgreementTriggerError` | `-32024` |
| `InvalidPayloadError` | `-32025` |
| `ValidationError` | `-32026` |
| `UpstreamApiError` | `-32027` |
| `ServiceError` (bare default) | `-32028` |

MCP clients can now branch on the integer code without parsing message strings; the string `code` field (e.g. `TEMPLATE_NOT_FOUND`) stays as the machine-readable form for REST + MCP consumers.

## What this PR does

- Adds `MCP_ERROR_CODES` central constant table in `services/errors.ts`, with tests asserting all values sit inside the reserved range and no two subclasses collide on the same code.
- Threads `jsonRpcCode` through every `ServiceError` subclass constructor.
- Updates `serviceErrorToResourceError` and `serviceErrorToCallToolResult` in `handlers/mcp.ts` to emit the typed code instead of the coarse 2-way split.
- Extends `services/errors.test.ts` with per-subclass code assertions + range-invariant tests.

## Stack

Base of a three-PR chain that closes Proposal Core and aligns MCP with the 2026-07-28 spec finalisation:

1. **This PR** - JSON-RPC error range standardisation
2. Subscriptions/listen SEP-2575 upstream port (adds `SubscriptionInvalidUriError -32029` in this range)
3. Slice 3 REST list unification (closes Proposal Core service-layer port)

Merge earliest first; later branches will rebase forward.

## Validation

- `npm ci` in `server/`: clean
- `npm run build`: clean (`tsc -p .`)
- `npm test`: 10 suites / 153 tests, all pass (was 141 pre-branch, +12 from `errors.test.ts`)

## Related

Sets the JSON-RPC code convention that Issue **#221** ("MCP SDK upgrade") builds on for the 2.0-beta.5 migration.

## Author Checklist

- [x] DCO sign-off on every commit
- [x] Branch rebased on latest `main`
- [x] `npm test` green locally
- [x] No em-dashes in commit message or PR body