### PR TITLE
chore(): Upgrade cicero-core to 2.x, concerto-core/util to 4.x

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,7 @@
 
 # Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
 
-ARG NODE_VERSION=20.18.1
+ARG NODE_VERSION=22.13.1
 
 ################################################################################
 # Use node image for base image for all stages.

--- a/server/README.md
+++ b/server/README.md
@@ -162,7 +162,7 @@ curl --request POST \
 		"$class": "org.accordproject.protocol@1.0.0.TemplateMetadata",
 		"runtime": "typescript",
 		"template": "clause",
-		"cicero": "0.25.x"
+		"cicero": "2.x"
 	},
 	"logo": null,
 	"templateModel": {
@@ -209,7 +209,7 @@ Response:
 		"$class": "org.accordproject.protocol@1.0.0.TemplateMetadata",
 		"runtime": "typescript",
 		"template": "clause",
-		"cicero": "0.25.x"
+		"cicero": "2.x"
 	},
 	"logo": null,
 	"templateModel": {
@@ -258,7 +258,7 @@ Response:
 		"$class": "org.accordproject.protocol@1.0.0.TemplateMetadata",
 		"runtime": "typescript",
 		"template": "clause",
-		"cicero": "0.25.x"
+		"cicero": "2.x"
 	},
 	"logo": null,
 	"templateModel": {
@@ -311,7 +311,7 @@ Response:
 				"$class": "org.accordproject.protocol@1.0.0.TemplateMetadata",
 				"runtime": "typescript",
 				"template": "clause",
-				"cicero": "0.25.x"
+				"cicero": "2.x"
 			},
 			"logo": null,
 			"templateModel": {
@@ -385,7 +385,7 @@ Response:
 		"$class": "org.accordproject.protocol@1.0.0.TemplateMetadata",
 		"runtime": "typescript",
 		"template": "clause",
-		"cicero": "0.25.x"
+		"cicero": "2.x"
 	},
 	"logo": null,
 	"templateModel": {
@@ -556,7 +556,7 @@ curl --request POST \
 		"$class": "org.accordproject.protocol@1.0.0.TemplateMetadata",
 		"runtime": "typescript",
 		"template": "clause",
-		"cicero": "0.25.x"
+		"cicero": "2.x"
 	},
 	"logo": null,
 	"templateModel": {

--- a/server/handlers/agreements.test.ts
+++ b/server/handlers/agreements.test.ts
@@ -539,6 +539,7 @@ describe('POST / - Agreement Creation with External Template', () => {
 
         beforeEach(async () => {
             realApTemplate = await createLateDeliveryTemplate();
+            // No target language: save the archive in the template's own declared runtime (typescript).
             templateBuffer = await realApTemplate.toArchive(undefined);
 
             // Save a reference to the real Node.js fetch

--- a/server/handlers/agreements.test.ts
+++ b/server/handlers/agreements.test.ts
@@ -539,7 +539,7 @@ describe('POST / - Agreement Creation with External Template', () => {
 
         beforeEach(async () => {
             realApTemplate = await createLateDeliveryTemplate();
-            templateBuffer = await realApTemplate.toArchive();
+            templateBuffer = await realApTemplate.toArchive(undefined);
 
             // Save a reference to the real Node.js fetch
             const originalFetch = (global as any).fetch;

--- a/server/handlers/agreements.test.ts
+++ b/server/handlers/agreements.test.ts
@@ -539,8 +539,8 @@ describe('POST / - Agreement Creation with External Template', () => {
 
         beforeEach(async () => {
             realApTemplate = await createLateDeliveryTemplate();
-            // No target language: save the archive in the template's own declared runtime (typescript).
-            templateBuffer = await realApTemplate.toArchive(undefined);
+            // Save the archive targeting the template's own declared runtime (typescript).
+            templateBuffer = await realApTemplate.toArchive('typescript');
 
             // Save a reference to the real Node.js fetch
             const originalFetch = (global as any).fetch;

--- a/server/handlers/concertovalidation.ts
+++ b/server/handlers/concertovalidation.ts
@@ -19,7 +19,7 @@ let DEFAULT_MODEL_MANAGER:ModelManager = undefined;
  */
 export async function concertoValidation(typeName: string, body: any, modelManager?: ModelManager): Promise<ValidationResult> {
     if(!DEFAULT_MODEL_MANAGER) {
-        DEFAULT_MODEL_MANAGER = new ModelManager({ strict: true, addMetamodel: true });
+        DEFAULT_MODEL_MANAGER = new ModelManager({ addMetamodel: true });
         DEFAULT_MODEL_MANAGER.addCTOModel(Buffer.from(MODEL, 'base64').toString(), 'protocol.cto', true);
         await DEFAULT_MODEL_MANAGER.updateExternalModels();
     }

--- a/server/handlers/concertovalidation.ts
+++ b/server/handlers/concertovalidation.ts
@@ -19,6 +19,7 @@ let DEFAULT_MODEL_MANAGER:ModelManager = undefined;
  */
 export async function concertoValidation(typeName: string, body: any, modelManager?: ModelManager): Promise<ValidationResult> {
     if(!DEFAULT_MODEL_MANAGER) {
+        // `strict` was removed in concerto-core 4.x; versioned namespaces are mandatory now.
         DEFAULT_MODEL_MANAGER = new ModelManager({ addMetamodel: true });
         DEFAULT_MODEL_MANAGER.addCTOModel(Buffer.from(MODEL, 'base64').toString(), 'protocol.cto', true);
         await DEFAULT_MODEL_MANAGER.updateExternalModels();

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3985,9 +3985,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -3998,7 +3998,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -4006,6 +4006,22 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/brace-expansion": {
@@ -9450,14 +9466,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -9469,13 +9485,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9923,9 +9939,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
-      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "Apache-2",
       "dependencies": {
-        "@accordproject/cicero-core": "0.25.2",
-        "@accordproject/concerto-core": "3.21.0",
-        "@accordproject/concerto-util": "3.20.4",
+        "@accordproject/cicero-core": "2.1.1",
+        "@accordproject/concerto-core": "4.1.5",
+        "@accordproject/concerto-util": "4.1.5",
         "@accordproject/template-engine": "^4.0.0",
         "@modelcontextprotocol/client": "^2.0.0",
         "@modelcontextprotocol/core": "^2.0.0",
@@ -53,46 +53,49 @@
         "wait-on": "^9.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@accordproject/cicero-core": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.25.2.tgz",
-      "integrity": "sha512-mx8moSOcJl+CWs8fXEIzGRM8sbw+heClWa3Zf6SCroTpidT7iZFhSehfq1LMTIgzadEc78Rcd+PWs9n9wdaafw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-2.1.1.tgz",
+      "integrity": "sha512-1OkV41WYM7zJhwSjDUOkJfj36OmZNxwEWFATec8Bt2dKKtdijU4T1T/K0M/NriI1W3C/eeSIDTdT/UITzUnvRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@accordproject/concerto-util": "3.25.7",
-        "@accordproject/markdown-cicero": "0.17.2",
-        "@accordproject/markdown-common": "0.17.2",
-        "@accordproject/markdown-template": "0.17.2",
-        "@accordproject/markdown-transform": "0.17.2",
-        "@types/node": "^22.13.13",
-        "axios": "1.13.6",
+        "@accordproject/concerto-core": "4.1.4",
+        "@accordproject/concerto-util": "4.1.4",
+        "@accordproject/markdown-cicero": "1.0.1",
+        "@accordproject/markdown-common": "1.0.1",
+        "@accordproject/markdown-template": "1.0.1",
+        "@accordproject/markdown-transform": "1.0.1",
+        "axios": "1.15.0",
         "debug": "4.3.4",
         "ietf-language-tag-regex": "0.0.5",
         "json-stable-stringify": "1.0.2",
         "jszip": "3.10.1",
         "node-cache": "5.1.2",
+        "node-forge": "^1.4.0",
         "semver": "7.5.3",
         "slash": "3.0.0",
         "xregexp": "5.1.1"
       },
       "engines": {
-        "node": ">=20",
+        "node": ">=22",
         "npm": ">=10"
+      },
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.3"
       }
     },
     "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-core": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
-      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.4.tgz",
+      "integrity": "sha512-Fc0S/+jQUPxouhN/onRoVjSV+WYm/yjCzKN3JEM0mzV8lHXBtLOR6SQtOfJC8Ott0JIySKI9J4QtBKpicIHdQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.25.7",
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.7",
+        "@accordproject/concerto-cto": "4.1.4",
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.4",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
@@ -101,11 +104,11 @@
         "semver": "7.6.3",
         "urijs": "1.19.11",
         "uuid": "11.0.3",
-        "yaml": "2.8.0"
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=18",
-        "npm": ">=10"
+        "npm": ">=9"
       }
     },
     "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-core/node_modules/debug": {
@@ -143,61 +146,37 @@
         "node": ">=10"
       }
     },
-    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.6",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
-      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-cto": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.4.tgz",
+      "integrity": "sha512-ZA5naXqHdX2FcdMIM5945/wIO+CzqG8beGzB1sqKNwsbEutjin+NQW/VM+gjqplWITR3ZR6b8tsIu/Q0jU5RMw==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.4",
+        "acorn": "^8.15.0",
+        "path-browserify": "^1.0.1",
+        "schema-utils": "^4.3.3"
+      },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6"
+        "node": ">=18",
+        "npm": ">=9"
       }
     },
     "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-util": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
-      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.4.tgz",
+      "integrity": "sha512-FifiXZkUIZisSxG6AJ9ORR/+EULHKxk9qeW69pffLei+WpmSUJDFSp4gHiW8hb11Z46IXO+/9RqdcJfXYI43eA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
         "slash": "3.0.0"
       },
       "engines": {
         "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-util/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-util/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/cicero-core/node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
+        "npm": ">=9"
       }
     },
     "node_modules/@accordproject/cicero-core/node_modules/debug": {
@@ -256,27 +235,15 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
-    "node_modules/@accordproject/cicero-core/node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/@accordproject/concerto-core": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.21.0.tgz",
-      "integrity": "sha512-+R9zA2HuDWNl/BeUrYXJpQFQfveWx1Ut0wYVMLV2WrlsyVCnPqP8IvMGxJ28oxx6Er/Yveo41JcEHMgcvxJw1g==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.5.tgz",
+      "integrity": "sha512-flbKeQXK0ByjPbXZ7cG0Ef7u0TGHzW8ZoUMqEy1TJrDhJLwwYCQz6fqT6bv2L/AiiGFOT4jNvIOHTobknPT/0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.21.0",
-        "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.21.0",
+        "@accordproject/concerto-cto": "4.1.5",
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.5",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
@@ -284,40 +251,12 @@
         "rfdc": "1.4.1",
         "semver": "7.6.3",
         "urijs": "1.19.11",
-        "uuid": "11.0.3"
+        "uuid": "11.0.3",
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.21.0.tgz",
-      "integrity": "sha512-oeMxG/rAByPCWQFpJO94PYmWRf+nQN/CyJGEg7+vddgLPU8aqP6KKCdPj9ADqC4z60h12/RP3DLAwu4Z6YK3XA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "3.11.0",
-        "@accordproject/concerto-util": "3.21.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.21.0.tgz",
-      "integrity": "sha512-INnZfPO3so2javeeNRkDozZad+pInbd60R6M9VmPrm1xM7Gl/pbj895qvaEHEF8WcifBbiJ7UHys3qeIcasOQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+        "npm": ">=9"
       }
     },
     "node_modules/@accordproject/concerto-core/node_modules/debug": {
@@ -356,71 +295,26 @@
       }
     },
     "node_modules/@accordproject/concerto-cto": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.25.7.tgz",
-      "integrity": "sha512-99VUBCW8ye/wMNukmt5PHcCC3zG6RTwHAcVixLjVO/RJFiMDXZMdfYiH750dxyGfb3sbTK36pZn3Bu809o9ISw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.5.tgz",
+      "integrity": "sha512-rRNLTHv0s6dH2YGEruLeT1gQi3ySkkkGn8Al/xry9BEDp0AavgIWBPTIfgRSklRH9Rrn01/V2gmO6g+10ByL9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.7"
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.5",
+        "acorn": "^8.15.0",
+        "path-browserify": "^1.0.1",
+        "schema-utils": "^4.3.3"
       },
       "engines": {
         "node": ">=18",
-        "npm": ">=10"
+        "npm": ">=9"
       }
-    },
-    "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.6",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
-      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-util": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
-      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-cto/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/concerto-cto/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.11.0.tgz",
-      "integrity": "sha512-fEihaIrOlxtrVejPAX26OHcDdgasGLQo/Xwt89i36gM70B8B77jShLZqbvgBj97sC5YaqRVfRH9xlec7Yfqdqg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.14.0.tgz",
+      "integrity": "sha512-qtDdKYyAmnSDBDHg+1myNsT2RtFHyXDCe9LiEdtxgw+wVXPuqQemLosdIkdGDUbcc4VLXsiyDim8ptwUfXFuqg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14",
@@ -428,27 +322,28 @@
       }
     },
     "node_modules/@accordproject/concerto-util": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.20.4.tgz",
-      "integrity": "sha512-Dyqep4H/rwPIw9KgZJoYl+QUT/C/e7KquvovcOXspl9dxBNXYCxyvLbp8DE+xVu1MWR0LD9K3sjLzfLa5QKChg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.5.tgz",
+      "integrity": "sha512-9wBw9XjiNql9CMajfC2GJORUKHhh6E+ZJod2zjw1ItrvFQQaKt80T3SgzBlZ6XG/wEfgFqyypyU0XwLYGlUy+g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
         "slash": "3.0.0"
       },
       "engines": {
         "node": ">=18",
-        "npm": ">=10"
+        "npm": ">=9"
       }
     },
     "node_modules/@accordproject/concerto-util/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
+        "ms": "2.1.2"
       },
       "engines": {
         "node": ">=6.0"
@@ -460,9 +355,9 @@
       }
     },
     "node_modules/@accordproject/concerto-util/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "license": "MIT"
     },
     "node_modules/@accordproject/concerto-vocabulary": {
@@ -479,105 +374,25 @@
         "npm": ">=9"
       }
     },
-    "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.14.0.tgz",
-      "integrity": "sha512-qtDdKYyAmnSDBDHg+1myNsT2RtFHyXDCe9LiEdtxgw+wVXPuqQemLosdIkdGDUbcc4VLXsiyDim8ptwUfXFuqg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
     "node_modules/@accordproject/markdown-cicero": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.17.2.tgz",
-      "integrity": "sha512-SL/D5s0a5thydsHX/0hfrZqxgh1/R3ikJD+LcH7iRy2DcMFCKh2N74LcGleLdsCB78aT8aDkgFA/F01NAx5t6w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-1.0.1.tgz",
+      "integrity": "sha512-+S5lJA1g2+CHJ6qvA3kaQEO8GU9rH7KU7wLniQQVq1TbAFri+sAglKj3lN1bo4kIpUIQJ3SKQK5w+TmVSa2aJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@accordproject/markdown-common": "0.17.2",
-        "@accordproject/markdown-it-cicero": "0.17.2",
+        "@accordproject/markdown-common": "1.0.1",
+        "@accordproject/markdown-it-cicero": "1.0.1",
         "markdown-it": "^14.1.0",
         "semver": "7.6.3",
         "winston": "3.17.0"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-core": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
-      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-cto": "3.25.7",
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.7",
-        "dayjs": "1.11.13",
-        "debug": "4.3.7",
-        "lorem-ipsum": "2.0.8",
-        "randexp": "0.5.3",
-        "rfdc": "1.4.1",
-        "semver": "7.6.3",
-        "urijs": "1.19.11",
-        "uuid": "11.0.3",
-        "yaml": "2.8.0"
       },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.2"
       }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.6",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
-      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-util": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
-      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/@accordproject/markdown-cicero/node_modules/semver": {
       "version": "7.6.3",
@@ -591,399 +406,108 @@
         "node": ">=10"
       }
     },
-    "node_modules/@accordproject/markdown-cicero/node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/@accordproject/markdown-common": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.17.2.tgz",
-      "integrity": "sha512-OmpPp7uDLSO5odjhhTThjJjK7zCB2uuR/bGnalWLJwhfJrITo8JyvAYS+61DfHocuxVH1sHQg5NVnsEoqwIdeg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-1.0.1.tgz",
+      "integrity": "sha512-3ZpZZaGDB7FVQiv7SWjsAtb7mnkHDUxoH74iYxEzoWQxL89C6qMSXRecmP+CGA5jPxbSsOspjiPYZDqrQPHgxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@xmldom/xmldom": "^0.9.5",
+        "@xmldom/xmldom": "^0.9.10",
         "markdown-it": "^14.1.0"
       },
       "engines": {
-        "node": ">=15",
+        "node": ">=22",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/@accordproject/concerto-core": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
-      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-cto": "3.25.7",
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.7",
-        "dayjs": "1.11.13",
-        "debug": "4.3.7",
-        "lorem-ipsum": "2.0.8",
-        "randexp": "0.5.3",
-        "rfdc": "1.4.1",
-        "semver": "7.6.3",
-        "urijs": "1.19.11",
-        "uuid": "11.0.3",
-        "yaml": "2.8.0"
       },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.6",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
-      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/@accordproject/concerto-util": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
-      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.3"
       }
     },
     "node_modules/@accordproject/markdown-html": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.17.2.tgz",
-      "integrity": "sha512-OonOpU/BA6gIf3xYrDaa0gB7jKEoniNVrfOEq9dag/7ZoGVdKTMtK16CKC75avuzgAxLZyNXsU50dNzAS5sWdg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-1.0.1.tgz",
+      "integrity": "sha512-WZDHTrlJUdi9sd3VrwnLBZGkcr+qi1ShpUIGmcFWFw+lUOw2kENROGX1CZJnnhuboFQrZMsgvZAvBuqJfhn96Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/markdown-cicero": "0.17.2",
-        "@accordproject/markdown-common": "0.17.2",
+        "@accordproject/markdown-cicero": "1.0.1",
+        "@accordproject/markdown-common": "1.0.1",
         "jsdom": "^25.0.1",
+        "process": "^0.11.10",
         "type-of": "^2.0.1"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
       }
     },
     "node_modules/@accordproject/markdown-it-cicero": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.17.2.tgz",
-      "integrity": "sha512-I1csdMEhgyW4uiZlVubKknP0E64Qdz8d44FD9+dqWhVS+btwV6/X6TxNuMaTXVIyPw3RN9l4ZJRYcT6FO7MLoQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-1.0.1.tgz",
+      "integrity": "sha512-6cgDtb9/OJtWb0fzNsRsKWPdnOSeklfQMn371i8B3mnFI5pj7SQplyQUlTe6DGjYFP4BWmslV8VHKywa+uhuKA==",
       "license": "Apache-2.0",
       "dependencies": {
         "markdown-it": "^14.1.0"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
       }
     },
     "node_modules/@accordproject/markdown-it-template": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.17.2.tgz",
-      "integrity": "sha512-3BANEXlGaRUpo/FoTPmD9uhdmcGRS6dkkJTw02iiuiokCoiz5uwbo+HWqsQO9HUS2ucVn2CXYM+GjgaNQRPAMQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-1.0.1.tgz",
+      "integrity": "sha512-I8Op+r3ZCEBuHrL2URn/hxxP0Gss66cWjn30/E4uVbZS6Jf3K0YeQWSWTpvLwxeFVQBn50MiXaTs89e+KHFl/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "markdown-it": "^14.1.0"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
       }
     },
     "node_modules/@accordproject/markdown-template": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.17.2.tgz",
-      "integrity": "sha512-N7zFBCixTgUD/ZRz581pF00HfLcSK17YNvv864RRsmQyM4VFIgD56Us9G6JuHXaHy+gdr7fkWT/gjhCmbHH5vg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-1.0.1.tgz",
+      "integrity": "sha512-P1yEXbtUdSwUS/PbDKWms41etpa/gjD7PfWlXiotE0F2IglgHZfAjzWh5/elpdwXSY54rLpOH2JK9edpyZrSwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@accordproject/concerto-cto": "3.25.7",
-        "@accordproject/markdown-cicero": "0.17.2",
-        "@accordproject/markdown-common": "0.17.2",
-        "@accordproject/markdown-it-template": "0.17.2",
+        "@accordproject/markdown-cicero": "1.0.1",
+        "@accordproject/markdown-common": "1.0.1",
+        "@accordproject/markdown-it-template": "1.0.1",
         "dayjs": "1.11.13",
-        "markdown-it": "^14.1.0"
+        "markdown-it": "^14.1.0",
+        "process": "^0.11.10"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/@accordproject/concerto-core": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
-      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-cto": "3.25.7",
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.7",
-        "dayjs": "1.11.13",
-        "debug": "4.3.7",
-        "lorem-ipsum": "2.0.8",
-        "randexp": "0.5.3",
-        "rfdc": "1.4.1",
-        "semver": "7.6.3",
-        "urijs": "1.19.11",
-        "uuid": "11.0.3",
-        "yaml": "2.8.0"
       },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.6",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
-      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/@accordproject/concerto-util": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
-      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.3",
+        "@accordproject/concerto-cto": "^4.1.3"
       }
     },
     "node_modules/@accordproject/markdown-transform": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.17.2.tgz",
-      "integrity": "sha512-6cjrwwJI/oiIiP4Q6WfjZBaVIuh0qmDIJs0Y5zDLBzcDvPRJvJM2ete9DwjZVYx6Dd9hW4a0A60lu2wuLk+Yng==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-1.0.1.tgz",
+      "integrity": "sha512-gth7Nz34DPhSvoh4IxxMZK6ZfcvHRMdSGYW9/0z4Ohau46lyMpUMudoRU+EsYh9ELjAdosoBgrg3ac3zFHi/xw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@accordproject/markdown-cicero": "0.17.2",
-        "@accordproject/markdown-common": "0.17.2",
-        "@accordproject/markdown-html": "0.17.2",
-        "@accordproject/markdown-template": "0.17.2",
+        "@accordproject/markdown-cicero": "1.0.1",
+        "@accordproject/markdown-common": "1.0.1",
+        "@accordproject/markdown-html": "1.0.1",
+        "@accordproject/markdown-template": "1.0.1",
         "dijkstrajs": "^1.0.3",
-        "jszip": "^3.10.1"
+        "jszip": "^3.10.1",
+        "process": "^0.11.10"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-core": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
-      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-cto": "3.25.7",
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.7",
-        "dayjs": "1.11.13",
-        "debug": "4.3.7",
-        "lorem-ipsum": "2.0.8",
-        "randexp": "0.5.3",
-        "rfdc": "1.4.1",
-        "semver": "7.6.3",
-        "urijs": "1.19.11",
-        "uuid": "11.0.3",
-        "yaml": "2.8.0"
       },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.6",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
-      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-util": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
-      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@accordproject/markdown-transform/node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.3"
       }
     },
     "node_modules/@accordproject/template-engine": {
@@ -1148,16 +672,6 @@
         "npm": ">=9"
       }
     },
-    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.14.0.tgz",
-      "integrity": "sha512-qtDdKYyAmnSDBDHg+1myNsT2RtFHyXDCe9LiEdtxgw+wVXPuqQemLosdIkdGDUbcc4VLXsiyDim8ptwUfXFuqg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
     "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-util": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.4.tgz",
@@ -1172,142 +686,6 @@
       "engines": {
         "node": ">=18",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-1.0.1.tgz",
-      "integrity": "sha512-+S5lJA1g2+CHJ6qvA3kaQEO8GU9rH7KU7wLniQQVq1TbAFri+sAglKj3lN1bo4kIpUIQJ3SKQK5w+TmVSa2aJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/markdown-common": "1.0.1",
-        "@accordproject/markdown-it-cicero": "1.0.1",
-        "markdown-it": "^14.1.0",
-        "semver": "7.6.3",
-        "winston": "3.17.0"
-      },
-      "engines": {
-        "node": ">=22",
-        "npm": ">=9"
-      },
-      "peerDependencies": {
-        "@accordproject/concerto-core": "^4.1.2"
-      }
-    },
-    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-cicero/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-common": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-1.0.1.tgz",
-      "integrity": "sha512-3ZpZZaGDB7FVQiv7SWjsAtb7mnkHDUxoH74iYxEzoWQxL89C6qMSXRecmP+CGA5jPxbSsOspjiPYZDqrQPHgxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.9.10",
-        "markdown-it": "^14.1.0"
-      },
-      "engines": {
-        "node": ">=22",
-        "npm": ">=9"
-      },
-      "peerDependencies": {
-        "@accordproject/concerto-core": "^4.1.3"
-      }
-    },
-    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-html": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-1.0.1.tgz",
-      "integrity": "sha512-WZDHTrlJUdi9sd3VrwnLBZGkcr+qi1ShpUIGmcFWFw+lUOw2kENROGX1CZJnnhuboFQrZMsgvZAvBuqJfhn96Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/markdown-cicero": "1.0.1",
-        "@accordproject/markdown-common": "1.0.1",
-        "jsdom": "^25.0.1",
-        "process": "^0.11.10",
-        "type-of": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=22",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-it-cicero": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-1.0.1.tgz",
-      "integrity": "sha512-6cgDtb9/OJtWb0fzNsRsKWPdnOSeklfQMn371i8B3mnFI5pj7SQplyQUlTe6DGjYFP4BWmslV8VHKywa+uhuKA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "engines": {
-        "node": ">=22",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-it-template": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-1.0.1.tgz",
-      "integrity": "sha512-I8Op+r3ZCEBuHrL2URn/hxxP0Gss66cWjn30/E4uVbZS6Jf3K0YeQWSWTpvLwxeFVQBn50MiXaTs89e+KHFl/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "markdown-it": "^14.1.0"
-      },
-      "engines": {
-        "node": ">=22",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-template": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-1.0.1.tgz",
-      "integrity": "sha512-P1yEXbtUdSwUS/PbDKWms41etpa/gjD7PfWlXiotE0F2IglgHZfAjzWh5/elpdwXSY54rLpOH2JK9edpyZrSwQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/markdown-cicero": "1.0.1",
-        "@accordproject/markdown-common": "1.0.1",
-        "@accordproject/markdown-it-template": "1.0.1",
-        "dayjs": "1.11.13",
-        "markdown-it": "^14.1.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": ">=22",
-        "npm": ">=9"
-      },
-      "peerDependencies": {
-        "@accordproject/concerto-core": "^4.1.3",
-        "@accordproject/concerto-cto": "^4.1.3"
-      }
-    },
-    "node_modules/@accordproject/template-engine/node_modules/@accordproject/markdown-transform": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-1.0.1.tgz",
-      "integrity": "sha512-gth7Nz34DPhSvoh4IxxMZK6ZfcvHRMdSGYW9/0z4Ohau46lyMpUMudoRU+EsYh9ELjAdosoBgrg3ac3zFHi/xw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/markdown-cicero": "1.0.1",
-        "@accordproject/markdown-common": "1.0.1",
-        "@accordproject/markdown-html": "1.0.1",
-        "@accordproject/markdown-template": "1.0.1",
-        "dijkstrajs": "^1.0.3",
-        "jszip": "^3.10.1",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": ">=22",
-        "npm": ">=9"
-      },
-      "peerDependencies": {
-        "@accordproject/concerto-core": "^4.1.3"
       }
     },
     "node_modules/@accordproject/template-engine/node_modules/ajv-formats": {
@@ -11109,12 +10487,6 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
-    "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -11515,9 +10887,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2",
   "keywords": [],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "db:studio": "drizzle-kit studio",
@@ -28,9 +28,9 @@
     "axios": "1.19.0"
   },
   "dependencies": {
-    "@accordproject/cicero-core": "0.25.2",
-    "@accordproject/concerto-core": "3.21.0",
-    "@accordproject/concerto-util": "3.20.4",
+    "@accordproject/cicero-core": "2.1.1",
+    "@accordproject/concerto-core": "4.1.5",
+    "@accordproject/concerto-util": "4.1.5",
     "@accordproject/template-engine": "^4.0.0",
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/core": "^2.0.0",

--- a/server/scripts/drizzle-gen.ts
+++ b/server/scripts/drizzle-gen.ts
@@ -255,6 +255,7 @@ import { createSelectSchema, createInsertSchema, createUpdateSchema } from 'driz
 }
 
 async function main() {
+    // `strict` was removed in concerto-core 4.x; versioned namespaces are mandatory now.
     const mm = new ModelManager();
     const cto = fs.readFileSync('../model/protocol.cto', 'utf8');
     mm.addCTOModel(cto, 'protocol.cto', true);

--- a/server/scripts/drizzle-gen.ts
+++ b/server/scripts/drizzle-gen.ts
@@ -99,7 +99,7 @@ import { createSelectSchema, createInsertSchema, createUpdateSchema } from 'driz
      */
     visitModelFile(modelFile: ModelFile, parameters: any): any {
         modelFile.getAllDeclarations()
-            .filter(declaration => !declaration.isScalarDeclaration?.()).forEach((decl) => {
+            .filter((declaration: any) => !declaration.isScalarDeclaration?.()).forEach((decl: any) => {
                 decl.accept(this, parameters);
             });
 
@@ -114,7 +114,7 @@ import { createSelectSchema, createInsertSchema, createUpdateSchema } from 'driz
      * @private
      */
     visitEnumDeclaration(enumDeclaration: EnumDeclaration, parameters: any): any {
-        const names = enumDeclaration.getProperties().map((property) => `'${property.getName()}'`);
+        const names = enumDeclaration.getProperties().map((property: any) => `'${property.getName()}'`);
         parameters.fileWriter.writeLine(0, `export const ${enumDeclaration.getName()} = pgEnum('${enumDeclaration.getName()}', [${names.join(',\n')}]);`);
         return null;
     }
@@ -136,7 +136,7 @@ import { createSelectSchema, createInsertSchema, createUpdateSchema } from 'driz
             // create a database ID for the resource, serial, PK
             parameters.fileWriter.writeLine(1, 'id: serial().primaryKey(),');
 
-            classDeclaration.getOwnProperties().forEach((property) => {
+            classDeclaration.getOwnProperties().forEach((property: any) => {
                 const idField = property.getName() === idFieldName;
                 property.accept(this, {idField, ...parameters});
             });
@@ -255,7 +255,7 @@ import { createSelectSchema, createInsertSchema, createUpdateSchema } from 'driz
 }
 
 async function main() {
-    const mm = new ModelManager({ strict: true });
+    const mm = new ModelManager();
     const cto = fs.readFileSync('../model/protocol.cto', 'utf8');
     mm.addCTOModel(cto, 'protocol.cto', true);
     await mm.updateExternalModels();

--- a/server/test/archives/latedeliveryandpenalty-typescript/apap_request.json
+++ b/server/test/archives/latedeliveryandpenalty-typescript/apap_request.json
@@ -10,7 +10,7 @@
     "$class": "org.accordproject.protocol@1.0.0.TemplateMetadata",
     "runtime": "typescript",
     "template": "clause",
-    "cicero": "^0.25.0"
+    "cicero": "^2.0.0"
   },
   "logo": null,
   "templateModel": {

--- a/server/test/archives/latedeliveryandpenalty-typescript/package.json
+++ b/server/test/archives/latedeliveryandpenalty-typescript/package.json
@@ -5,6 +5,6 @@
     "accordproject": {
         "runtime": "typescript",
         "template": "clause",
-        "cicero": "^0.25.0"
+        "cicero": "^2.0.0"
     }
 }


### PR DESCRIPTION
## Summary

- Bump `@accordproject/cicero-core` in `server/` from `0.25.2` to the latest 2.x release, `2.1.1`.
- Bump `@accordproject/concerto-core` and `@accordproject/concerto-util` from `3.21.0`/`3.20.4` to the latest `4.1.5`, matching what `@accordproject/template-engine@4.0.0` already nests as a transitive dependency (previously the RI carried two separate major versions of concerto-core side by side).
- `@accordproject/template-engine` is left at `^4.0.0`, which already resolves to the latest `4.0.0`.

### Fallout fixed

- `concertovalidation.ts` and `scripts/drizzle-gen.ts` both constructed `ModelManager` with a `strict: true` option; that option was removed in concerto-core 4.x (versioned namespaces are already mandatory), so the object literal no longer type-checks. Dropped it.
- `scripts/drizzle-gen.ts`'s visitor callbacks (`getAllDeclarations`, `getProperties`, `getOwnProperties`) relied on concerto-core's introspect API returning concretely-typed arrays for parameter inference. In concerto-core 4.x these getters are typed `any`, so the callback parameters needed explicit `any` annotations to satisfy `noImplicitAny`.
- `Template#toArchive` in cicero-core 2.x makes the `language` parameter required (still handled as falsy at runtime) — updated the one test call site.
- `Template.fromArchive` now enforces the `accordproject.cicero` semver range declared in a template's `package.json` against the running cicero-core version. Bumped the test fixture's declared range (`server/test/archives/latedeliveryandpenalty-typescript/package.json` and the paired `apap_request.json`) from `^0.25.0` to `^2.0.0`.
- cicero-core 2.x requires Node `>=22`. Bumped `server/package.json` `engines.node` and the `Dockerfile`'s `ARG NODE_VERSION` from `20.18.1` to `22.13.1` — CI (`.github/workflows/build.yml`) already runs the matrix on Node 22.x/24.x, so this aligns the local dev/Docker story with CI rather than changing it.
- Updated `server/README.md`'s example request bodies from `"cicero": "0.25.x"` to `"cicero": "2.x"`.

## Test plan

- [x] `npm run build` (`tsc -p .`) passes cleanly in `server/`.
- [x] `npm test` in `server/`: 152/159 passing. The remaining 7 failures are all in `handlers/agreements.test.ts` and share one root cause — a test fixture template imports Concerto models over HTTPS from `models.accordproject.org`, which this sandbox's network policy blocks (`403` at the proxy). Verified these same 7 tests fail identically against the pre-upgrade code in this same sandbox, so this is a pre-existing sandbox network limitation, not a regression — these should pass in the project's actual CI, which has normal internet access.
- [x] Confirmed `db/schema.ts` (generated from `model/protocol.cto` via `scripts/drizzle-gen.ts`) is unaffected — the model itself didn't change, and a diff against a pre-upgrade copy is identical.


---
_Generated by [Claude Code](https://claude.ai/code/session_0126thR7JHJE8j7ogxv4cGLj)_