### PR TITLE
feat: add support for Postgres 18 (closes #118)

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -49,6 +49,35 @@ docker compose down --rmi all
 docker-compose build
 ```
 
+## Upgrading from Postgres 17
+
+The RI now ships Postgres 18 in `compose.yaml`. Postgres 18 relocated its
+`PGDATA` from `/var/lib/postgresql/data` to `/var/lib/postgresql/<MAJOR>/docker`,
+and the compose volume mount was updated from `db-data:/var/lib/postgresql/data`
+to `db-data:/var/lib/postgresql` to match.
+
+If you have never run the RI before, `docker compose up` on a fresh machine
+"just works": Postgres 18 boots on an empty volume.
+
+If you have an existing `server_db-data` volume created under Postgres 17, it
+will NOT auto-migrate. Pick one path:
+
+1. Throw away the dev volume (fastest, loses data):
+   ```bash
+   docker compose down
+   docker volume rm server_db-data
+   docker compose up
+   npx drizzle-kit push
+   ```
+
+2. Dump-and-restore into a fresh Postgres 18 volume (preserves data):
+   ```bash
+   cd server
+   ./upgrade-postgres-17-to-18.sh
+   ```
+   The script spins up a temporary Postgres 17 against the existing volume,
+   runs `pg_dumpall`, recreates the volume, boots Postgres 18, and restores.
+
 # Running Locally without Docker
 
 The RI uses a Postgres database for persistence. Set the POSTGRES_URL environment variable to a Postgres connection string. If you are running

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -21,11 +21,20 @@ services:
       db:
         condition: service_healthy
   db:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     restart: always
     user: postgres
+    # NOTE: Postgres 18+ changes the data layout: the image now uses
+    # /var/lib/postgresql/<MAJOR>/docker as the PGDATA location and
+    # defines the VOLUME at /var/lib/postgresql.
+    # If you have an existing db-data volume created with Postgres 17 (which used
+    # /var/lib/postgresql/data), you MUST either:
+    #  - backup and recreate the volume, OR
+    #  - migrate the files inside the volume into the new subdirectory
+    #    (e.g. move existing files into /var/lib/postgresql/18/docker).
+    # See server/upgrade-postgres-17-to-18.sh for a scripted dump/restore path.
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_PASSWORD=1baddeed

--- a/server/upgrade-postgres-17-to-18.sh
+++ b/server/upgrade-postgres-17-to-18.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Migrates a Docker Postgres 17 volume to Postgres 18 using dump/restore.
+# Steps:
+# 1. Start temporary Postgres 17 using existing volume
+# 2. Create dump.sql
+# 3. Remove old volume
+# 4. Start Postgres 18
+# 5. Restore dump
+
+WORKDIR="$(pwd)"
+DUMP="$WORKDIR/dump.sql"
+VOLUME_NAME="server_db-data"
+TEMP_CONTAINER="pg17-temp"
+
+# Ensure volume exists
+if ! docker volume ls --format '{{.Name}}' | grep -q "^$VOLUME_NAME$"; then
+  echo "ERROR: Volume $VOLUME_NAME not found"
+  exit 1
+fi
+
+# Stop compose services
+docker compose down || true
+
+# Start temporary Postgres 17 container using existing volume
+docker run -d \
+  --name "$TEMP_CONTAINER" \
+  -e POSTGRES_PASSWORD=1baddeed \
+  -v "$VOLUME_NAME":/var/lib/postgresql/data \
+  postgres:17-alpine
+
+# Wait until Postgres is ready
+until docker exec "$TEMP_CONTAINER" pg_isready -U postgres >/dev/null 2>&1; do
+  sleep 1
+done
+
+# Create dump
+docker exec "$TEMP_CONTAINER" pg_dumpall -U postgres > "$DUMP"
+
+# Stop temporary container
+docker stop "$TEMP_CONTAINER"
+docker rm "$TEMP_CONTAINER"
+
+# Remove containers using the volume
+USING=$(docker ps -a --filter volume="$VOLUME_NAME" -q || true)
+if [ -n "$USING" ]; then
+  docker rm -f $USING
+fi
+
+# Remove old volume
+docker volume rm "$VOLUME_NAME"
+
+# Create fresh volume
+docker volume create "$VOLUME_NAME"
+
+# Start Postgres 18
+docker compose up -d db
+
+# Wait until Postgres 18 is ready
+until docker compose exec db pg_isready -U postgres >/dev/null 2>&1; do
+  sleep 1
+done
+
+# Restore dump
+docker compose exec -T db psql -U postgres < "$DUMP"
+
+# Verify databases
+docker compose exec db psql -U postgres -c "\l"
+
+echo "Migration completed successfully."


### PR DESCRIPTION
Closes **#118**.

Bumps `server/compose.yaml` from `postgres:17-alpine` to `postgres:18-alpine` and updates the volume mount to match Postgres 18's new PGDATA layout.

## What changed

- **`server/compose.yaml`**: image `postgres:17-alpine` → `postgres:18-alpine`, volume `db-data:/var/lib/postgresql/data` → `db-data:/var/lib/postgresql` (Postgres 18 relocated PGDATA to `/var/lib/postgresql/<MAJOR>/docker` and now declares the `VOLUME` one level up). Inline comment documents the incompatibility with existing PG 17 volumes.
- **`server/upgrade-postgres-17-to-18.sh`** (new, `chmod +x`): scripted `pg_dumpall` + volume recreate + restore path for developers with an existing `server_db-data` volume they want to preserve.
- **`server/README.md`**: new "Upgrading from Postgres 17" section covering both the throw-away-the-dev-volume path and the scripted dump/restore path.

## Attribution

Rebases **@Vaggelis-Arg**'s original **#119** (commit `f67f81e`), which was auto-closed by the stale bot before it could land despite @dselman's *"This looks great"* review. Per stale-PR takeover policy, opening as a replacement with co-authorship credit preserved via `Co-authored-by:` trailer on the commit.

Script content is byte-identical to Vaggelis's original. Added the README section and a compose.yaml pointer to the script that **#119** did not include.

## Migration impact

Existing dev environments with a `server_db-data` volume created under Postgres 17 will NOT auto-migrate: the mount path change means PG 18 sees an empty volume and initialises a fresh cluster inside a subdirectory the old data is not in. README documents both remediation paths.

Fresh installs (no existing volume) just work: `docker compose up` on a new machine boots PG 18 cleanly, and `npx drizzle-kit push` bootstraps the schema as before.

## Validation

- `docker compose -f server/compose.yaml config` parses clean
- `docker compose -f server/compose.yaml build` succeeds against current `main` (verified locally 2026-07-31)
- `postgres-js@3.4.5` and `drizzle-orm@0.45.2` both work with PG 18 per the manual test transcript in **#119**

## Author Checklist

- [x] DCO sign-off on every commit
- [x] Co-authorship credit for @Vaggelis-Arg via commit trailer
- [x] Rebased on latest `main`
- [x] Docker build validated locally
- [x] No em-dashes in commit message or PR body