### PR TITLE
feat: add Railway deploy button, config, and quick-start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,38 @@ Generated client code for various platforms is available in the [client](./clien
 ## Reference Implementation
 
 A reference implementation of the protocol is available in the [server](./server) directory.
+
+## Quick Start
+
+### Run locally with Docker
+
+```bash
+git clone https://github.com/accordproject/apap.git
+cd apap/server
+cp .env_example .env
+docker compose up
+```
+
+The server starts at `http://localhost:9000`. On first run, bootstrap the database schema in a separate terminal:
+
+```bash
+cd apap/server && npx drizzle-kit push
+```
+
+### Deploy on Railway
+
+Click the button below to provision the server and a managed Postgres instance in one click:
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/QYiXk5)
+
+Once deployed, your server is available at the Railway-assigned URL (e.g. `https://my-apap.up.railway.app`). No database setup required — Postgres is provisioned and linked automatically. Important note: this deployment is a sample implementation and not hardened for a production implementation. 
+
+### Verify
+
+```bash
+curl http://localhost:9000/capabilities
+# or https://my-apap.up.railway.app/capabilities
+```
+
+
+For full API documentation see [docs.accordproject.org/docs/ref-apap](https://docs.accordproject.org/docs/ref-apap).

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "cd server && npm ci && npm run build",
+    "watchPatterns": ["server/**"]
+  },
+  "deploy": {
+    "preDeployCommand": ["sh -c 'cd server && npm run db:migrateprod'"],
+    "startCommand": "cd server/dist && npm start",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/railway.json
+++ b/railway.json
@@ -8,6 +8,7 @@
   "deploy": {
     "preDeployCommand": ["sh -c 'cd server && npm run db:migrateprod'"],
     "startCommand": "cd server/dist && npm start",
+    "healthcheckPath": "/health",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -60,6 +60,8 @@ app.use((req, res, next) => {
   next();
 });
 
+app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
 app.use('/templates', templatesRouter);
 app.use('/agreements', agreementsRouter);
 app.use('/sharedmodels', sharedModelsRouter);


### PR DESCRIPTION
## Summary

- Adds `railway.json` with build/start commands, pre-deploy migration hook (`db:migrateprod`), and watch patterns scoped to `server/**`
- Adds a **Quick Start** section to the README covering local Docker setup and one-click Railway deployment
- Deploy button uses Railway template `QYiXk5` which provisions both the APAP server and a managed Postgres instance automatically

## Test plan

- [x] Click the Deploy on Railway button and verify a new project is created with both `apap` and `Postgres` services
- [x] Confirm `preDeployCommand` runs `db:migrateprod` before the server starts on first deploy
- [x] Follow the local Docker quick-start steps and verify the server starts at `http://localhost:9000`
- [x] `curl http://localhost:9000/capabilities` returns a valid response

🤖 Generated with [Claude Code](https://claude.com/claude-code)