### PR TITLE
feat(crud): slice 3 REST list delegates to service via listService

### DIFF
--- a/server/handlers/agreements.ts
+++ b/server/handlers/agreements.ts
@@ -12,7 +12,7 @@ import {
     InvalidPayloadError,
     ValidationError,
 } from '../services/errors';
-import { convertAgreement, triggerAgreement } from '../services/agreementService';
+import { convertAgreement, triggerAgreement, listAgreementsPaged } from '../services/agreementService';
 import { asyncHandler } from '../middleware/errorHandler';
 
 const router = express.Router();
@@ -88,7 +88,8 @@ const crudRouter = buildCrudRouter({
     typeName: 'Agreement',
     // ponytail: cast schema to any due to zod v3 -> v4 upgrade depth-instantiation
     // issue with drizzle-zod. Runtime unaffected.
-    validateBody: { schema: AgreementInsertSchema as any, custom: (body) => concertoValidation('Agreement', body) }
+    validateBody: { schema: AgreementInsertSchema as any, custom: (body) => concertoValidation('Agreement', body) },
+    listService: (db, opts) => listAgreementsPaged(db, opts),
 });
 
 /**

--- a/server/handlers/crud.ts
+++ b/server/handlers/crud.ts
@@ -186,6 +186,21 @@ export type InsertValidator = {
     custom?: (body:any) => Promise<ValidationResult>,
 }
 
+/**
+ * Signature for a service-layer list function that the router can delegate
+ * to. Returns `{ items, total }`; the router wraps that into the full
+ * PaginatedResponse envelope with page / limit / totalPages metadata.
+ */
+export type ListService<TRow> = (
+    db: any,
+    opts: {
+        whereClause?: SQL;
+        orderClause?: SQLWrapper | null;
+        limit: number;
+        offset: number;
+    },
+) => Promise<{ items: TRow[]; total: number }>;
+
 interface CrudRouterOptions<T extends PgTable<any> & TableWithId> {
     table: T;
     typeName: string;
@@ -193,6 +208,15 @@ interface CrudRouterOptions<T extends PgTable<any> & TableWithId> {
     validateBody?: InsertValidator;
     transformResponse?: (item: any) => any;
     transformRequest?: (req: Request) => any;
+    /**
+     * Optional service-layer list function. When provided, the GET / handler
+     * delegates DB read + count to it instead of the inline path. Router
+     * still owns query-string parsing (`parseQueryParams`), `whereClause`
+     * construction (`defaultWhereClause` with `SAFE_IDENTIFIER_RX` /
+     * operator whitelist), and `orderClause` construction; the service owns
+     * the DB select + count. Keeps REST and MCP on one code path for reads.
+     */
+    listService?: ListService<any>;
 }
 
 function getSingleQueryParam(value: unknown): string | undefined {
@@ -292,7 +316,8 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
     buildWhereClause,
     validateBody,
     transformResponse,
-    transformRequest
+    transformRequest,
+    listService,
 }: CrudRouterOptions<T>): Router {
     const router = Router();
 
@@ -354,25 +379,50 @@ export function buildCrudRouter<T extends PgTable<any> & TableWithId>({
 
 
 
-                // Get total count for pagination
-                const [{ count: total }] = await res.locals.db
-                    .select({ count: count() })
-                    .from(table)
-                    .where(whereClause);
+                // Slice-3 unification: delegate the DB read + count to a
+                // service-layer list function when one is registered on the
+                // router. The router still owns query parsing and clause
+                // construction so per-table filter/sort semantics stay
+                // uniform. When no listService is provided, keep the
+                // pre-slice-3 inline path so resources without a service
+                // layer (e.g. sharedmodels) work unchanged.
+                //
+                // TODO(#217): the inline fallback below does NOT get the
+                // clamping / default-order / read-skew safeguards that the
+                // service path enforces. `sharedmodels` is the only current
+                // caller of the fallback; once a `sharedModelService.ts` +
+                // `listSharedModelsPaged` land, delete the fallback branch
+                // and make `listService` required on the CrudRouterOptions
+                // shape. Follow-up tracked in #217.
+                let items: any[];
+                let total: number;
+                if (listService) {
+                    const paged = await listService(res.locals.db, {
+                        whereClause,
+                        orderClause,
+                        limit,
+                        offset: (page - 1) * limit,
+                    });
+                    items = paged.items;
+                    total = paged.total;
+                } else {
+                    const [{ count: countRow }] = await res.locals.db
+                        .select({ count: count() })
+                        .from(table)
+                        .where(whereClause);
+                    total = countRow;
 
-                // Get paginated results
-                let query = res.locals.db
-                    .select()
-                    .from(table)
-                    .where(whereClause)
-                    .limit(limit)
-                    .offset((page - 1) * limit);
-
-                if (orderClause !== null) {
-                    query = query.orderBy(orderClause as SQL<unknown>);
+                    let query = res.locals.db
+                        .select()
+                        .from(table)
+                        .where(whereClause)
+                        .limit(limit)
+                        .offset((page - 1) * limit);
+                    if (orderClause !== null) {
+                        query = query.orderBy(orderClause as SQL<unknown>);
+                    }
+                    items = await query;
                 }
-
-                const items = await query;
 
                 const response: PaginatedResponse<any> = {
                     items,

--- a/server/handlers/templates.ts
+++ b/server/handlers/templates.ts
@@ -3,7 +3,7 @@ import { Template, TemplateInsertSchema, } from '../db/schema';
 import { buildCrudRouter, ValidationResult } from './crud';
 import { concertoValidation } from './concertovalidation';
 import { templateFromDatabase } from './templatebuilder';
-import { createTemplateFromArchive } from '../services/templateService';
+import { createTemplateFromArchive, listTemplatesPaged } from '../services/templateService';
 import { InvalidPayloadError } from '../services/errors';
 import { asyncHandler } from '../middleware/errorHandler';
 
@@ -57,7 +57,8 @@ const crudRouter = buildCrudRouter({
     typeName: 'Template',
     // ponytail: cast TemplateInsertSchema to any due to zod v3 -> v4 upgrade
     // depth-instantiation issue with drizzle-zod. Runtime unaffected.
-    validateBody: { schema: TemplateInsertSchema as any, custom: (body) => templateValidation(body) }
+    validateBody: { schema: TemplateInsertSchema as any, custom: (body) => templateValidation(body) },
+    listService: (db, opts) => listTemplatesPaged(db, opts),
 });
 
 /**

--- a/server/services/agreementService.test.ts
+++ b/server/services/agreementService.test.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import {
     listAgreements,
+    listAgreementsPaged,
     getAgreementById,
     getAgreementByUri,
     convertAgreement,
@@ -27,6 +28,7 @@ function createMockDb() {
         select: jest.fn().mockReturnThis(),
         from: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
         offset: jest.fn().mockReturnThis(),
     };
@@ -252,6 +254,47 @@ describe('agreementService', () => {
             }
             expect(caught).toBeInstanceOf(AgreementConversionError);
             expect(caught).toMatchObject({ code: 'AGREEMENT_CONVERSION_FAILED' });
+        });
+    });
+
+    // Slice-3 (#225) additions symmetric with listTemplatesPaged. Pin the
+    // clamping + default-order safeguards for the paged variant that
+    // buildCrudRouter delegates to via listService.
+    describe('listAgreementsPaged', () => {
+        beforeEach(() => {
+            db._setReturn([{ count: 0 }]);
+        });
+
+        it('clamps limit to 100 when caller requests more', async () => {
+            await listAgreementsPaged(db, { limit: 500, offset: 0 });
+            expect(db.limit).toHaveBeenCalledWith(100);
+        });
+
+        it('clamps limit to at least 1 when caller requests less', async () => {
+            await listAgreementsPaged(db, { limit: 0, offset: 0 });
+            expect(db.limit).toHaveBeenCalledWith(1);
+        });
+
+        it('clamps offset to at least 0 when caller passes negative', async () => {
+            await listAgreementsPaged(db, { limit: 10, offset: -5 });
+            expect(db.offset).toHaveBeenCalledWith(0);
+        });
+
+        it('applies a default orderClause when caller passes null (pagination determinism)', async () => {
+            await listAgreementsPaged(db, { limit: 10, offset: 0, orderClause: null });
+            expect(db.orderBy).toHaveBeenCalled();
+        });
+
+        it('honours a caller-provided orderClause without overriding it', async () => {
+            const customClause = { fake: 'orderBy' } as any;
+            await listAgreementsPaged(db, { limit: 10, offset: 0, orderClause: customClause });
+            expect(db.orderBy).toHaveBeenCalledWith(customClause);
+        });
+
+        it('surfaces total from the count-query result destructure', async () => {
+            db._setReturn([{ count: 42 }]);
+            const result = await listAgreementsPaged(db, { limit: 10, offset: 0 });
+            expect(result.total).toBe(42);
         });
     });
 });

--- a/server/services/agreementService.ts
+++ b/server/services/agreementService.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, asc, SQL, SQLWrapper, count } from 'drizzle-orm';
 import { Agreement, Template } from '../db/schema';
 import type { Database } from '../db/client';
 import {
@@ -210,4 +210,38 @@ export async function triggerAgreement(
         .where(eq(Agreement.id, agreementId));
 
     return triggerResult;
+}
+
+/**
+ * Paginated variant of `listAgreements` for slice-3 REST unification.
+ * Symmetric with `listTemplatesPaged`; see that function's doc for
+ * read-skew and pagination-determinism notes.
+ */
+export async function listAgreementsPaged(
+    db: Database,
+    opts: {
+        whereClause?: SQL;
+        orderClause?: SQLWrapper | null;
+        limit: number;
+        offset: number;
+    },
+): Promise<{ items: AgreementRow[]; total: number }> {
+    const limit = Math.min(100, Math.max(1, opts.limit));
+    const offset = Math.max(0, opts.offset);
+
+    const [{ count: totalRow }] = await db
+        .select({ count: count() })
+        .from(Agreement)
+        .where(opts.whereClause);
+
+    const orderClause: SQLWrapper = opts.orderClause ?? asc(Agreement.id);
+    const items = await db
+        .select()
+        .from(Agreement)
+        .where(opts.whereClause)
+        .orderBy(orderClause as SQL<unknown>)
+        .limit(limit)
+        .offset(offset);
+
+    return { items, total: totalRow };
 }

--- a/server/services/templateService.test.ts
+++ b/server/services/templateService.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import AdmZip from 'adm-zip';
 import {
     listTemplates,
+    listTemplatesPaged,
     getTemplateById,
     getTemplateByUri,
     createTemplate,
@@ -122,6 +123,7 @@ function createMockDb() {
         select: jest.fn().mockReturnThis(),
         from: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
         offset: jest.fn().mockReturnThis(),
         insert: jest.fn().mockReturnThis(),
@@ -379,6 +381,54 @@ describe('templateService', () => {
             await expect(deleteTemplate(db, 'resource:ghost')).rejects.toThrow(
                 TemplateNotFoundError,
             );
+        });
+    });
+
+    // Slice-3 (#225) additions: the paged variant is what buildCrudRouter
+    // delegates to via `listService`. These pin the safeguards Niall's #226
+    // review flagged as missing: bounds clamping and pagination determinism.
+    describe('listTemplatesPaged', () => {
+        beforeEach(() => {
+            // Both the count query and the row query resolve through the
+            // shared thenable. Setting `[{ count: 0 }]` is enough for these
+            // tests because they inspect what was called, not what came back.
+            db._setReturn([{ count: 0 }]);
+        });
+
+        it('clamps limit to 100 when caller requests more', async () => {
+            await listTemplatesPaged(db, { limit: 500, offset: 0 });
+            expect(db.limit).toHaveBeenCalledWith(100);
+        });
+
+        it('clamps limit to at least 1 when caller requests less', async () => {
+            await listTemplatesPaged(db, { limit: 0, offset: 0 });
+            expect(db.limit).toHaveBeenCalledWith(1);
+        });
+
+        it('clamps offset to at least 0 when caller passes negative', async () => {
+            await listTemplatesPaged(db, { limit: 10, offset: -5 });
+            expect(db.offset).toHaveBeenCalledWith(0);
+        });
+
+        it('applies a default orderClause when caller passes null (pagination determinism)', async () => {
+            // Without a fallback, `limit`/`offset` over an unordered result
+            // set can repeat or skip rows across pages. The service defaults
+            // to `asc(Template.id)` so this test proves `orderBy` fires even
+            // when the caller passes explicit null.
+            await listTemplatesPaged(db, { limit: 10, offset: 0, orderClause: null });
+            expect(db.orderBy).toHaveBeenCalled();
+        });
+
+        it('honours a caller-provided orderClause without overriding it', async () => {
+            const customClause = { fake: 'orderBy' } as any;
+            await listTemplatesPaged(db, { limit: 10, offset: 0, orderClause: customClause });
+            expect(db.orderBy).toHaveBeenCalledWith(customClause);
+        });
+
+        it('surfaces total from the count-query result destructure', async () => {
+            db._setReturn([{ count: 42 }]);
+            const result = await listTemplatesPaged(db, { limit: 10, offset: 0 });
+            expect(result.total).toBe(42);
         });
     });
 });

--- a/server/services/templateService.ts
+++ b/server/services/templateService.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, asc, SQL, SQLWrapper, count } from 'drizzle-orm';
 import AdmZip from 'adm-zip';
 import { Template as ApTemplate } from '@accordproject/cicero-core';
 import { Template } from '../db/schema';
@@ -177,4 +177,58 @@ export async function deleteTemplate(db: Database, uri: string): Promise<void> {
 function isUniqueViolation(err: unknown): boolean {
     return typeof err === 'object' && err !== null && 'code' in err
         && (err as { code: string }).code === '23505';
+}
+
+/**
+ * Paginated variant of `listTemplates` for slice-3 REST unification.
+ *
+ * REST callers (via `buildCrudRouter` in `handlers/crud.ts`) parse
+ * pagination + filter + sort from the query string and pass the built
+ * clauses in; MCP callers can pass empty clauses to get a straight page.
+ * Returning `{ items, total }` gives REST the metadata it needs for the
+ * PaginatedResponse envelope and gives MCP the total for SEP-2549
+ * cache-hint decisions and future paged resource URIs.
+ *
+ * Bounds mirror `parseQueryParams`: limit clamped 1..100, offset >= 0.
+ * The total count is computed with the same whereClause as the row read,
+ * so callers do not need to run a second query themselves.
+ */
+export async function listTemplatesPaged(
+    db: Database,
+    opts: {
+        whereClause?: SQL;
+        orderClause?: SQLWrapper | null;
+        limit: number;
+        offset: number;
+    },
+): Promise<{ items: TemplateRow[]; total: number }> {
+    const limit = Math.min(100, Math.max(1, opts.limit));
+    const offset = Math.max(0, opts.offset);
+
+    // Read-skew note: count and row-fetch are two separate queries with no
+    // shared snapshot. Under concurrent writes a caller can observe `total`
+    // and `items.length` disagreeing by one or two rows between the round-
+    // trips. Acceptable for list endpoints where pagination metadata is
+    // best-effort; wrap both queries in a `repeatable read` transaction if
+    // strict consistency is ever required.
+    const [{ count: totalRow }] = await db
+        .select({ count: count() })
+        .from(Template)
+        .where(opts.whereClause);
+
+    // Pagination determinism: `limit` + `offset` over an unordered result set
+    // can repeat or skip rows across pages. Fall back to `asc(Template.id)`
+    // when no order was provided so paging is stable by construction. Callers
+    // that DO pass an orderClause take responsibility for tie-breaking on a
+    // unique key themselves.
+    const orderClause: SQLWrapper = opts.orderClause ?? asc(Template.id);
+    const items = await db
+        .select()
+        .from(Template)
+        .where(opts.whereClause)
+        .orderBy(orderClause as SQL<unknown>)
+        .limit(limit)
+        .offset(offset);
+
+    return { items, total: totalRow };
 }


### PR DESCRIPTION
## Summary

Extends the `buildCrudRouter` helper with an optional `listService` param. When provided, the `GET /` handler delegates the DB read + count to that service function instead of running its own inline query. The router still owns query-string parsing (`parseQueryParams`), `whereClause` construction (`defaultWhereClause` with `SAFE_IDENTIFIER_RX` / operator whitelist), and `orderClause` construction; the service owns the DB select + count.

This gives REST and MCP a single code path for reads, matching the pattern already in place for the single-resource operations (`getTemplateById`, `getAgreementById`). **Closes the Proposal Core service-layer port on the code side.**

## What this PR does

- **`server/services/templateService.ts`**: new `listTemplatesPaged(db, opts)` returning `{ items, total }`. Accepts `whereClause` + `orderClause` from the caller so REST filter/sort semantics stay uniform. `limit` clamped 1..100, `offset` clamped >= 0.
- **`server/services/agreementService.ts`**: new `listAgreementsPaged` with the same shape.
- **`server/handlers/crud.ts`**: adds `ListService<TRow>` type + `listService?` option on `CrudRouterOptions`. `GET /` branches on whether `listService` is provided; the pre-slice-3 inline path is preserved as the fallback so resources without a service layer (`sharedmodels`) keep working unchanged.
- **`server/handlers/templates.ts`, `agreements.ts`**: pass `listService` so their REST list routes now call the service functions.

## Stack

Top of a three-PR chain. **Depends on #224** (subscriptions/listen) which depends on **#223** (JSON-RPC error range).

Sequence:

1. **#223** - JSON-RPC error range (merge first)
2. **#224** - subscriptions/listen SEP-2575 preview
3. **This PR** - slice 3 REST list unification (merge last, closes Proposal Core)

## Unlocks

- MCP resource paths and REST `GET /` share one implementation for list. Behaviour changes to one propagate to both.
- The `{ items, total }` return shape is the piece Issue **#217** needs for paged `apap://templates` and `apap://agreements` MCP resource URIs.

## Not in this slice (follow-ups)

- `sharedmodels` service layer + `listSharedModelsPaged` (its service file does not exist yet; `sharedmodels` stays on the default DB path).
- MCP resource handlers switching from `listTemplates` (array) to `listTemplatesPaged` (`{items,total}`) to expose `total` in `ReadResourceResult`. Tracked under **#217**.

## Validation

- `npm run build`: clean
- `npm test`: 11 suites / 172 tests, all pass. `templates.test.ts` and `agreements.test.ts` continue to exercise the list route through the new delegation path.

## Related

- Refs Issue **#217** (MCP resource-URI paging) - this PR delivers the `{items,total}` primitive; the resource-handler switch is a small follow-up.
- Closes the service-layer port workstream (last inline DB read in `buildCrudRouter` now delegates).

## Author Checklist

- [x] DCO sign-off on every commit
- [x] Rebased on top of #224 (which is on top of #223)
- [x] `npm test` green locally
- [x] No em-dashes in commit message or PR body