### PR TITLE
docs: use a template from templates.accordproject.org (cold start)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ The archive is parsed, deduplicated on its content hash, and stored as a
 template with the URI `archive:latedeliveryandpenalty@1.0.0` — which agreements
 then reference as their `template`. Archives declare the Cicero version they
 target and are rejected with a `422` if the server does not run a matching
-version, so see
+version (the library's archives are being upgraded to Cicero 2.x in
+[cicero-template-library#526](https://github.com/accordproject/cicero-template-library/pull/526)),
+so see
 [Deploying a Template Archive](./server/README.md#deploying-a-template-archive-cta)
 for the compatibility check and the rest of the walkthrough (creating an
 agreement and rendering it to HTML).

--- a/README.md
+++ b/README.md
@@ -77,33 +77,32 @@ curl http://localhost:9000/capabilities
 # or https://my-apap.up.railway.app/capabilities
 ```
 
-### Deploy a template
+### Draft your first agreement
 
 A new server starts with an empty database, so there is nothing to draft until a
-template is loaded. Rather than hand-writing one, deploy an existing Cicero
-Template Archive (`.cta`) from
-[templates.accordproject.org](https://templates.accordproject.org):
+template is loaded. The shortest way in is to point an agreement straight at a
+Cicero Template Archive (`.cta`) hosted on
+[templates.accordproject.org](https://templates.accordproject.org) — the server
+fetches and caches the template for you, so there is no separate deploy step:
 
 ```bash
-curl -sL -o latedeliveryandpenalty.cta \
-  https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta
-
 curl --request POST \
-  --url http://localhost:9000/templates/archive \
-  --header 'Content-Type: application/octet-stream' \
-  --data-binary @latedeliveryandpenalty.cta
+  --url http://localhost:9000/agreements \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"uri": "apap://agreement-ldp",
+	"template": "https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta",
+	"agreementStatus": "DRAFT",
+	"data": { "...": "an instance of the template model" }
+}'
+
+curl http://localhost:9000/agreements/1/convert/html
 ```
 
-The archive is parsed, deduplicated on its content hash, and stored as a
-template whose URI is `ap://latedeliveryandpenalty@1.0.0#<hash>` — the Accord
-Project template URI syntax, which agreements then reference as their
-`template`. Archives declare the Cicero version they
-target and are rejected with a `422` if the server does not run a matching
-version (the library's archives are being upgraded to Cicero 2.x in
-[cicero-template-library#526](https://github.com/accordproject/cicero-template-library/pull/526)),
-so see
-[Deploying a Template Archive](./server/README.md#deploying-a-template-archive-cta)
-for the compatibility check and the rest of the walkthrough (creating an
-agreement and rendering it to HTML).
+See
+[Using a Template from templates.accordproject.org](./server/README.md#using-a-template-from-templatesaccordprojectorg)
+for the full agreement body, the Cicero version compatibility check, and
+`POST /templates/archive` — the explicit upload path for custom archives or
+servers without network egress.
 
 For full API documentation see [docs.accordproject.org/docs/ref-apap](https://docs.accordproject.org/docs/ref-apap).

--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ curl --request POST \
 ```
 
 The archive is parsed, deduplicated on its content hash, and stored as a
-template with the URI `archive:latedeliveryandpenalty@1.0.0` — which agreements
-then reference as their `template`. Archives declare the Cicero version they
+template whose URI is `ap://latedeliveryandpenalty@1.0.0#<hash>` — the Accord
+Project template URI syntax, which agreements then reference as their
+`template`. Archives declare the Cicero version they
 target and are rejected with a `422` if the server does not run a matching
 version (the library's archives are being upgraded to Cicero 2.x in
 [cicero-template-library#526](https://github.com/accordproject/cicero-template-library/pull/526)),

--- a/README.md
+++ b/README.md
@@ -77,5 +77,30 @@ curl http://localhost:9000/capabilities
 # or https://my-apap.up.railway.app/capabilities
 ```
 
+### Deploy a template
+
+A new server starts with an empty database, so there is nothing to draft until a
+template is loaded. Rather than hand-writing one, deploy an existing Cicero
+Template Archive (`.cta`) from
+[templates.accordproject.org](https://templates.accordproject.org):
+
+```bash
+curl -sL -o latedeliveryandpenalty.cta \
+  https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta
+
+curl --request POST \
+  --url http://localhost:9000/templates/archive \
+  --header 'Content-Type: application/octet-stream' \
+  --data-binary @latedeliveryandpenalty.cta
+```
+
+The archive is parsed, deduplicated on its content hash, and stored as a
+template with the URI `archive:latedeliveryandpenalty@1.0.0` — which agreements
+then reference as their `template`. Archives declare the Cicero version they
+target and are rejected with a `422` if the server does not run a matching
+version, so see
+[Deploying a Template Archive](./server/README.md#deploying-a-template-archive-cta)
+for the compatibility check and the rest of the walkthrough (creating an
+agreement and rendering it to HTML).
 
 For full API documentation see [docs.accordproject.org/docs/ref-apap](https://docs.accordproject.org/docs/ref-apap).

--- a/server/README.md
+++ b/server/README.md
@@ -233,58 +233,34 @@ If the delay is more than 15 days, the Buyer is entitled to terminate this Contr
 ```
 
 > Drafting works for any archive the server accepts. Triggering additionally
-> requires the archive's `logic/` to resolve its own imports: the published
-> `latedeliveryandpenalty@1.0.0` archive stores its generated Concerto classes
-> flat under `logic/` while `logic/logic.ts` imports values from
-> `./generated/...`, so `POST /agreements/:id/trigger` cannot resolve the import
-> for that particular archive.
-> [cicero-template-library#526](https://github.com/accordproject/cicero-template-library/pull/526)
-> makes those imports type-only, which resolves it — triggering that template
-> returns a `LateDeliveryAndPenaltyResponse` with a `MonetaryAmount` penalty and
-> a `PaymentObligationEvent`. See
+> requires the archive to ship logic whose imports resolve within the archive
+> itself — an archive whose `logic/` imports values from a path it does not
+> contain drafts fine but fails at `POST /agreements/:id/trigger`. See
 > [Trigger an Agreement](#trigger-an-agreement) for the request/response shape.
 
 ### Cicero version compatibility
 
 Every archive declares the Cicero version range its contents were built for, and
 the RI only accepts archives whose range covers the `@accordproject/cicero-core`
-version pinned in [`package.json`](./package.json):
+version pinned in [`package.json`](./package.json). To see what an archive asks
+for before using it:
 
 ```bash
-curl -sL -o latedeliveryandpenalty.cta \
-  https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta
-unzip -p latedeliveryandpenalty.cta package.json | jq .accordproject
-# { "template": "clause", "runtime": "typescript", "cicero": "^1.0.0" }
+curl -sL -o template.cta \
+  https://templates.accordproject.org/archives/<name>@<version>.cta
+unzip -p template.cta package.json | jq .accordproject.cicero
 ```
 
-The archives currently published on templates.accordproject.org declare
-`"cicero": "^1.0.0"`, which the RI's cicero-core 2.x does not satisfy, so they
-are rejected — as a plain `500` from `POST /agreements`, or as the typed `422`
-below from `POST /templates/archive`:
+A range the server cannot satisfy is rejected. `POST /agreements` surfaces that
+as a plain `500` carrying cicero's own message:
 
 ```
 The template targets Cicero version ^1.0.0 but the current Cicero version is 2.1.1.
 ```
 
-[cicero-template-library#526](https://github.com/accordproject/cicero-template-library/pull/526)
-upgrades the library's templates to `"cicero": "^2.0.0"` — once it lands and the
-archives are republished (`latedeliveryandpenalty@1.0.1`), the walkthrough above
-runs end to end with no extra steps. Until then, use an archive built for the
-RI's Cicero major — or, if you know the template's contents are compatible,
-retarget the declared range and upload the result with `POST /templates/archive`
-below:
-
-```bash
-# ^2.0.0 here is the RI's Cicero major — use ^0.25.0 on a checkout pinning
-# cicero-core 0.25.x, and so on.
-mkdir -p retarget && cd retarget && unzip -oq ../latedeliveryandpenalty.cta
-jq '.accordproject.cicero = "^2.0.0"' package.json > package.tmp && mv package.tmp package.json
-zip -qr ../latedeliveryandpenalty-retargeted.cta . && cd ..
-```
-
-Retargeting only rewrites the declared range — it does not make an incompatible
-template work, so run a `convert` afterwards to confirm the template still
-drafts.
+`POST /templates/archive` reports the same condition as a typed `422`
+([below](#deploying-an-archive-explicitly)). Either way, the fix is an archive
+built for the Cicero major this RI runs.
 
 ### Deploying an archive explicitly
 
@@ -292,8 +268,7 @@ drafts.
 template row, without an agreement being involved. Reach for it when the quick
 path above does not fit:
 
-- the archive is one you built locally, or edited (a retargeted range, a custom
-  clause) and never published
+- the archive is one you built or edited locally and never published
 - the RI has no network egress, or the archive lives somewhere it cannot reach
 - you want the template registered and listable before any agreement exists, and
   a malformed or incompatible archive rejected up front — with a typed error —
@@ -302,10 +277,13 @@ path above does not fit:
 The body is the raw archive, not JSON:
 
 ```bash
+curl -sL -o latedeliveryandpenalty.cta \
+  https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta
+
 curl --request POST \
   --url http://localhost:9000/templates/archive \
   --header 'Content-Type: application/octet-stream' \
-  --data-binary @latedeliveryandpenalty-retargeted.cta
+  --data-binary @latedeliveryandpenalty.cta
 ```
 
 Response (`201`, abridged — the model, text and logic of the archive are stored

--- a/server/README.md
+++ b/server/README.md
@@ -141,6 +141,220 @@ Example response:
 
 These capabiltities will evolve as the functionality of the RI is extended to new use cases.
 
+## Deploying a Template Archive (.cta)
+
+A freshly bootstrapped RI has an empty database, so there is nothing to draft or
+trigger until a template is loaded — the cold start problem. Hand-writing the
+`POST /templates` body (see [Creating a Template](#creating-a-template)) means
+pasting an escaped Concerto model and template text into JSON. `POST
+/templates/archive` skips that: it takes a Cicero Template Archive (`.cta`)
+verbatim and explodes it into a template row for you, so an existing template
+from [templates.accordproject.org](https://templates.accordproject.org) can seed
+the server in one request.
+
+### 1. Pick a template
+
+Archives are published at
+`https://templates.accordproject.org/archives/<name>@<version>.cta`, and the
+full index of names, versions and descriptions is at
+[template-library.json](https://templates.accordproject.org/template-library.json).
+This walkthrough uses `latedeliveryandpenalty`:
+
+```bash
+curl -sL -o latedeliveryandpenalty.cta \
+  https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta
+```
+
+### 2. Check the archive's Cicero version
+
+Every archive declares the Cicero version range its contents were built for, and
+the RI only accepts archives whose range covers the `@accordproject/cicero-core`
+version pinned in [`package.json`](./package.json):
+
+```bash
+unzip -p latedeliveryandpenalty.cta package.json | jq .accordproject
+# { "template": "clause", "runtime": "typescript", "cicero": "^1.0.0" }
+```
+
+> **Note:** the templates published on templates.accordproject.org currently
+> declare `"cicero": "^1.0.0"`, which no cicero-core version the RI has pinned
+> satisfies, so uploading one as-is is rejected with the `422` below. Until the
+> library republishes against the RI's Cicero major, use an archive built for
+> that major — or, if you know the template's contents are compatible, retarget
+> the declared range before uploading:
+>
+> ```bash
+> # ^2.0.0 here is the RI's Cicero major — use ^0.25.0 on a checkout pinning
+> # cicero-core 0.25.x, and so on.
+> mkdir -p retarget && cd retarget && unzip -oq ../latedeliveryandpenalty.cta
+> jq '.accordproject.cicero = "^2.0.0"' package.json > package.tmp && mv package.tmp package.json
+> zip -qr ../latedeliveryandpenalty-retargeted.cta . && cd ..
+> ```
+>
+> Retargeting only rewrites the declared range — it does not make an
+> incompatible template work, so run a `convert` afterwards to confirm the
+> template still drafts.
+
+### 3. Deploy the archive
+
+The body is the raw archive, not JSON:
+
+```bash
+curl --request POST \
+  --url http://localhost:9000/templates/archive \
+  --header 'Content-Type: application/octet-stream' \
+  --data-binary @latedeliveryandpenalty.cta
+```
+
+Response (`201`, abridged — the model, text and logic of the archive are stored
+in full). `hash` and `metadata.cicero` reflect the exact bytes uploaded, so the
+values below are for the retargeted archive from step 2:
+
+```json
+{
+	"id": 1,
+	"uri": "archive:latedeliveryandpenalty@1.0.0",
+	"hash": "e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
+	"author": "Accord Project",
+	"displayName": "Late Delivery and Penalty",
+	"version": "1.0.0",
+	"description": "A sample Late Delivery And Penalty clause.",
+	"license": "Apache-2.0",
+	"metadata": {
+		"template": "clause",
+		"runtime": "typescript",
+		"cicero": "^2.0.0"
+	},
+	"templateModel": { "model": { "$class": "org.accordproject.protocol@1.0.0.CtoModel", "ctoFiles": [ "..." ] } },
+	"text": { "templateText": "## Late Delivery and Penalty.\n\nIn case of delayed delivery{{#if forceMajeure}} except for Force Majeure cases,{{/if}}\n..." },
+	"logic": { "codes": [ "..." ] }
+}
+```
+
+Note the assigned `uri`: `archive:<name>@<version>`, taken from the archive's
+own `package.json`. That is the value agreements reference as their `template`.
+
+Uploads are deduplicated on the archive's content hash, so re-posting the same
+`.cta` returns the existing row (still `201`) rather than creating a duplicate —
+re-running the command above is safe.
+
+Errors:
+
+| Status | `error.code`                       | Cause                                                      |
+| ------ | ---------------------------------- | ---------------------------------------------------------- |
+| `400`  | `INVALID_PAYLOAD`                  | Empty body, or bytes that are not a readable `.cta` archive |
+| `422`  | `TEMPLATE_CICERO_VERSION_MISMATCH` | The archive targets a Cicero version this server does not run |
+
+```json
+{
+	"error": {
+		"code": "TEMPLATE_CICERO_VERSION_MISMATCH",
+		"message": "Template requires Cicero ^1.0.0, server supports 2.1.1",
+		"details": {
+			"declaredRange": "^1.0.0",
+			"serverVersion": "2.1.1"
+		}
+	}
+}
+```
+
+`serverVersion` is whatever `@accordproject/cicero-core` version this RI pins,
+so the exact numbers depend on the checkout.
+
+### 4. Create an agreement against the deployed template
+
+`template` is the `uri` returned above, and `data` is an instance of the
+archive's `@template` type — for this template the namespace comes from
+`model/clause.cto`, `org.accordproject.latedeliveryandpenalty@0.2.0`:
+
+```bash
+curl --request POST \
+  --url http://localhost:9000/agreements \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"uri": "apap://agreement-ldp",
+	"template": "archive:latedeliveryandpenalty@1.0.0",
+	"agreementStatus": "DRAFT",
+	"data": {
+		"$class": "org.accordproject.latedeliveryandpenalty@0.2.0.TemplateModel",
+		"clauseId": "c88e5ed7-c3e0-4249-a99c-ce9278684ac8",
+		"$identifier": "c88e5ed7-c3e0-4249-a99c-ce9278684ac8",
+		"buyer": "Betty Buyer",
+		"seller": "Steve Seller",
+		"forceMajeure": true,
+		"penaltyDuration": {
+			"$class": "org.accordproject.time@0.3.0.Duration",
+			"amount": 2,
+			"unit": "days"
+		},
+		"penaltyPercentage": 10.5,
+		"capPercentage": 55,
+		"termination": {
+			"$class": "org.accordproject.time@0.3.0.Duration",
+			"amount": 15,
+			"unit": "days"
+		},
+		"fractionalPart": "days"
+	}
+}'
+```
+
+### 5. Draft it
+
+```bash
+curl --request GET \
+  --url http://localhost:9000/agreements/1/convert/html
+```
+
+```html
+<html>
+<head><meta charset="UTF-8"></head>
+<body>
+<div class="document">
+<div class="clause" name="top" elementType="org.accordproject.latedeliveryandpenalty@0.2.0.TemplateModel">
+<h2>Late Delivery and Penalty.</h2>
+<p>In case of delayed delivery<span class="conditional" name="forceMajeure" whenTrue=" except for Force Majeure cases," whenFalse=""> except for Force Majeure cases,</span>
+Steve Seller (the Seller) shall pay to Betty Buyer (the Buyer) for every 2 days
+of delay penalty amounting to 10.5% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a <span class="variable" name="fractionalPart" enumValues="%5B%22seconds%22%2C%22minutes%22%2C%22hours%22%2C%22days%22%2C%22weeks%22%5D" elementType="org.accordproject.time@0.3.0.TemporalUnit">days</span> is to be
+considered a full <span class="variable" name="fractionalPart" enumValues="%5B%22seconds%22%2C%22minutes%22%2C%22hours%22%2C%22days%22%2C%22weeks%22%5D" elementType="org.accordproject.time@0.3.0.TemporalUnit">days</span>. The total amount of penalty shall not however,
+exceed 55.0% of the total value of the Equipment involved in late delivery.
+If the delay is more than 15 days, the Buyer is entitled to terminate this Contract.</p>
+</div>
+</div>
+</body>
+</html>
+```
+
+> Drafting works for any archive the server accepts. Triggering additionally
+> requires the archive's `logic/` to be self-contained: the published
+> `latedeliveryandpenalty@1.0.0` archive stores its generated Concerto classes
+> flat under `logic/` while `logic/logic.ts` imports them from
+> `./generated/...`, so `POST /agreements/:id/trigger` fails to resolve the
+> import for that particular archive. See
+> [Trigger an Agreement](#trigger-an-agreement) for a template whose logic
+> executes.
+
+### Letting an agreement fetch the archive instead
+
+`POST /agreements` also accepts an `http(s)` URL as its `template`, and fetches,
+hashes and caches the archive on the way through (see
+`handlers/retrievers/HttpTemplateRetriever.ts`) — one request instead of two:
+
+```json
+{
+	"uri": "apap://agreement-ldp-remote",
+	"template": "https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta",
+	"agreementStatus": "DRAFT",
+	"data": { "...": "as above" }
+}
+```
+
+Deploying the archive explicitly is still worth doing when you want the template
+available (and listable at `GET /templates`) before any agreement exists, when
+the archive is not reachable over HTTP from the server, or when you want the
+upload rejected up front rather than at first agreement.
+
 ## Creating a Template
 
 ```bash

--- a/server/README.md
+++ b/server/README.md
@@ -217,8 +217,8 @@ the `^2.0.0` below is the retargeted archive from step 2:
 ```json
 {
 	"id": 1,
-	"uri": "archive:latedeliveryandpenalty@1.0.0",
-	"hash": "e29682ed71694106…",
+	"uri": "ap://latedeliveryandpenalty@1.0.0#e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
+	"hash": "e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
 	"author": "Accord Project",
 	"displayName": "Late Delivery and Penalty",
 	"version": "1.0.0",
@@ -235,8 +235,14 @@ the `^2.0.0` below is the retargeted archive from step 2:
 }
 ```
 
-Note the assigned `uri`: `archive:<name>@<version>`, taken from the archive's
-own `package.json`. That is the value agreements reference as their `template`.
+Note the assigned `uri`: `ap://<name>@<version>#<hash>` — the Accord Project
+template URI syntax, the same form the
+[template library index](https://templates.accordproject.org/template-library.json)
+publishes. Name and version come from the archive's own `package.json`, and the
+fragment is its content hash, so the URI identifies those exact bytes. That is
+the value agreements reference as their `template`, and it has to match
+character for character — copy it from this response rather than the examples
+below, whose hash is illustrative and will not match your upload.
 
 Uploads are deduplicated on the archive's content hash, so re-posting the same
 `.cta` returns the existing row (still `201`) rather than creating a duplicate —
@@ -277,7 +283,7 @@ curl --request POST \
   --header 'Content-Type: application/json' \
   --data '{
 	"uri": "apap://agreement-ldp",
-	"template": "archive:latedeliveryandpenalty@1.0.0",
+	"template": "ap://latedeliveryandpenalty@1.0.0#e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
 	"agreementStatus": "DRAFT",
 	"data": {
 		"$class": "org.accordproject.latedeliveryandpenalty@0.2.0.TemplateModel",

--- a/server/README.md
+++ b/server/README.md
@@ -176,12 +176,15 @@ unzip -p latedeliveryandpenalty.cta package.json | jq .accordproject
 # { "template": "clause", "runtime": "typescript", "cicero": "^1.0.0" }
 ```
 
-> **Note:** the templates published on templates.accordproject.org currently
-> declare `"cicero": "^1.0.0"`, which no cicero-core version the RI has pinned
-> satisfies, so uploading one as-is is rejected with the `422` below. Until the
-> library republishes against the RI's Cicero major, use an archive built for
-> that major — or, if you know the template's contents are compatible, retarget
-> the declared range before uploading:
+> **Note:** the archives currently published on templates.accordproject.org
+> declare `"cicero": "^1.0.0"`, which the RI's cicero-core 2.x does not satisfy,
+> so uploading one as-is is rejected with the `422` below.
+> [cicero-template-library#526](https://github.com/accordproject/cicero-template-library/pull/526)
+> upgrades the library's templates to `"cicero": "^2.0.0"` — once it lands and
+> the archives are republished (`latedeliveryandpenalty@1.0.1`), this
+> walkthrough runs end to end with no extra steps. Until then, use an archive
+> built for the RI's Cicero major — or, if you know the template's contents are
+> compatible, retarget the declared range before uploading:
 >
 > ```bash
 > # ^2.0.0 here is the RI's Cicero major — use ^0.25.0 on a checkout pinning
@@ -207,14 +210,15 @@ curl --request POST \
 ```
 
 Response (`201`, abridged — the model, text and logic of the archive are stored
-in full). `hash` and `metadata.cicero` reflect the exact bytes uploaded, so the
-values below are for the retargeted archive from step 2:
+in full). `hash` is the archive's content hash and `metadata` is its
+`package.json.accordproject` block, so both follow the exact bytes uploaded —
+the `^2.0.0` below is the retargeted archive from step 2:
 
 ```json
 {
 	"id": 1,
 	"uri": "archive:latedeliveryandpenalty@1.0.0",
-	"hash": "e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
+	"hash": "e29682ed71694106…",
 	"author": "Accord Project",
 	"displayName": "Late Delivery and Penalty",
 	"version": "1.0.0",
@@ -327,13 +331,16 @@ If the delay is more than 15 days, the Buyer is entitled to terminate this Contr
 ```
 
 > Drafting works for any archive the server accepts. Triggering additionally
-> requires the archive's `logic/` to be self-contained: the published
+> requires the archive's `logic/` to resolve its own imports: the published
 > `latedeliveryandpenalty@1.0.0` archive stores its generated Concerto classes
-> flat under `logic/` while `logic/logic.ts` imports them from
-> `./generated/...`, so `POST /agreements/:id/trigger` fails to resolve the
-> import for that particular archive. See
-> [Trigger an Agreement](#trigger-an-agreement) for a template whose logic
-> executes.
+> flat under `logic/` while `logic/logic.ts` imports values from
+> `./generated/...`, so `POST /agreements/:id/trigger` cannot resolve the import
+> for that particular archive.
+> [cicero-template-library#526](https://github.com/accordproject/cicero-template-library/pull/526)
+> makes those imports type-only, which resolves it — triggering that template
+> returns a `LateDeliveryAndPenaltyResponse` with a `MonetaryAmount` penalty and
+> a `PaymentObligationEvent`. See
+> [Trigger an Agreement](#trigger-an-agreement) for the request/response shape.
 
 ### Letting an agreement fetch the archive instead
 

--- a/server/README.md
+++ b/server/README.md
@@ -141,141 +141,26 @@ Example response:
 
 These capabiltities will evolve as the functionality of the RI is extended to new use cases.
 
-## Deploying a Template Archive (.cta)
+## Using a Template from templates.accordproject.org
 
 A freshly bootstrapped RI has an empty database, so there is nothing to draft or
 trigger until a template is loaded — the cold start problem. Hand-writing the
 `POST /templates` body (see [Creating a Template](#creating-a-template)) means
-pasting an escaped Concerto model and template text into JSON. `POST
-/templates/archive` skips that: it takes a Cicero Template Archive (`.cta`)
-verbatim and explodes it into a template row for you, so an existing template
-from [templates.accordproject.org](https://templates.accordproject.org) can seed
-the server in one request.
-
-### 1. Pick a template
+pasting an escaped Concerto model and template text into JSON, so for a quick
+start use an existing Cicero Template Archive (`.cta`) from
+[templates.accordproject.org](https://templates.accordproject.org) instead.
 
 Archives are published at
 `https://templates.accordproject.org/archives/<name>@<version>.cta`, and the
 full index of names, versions and descriptions is at
 [template-library.json](https://templates.accordproject.org/template-library.json).
-This walkthrough uses `latedeliveryandpenalty`:
+The examples below use `latedeliveryandpenalty`.
 
-```bash
-curl -sL -o latedeliveryandpenalty.cta \
-  https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta
-```
+### Quick start: point an agreement at a hosted archive
 
-### 2. Check the archive's Cicero version
-
-Every archive declares the Cicero version range its contents were built for, and
-the RI only accepts archives whose range covers the `@accordproject/cicero-core`
-version pinned in [`package.json`](./package.json):
-
-```bash
-unzip -p latedeliveryandpenalty.cta package.json | jq .accordproject
-# { "template": "clause", "runtime": "typescript", "cicero": "^1.0.0" }
-```
-
-> **Note:** the archives currently published on templates.accordproject.org
-> declare `"cicero": "^1.0.0"`, which the RI's cicero-core 2.x does not satisfy,
-> so uploading one as-is is rejected with the `422` below.
-> [cicero-template-library#526](https://github.com/accordproject/cicero-template-library/pull/526)
-> upgrades the library's templates to `"cicero": "^2.0.0"` — once it lands and
-> the archives are republished (`latedeliveryandpenalty@1.0.1`), this
-> walkthrough runs end to end with no extra steps. Until then, use an archive
-> built for the RI's Cicero major — or, if you know the template's contents are
-> compatible, retarget the declared range before uploading:
->
-> ```bash
-> # ^2.0.0 here is the RI's Cicero major — use ^0.25.0 on a checkout pinning
-> # cicero-core 0.25.x, and so on.
-> mkdir -p retarget && cd retarget && unzip -oq ../latedeliveryandpenalty.cta
-> jq '.accordproject.cicero = "^2.0.0"' package.json > package.tmp && mv package.tmp package.json
-> zip -qr ../latedeliveryandpenalty-retargeted.cta . && cd ..
-> ```
->
-> Retargeting only rewrites the declared range — it does not make an
-> incompatible template work, so run a `convert` afterwards to confirm the
-> template still drafts.
-
-### 3. Deploy the archive
-
-The body is the raw archive, not JSON:
-
-```bash
-curl --request POST \
-  --url http://localhost:9000/templates/archive \
-  --header 'Content-Type: application/octet-stream' \
-  --data-binary @latedeliveryandpenalty.cta
-```
-
-Response (`201`, abridged — the model, text and logic of the archive are stored
-in full). `hash` is the archive's content hash and `metadata` is its
-`package.json.accordproject` block, so both follow the exact bytes uploaded —
-the `^2.0.0` below is the retargeted archive from step 2:
-
-```json
-{
-	"id": 1,
-	"uri": "ap://latedeliveryandpenalty@1.0.0#e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
-	"hash": "e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
-	"author": "Accord Project",
-	"displayName": "Late Delivery and Penalty",
-	"version": "1.0.0",
-	"description": "A sample Late Delivery And Penalty clause.",
-	"license": "Apache-2.0",
-	"metadata": {
-		"template": "clause",
-		"runtime": "typescript",
-		"cicero": "^2.0.0"
-	},
-	"templateModel": { "model": { "$class": "org.accordproject.protocol@1.0.0.CtoModel", "ctoFiles": [ "..." ] } },
-	"text": { "templateText": "## Late Delivery and Penalty.\n\nIn case of delayed delivery{{#if forceMajeure}} except for Force Majeure cases,{{/if}}\n..." },
-	"logic": { "codes": [ "..." ] }
-}
-```
-
-Note the assigned `uri`: `ap://<name>@<version>#<hash>` — the Accord Project
-template URI syntax, the same form the
-[template library index](https://templates.accordproject.org/template-library.json)
-publishes. Name and version come from the archive's own `package.json`, and the
-fragment is its content hash, so the URI identifies those exact bytes. That is
-the value agreements reference as their `template`, and it has to match
-character for character — copy it from this response rather than the examples
-below, whose hash is illustrative and will not match your upload.
-
-Uploads are deduplicated on the archive's content hash, so re-posting the same
-`.cta` returns the existing row (still `201`) rather than creating a duplicate —
-re-running the command above is safe.
-
-Errors:
-
-| Status | `error.code`                       | Cause                                                      |
-| ------ | ---------------------------------- | ---------------------------------------------------------- |
-| `400`  | `INVALID_PAYLOAD`                  | Empty body, or bytes that are not a readable `.cta` archive |
-| `422`  | `TEMPLATE_CICERO_VERSION_MISMATCH` | The archive targets a Cicero version this server does not run |
-
-```json
-{
-	"error": {
-		"code": "TEMPLATE_CICERO_VERSION_MISMATCH",
-		"message": "Template requires Cicero ^1.0.0, server supports 2.1.1",
-		"details": {
-			"declaredRange": "^1.0.0",
-			"serverVersion": "2.1.1"
-		}
-	}
-}
-```
-
-`serverVersion` is whatever `@accordproject/cicero-core` version this RI pins,
-so the exact numbers depend on the checkout.
-
-### 4. Create an agreement against the deployed template
-
-`template` is the `uri` returned above, and `data` is an instance of the
-archive's `@template` type — for this template the namespace comes from
-`model/clause.cto`, `org.accordproject.latedeliveryandpenalty@0.2.0`:
+`POST /agreements` accepts an `http(s)` URL as its `template` and resolves it on
+the way through (see `handlers/retrievers/HttpTemplateRetriever.ts`), so a
+single request gets you a usable agreement — no `/templates` call at all:
 
 ```bash
 curl --request POST \
@@ -283,7 +168,7 @@ curl --request POST \
   --header 'Content-Type: application/json' \
   --data '{
 	"uri": "apap://agreement-ldp",
-	"template": "ap://latedeliveryandpenalty@1.0.0#e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
+	"template": "https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta",
 	"agreementStatus": "DRAFT",
 	"data": {
 		"$class": "org.accordproject.latedeliveryandpenalty@0.2.0.TemplateModel",
@@ -309,7 +194,18 @@ curl --request POST \
 }'
 ```
 
-### 5. Draft it
+`data` is an instance of the archive's `@template` type — for this template the
+namespace comes from its `model/clause.cto`,
+`org.accordproject.latedeliveryandpenalty@0.2.0`.
+
+The RI fetches the archive, parses it, and stores it as a template row keyed by
+its content hash — its `uri` is the URL it came from, so it shows up in
+`GET /templates` — and records that hash on the agreement. A later agreement
+against the same URL fetches it again but reuses the stored row rather than
+duplicating it, and converting or triggering this agreement rebuilds the
+template from that row instead of going back to the URL.
+
+Then draft it:
 
 ```bash
 curl --request GET \
@@ -348,25 +244,142 @@ If the delay is more than 15 days, the Buyer is entitled to terminate this Contr
 > a `PaymentObligationEvent`. See
 > [Trigger an Agreement](#trigger-an-agreement) for the request/response shape.
 
-### Letting an agreement fetch the archive instead
+### Cicero version compatibility
 
-`POST /agreements` also accepts an `http(s)` URL as its `template`, and fetches,
-hashes and caches the archive on the way through (see
-`handlers/retrievers/HttpTemplateRetriever.ts`) — one request instead of two:
+Every archive declares the Cicero version range its contents were built for, and
+the RI only accepts archives whose range covers the `@accordproject/cicero-core`
+version pinned in [`package.json`](./package.json):
+
+```bash
+curl -sL -o latedeliveryandpenalty.cta \
+  https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta
+unzip -p latedeliveryandpenalty.cta package.json | jq .accordproject
+# { "template": "clause", "runtime": "typescript", "cicero": "^1.0.0" }
+```
+
+The archives currently published on templates.accordproject.org declare
+`"cicero": "^1.0.0"`, which the RI's cicero-core 2.x does not satisfy, so they
+are rejected — as a plain `500` from `POST /agreements`, or as the typed `422`
+below from `POST /templates/archive`:
+
+```
+The template targets Cicero version ^1.0.0 but the current Cicero version is 2.1.1.
+```
+
+[cicero-template-library#526](https://github.com/accordproject/cicero-template-library/pull/526)
+upgrades the library's templates to `"cicero": "^2.0.0"` — once it lands and the
+archives are republished (`latedeliveryandpenalty@1.0.1`), the walkthrough above
+runs end to end with no extra steps. Until then, use an archive built for the
+RI's Cicero major — or, if you know the template's contents are compatible,
+retarget the declared range and upload the result with `POST /templates/archive`
+below:
+
+```bash
+# ^2.0.0 here is the RI's Cicero major — use ^0.25.0 on a checkout pinning
+# cicero-core 0.25.x, and so on.
+mkdir -p retarget && cd retarget && unzip -oq ../latedeliveryandpenalty.cta
+jq '.accordproject.cicero = "^2.0.0"' package.json > package.tmp && mv package.tmp package.json
+zip -qr ../latedeliveryandpenalty-retargeted.cta . && cd ..
+```
+
+Retargeting only rewrites the declared range — it does not make an incompatible
+template work, so run a `convert` afterwards to confirm the template still
+drafts.
+
+### Deploying an archive explicitly
+
+`POST /templates/archive` takes a `.cta` verbatim and explodes it into a
+template row, without an agreement being involved. Reach for it when the quick
+path above does not fit:
+
+- the archive is one you built locally, or edited (a retargeted range, a custom
+  clause) and never published
+- the RI has no network egress, or the archive lives somewhere it cannot reach
+- you want the template registered and listable before any agreement exists, and
+  a malformed or incompatible archive rejected up front — with a typed error —
+  rather than at first agreement
+
+The body is the raw archive, not JSON:
+
+```bash
+curl --request POST \
+  --url http://localhost:9000/templates/archive \
+  --header 'Content-Type: application/octet-stream' \
+  --data-binary @latedeliveryandpenalty-retargeted.cta
+```
+
+Response (`201`, abridged — the model, text and logic of the archive are stored
+in full). `hash` is the archive's content hash and `metadata` is its
+`package.json.accordproject` block, so both follow the exact bytes uploaded:
 
 ```json
 {
-	"uri": "apap://agreement-ldp-remote",
-	"template": "https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta",
+	"id": 1,
+	"uri": "ap://latedeliveryandpenalty@1.0.0#e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
+	"hash": "e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
+	"author": "Accord Project",
+	"displayName": "Late Delivery and Penalty",
+	"version": "1.0.0",
+	"description": "A sample Late Delivery And Penalty clause.",
+	"license": "Apache-2.0",
+	"metadata": {
+		"template": "clause",
+		"runtime": "typescript",
+		"cicero": "^2.0.0"
+	},
+	"templateModel": { "model": { "$class": "org.accordproject.protocol@1.0.0.CtoModel", "ctoFiles": [ "..." ] } },
+	"text": { "templateText": "## Late Delivery and Penalty.\n\nIn case of delayed delivery{{#if forceMajeure}} except for Force Majeure cases,{{/if}}\n..." },
+	"logic": { "codes": [ "..." ] }
+}
+```
+
+Note the assigned `uri`: `ap://<name>@<version>#<hash>` — the Accord Project
+template URI syntax, the same form the
+[template library index](https://templates.accordproject.org/template-library.json)
+publishes. Name and version come from the archive's own `package.json`, and the
+fragment is its content hash, so the URI identifies those exact bytes.
+
+An agreement then references that URI as its `template`, in place of the URL
+used in the quick start — everything else about the agreement is unchanged:
+
+```json
+{
+	"uri": "apap://agreement-ldp-uploaded",
+	"template": "ap://latedeliveryandpenalty@1.0.0#e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712",
 	"agreementStatus": "DRAFT",
 	"data": { "...": "as above" }
 }
 ```
 
-Deploying the archive explicitly is still worth doing when you want the template
-available (and listable at `GET /templates`) before any agreement exists, when
-the archive is not reachable over HTTP from the server, or when you want the
-upload rejected up front rather than at first agreement.
+It has to match character for character, so copy the `uri` out of the upload
+response — the hash above is illustrative and will not match yours.
+
+Uploads are deduplicated on the archive's content hash, so re-posting the same
+`.cta` returns the existing row (still `201`) rather than creating a duplicate —
+re-running the command is safe.
+
+Errors:
+
+| Status | `error.code`                       | Cause                                                      |
+| ------ | ---------------------------------- | ---------------------------------------------------------- |
+| `400`  | `INVALID_PAYLOAD`                  | Empty body, or bytes that are not a readable `.cta` archive |
+| `422`  | `TEMPLATE_CICERO_VERSION_MISMATCH` | The archive targets a Cicero version this server does not run |
+
+```json
+{
+	"error": {
+		"code": "TEMPLATE_CICERO_VERSION_MISMATCH",
+		"message": "Template requires Cicero ^1.0.0, server supports 2.1.1",
+		"details": {
+			"declaredRange": "^1.0.0",
+			"serverVersion": "2.1.1"
+		}
+	}
+}
+```
+
+`serverVersion` is whatever `@accordproject/cicero-core` version this RI pins,
+so the exact numbers depend on the checkout.
 
 ## Creating a Template
 

--- a/server/handlers/templatebuilder.test.ts
+++ b/server/handlers/templatebuilder.test.ts
@@ -76,9 +76,15 @@ describe('Template Builder - extractTemplateForDatabase', () => {
 // outside that set, so an unsanitized name made convert/trigger fail with
 // "template name can only contain lowercase alphanumerics, _ or -".
 describe('Template Builder - templateNameFromUri', () => {
-    it('strips the scheme and version from an archive URI', () => {
+    it('takes the name out of an ap:// URI, ignoring the hash fragment', () => {
         // The URI POST /templates/archive assigns.
-        expect(templateNameFromUri('archive:latedeliveryandpenalty@1.0.0'))
+        expect(templateNameFromUri('ap://latedeliveryandpenalty@1.0.1#e29682ed71694106c8d22d4e66b895af55a3e6e2823197c4f6251d2e294dc712'))
+            .toBe('latedeliveryandpenalty');
+    });
+
+    it('falls back to generic parsing for an ap:// URI missing its hash', () => {
+        // TemplateLibrary.parseURI rejects these, so the generic path handles it.
+        expect(templateNameFromUri('ap://latedeliveryandpenalty@1.0.1'))
             .toBe('latedeliveryandpenalty');
     });
 
@@ -94,11 +100,11 @@ describe('Template Builder - templateNameFromUri', () => {
     });
 
     it('lowercases and replaces characters cicero rejects', () => {
-        expect(templateNameFromUri('archive:My Template!@2.0.0')).toBe('my-template');
+        expect(templateNameFromUri('ap://My Template!@2.0.0')).toBe('my-template');
     });
 
     it('falls back to a default name when the URI yields nothing usable', () => {
         expect(templateNameFromUri('')).toBe('dynamic-template');
-        expect(templateNameFromUri('archive:@1.0.0')).toBe('dynamic-template');
+        expect(templateNameFromUri('ap://@1.0.0')).toBe('dynamic-template');
     });
 });

--- a/server/handlers/templatebuilder.test.ts
+++ b/server/handlers/templatebuilder.test.ts
@@ -1,4 +1,4 @@
-import { extractTemplateForDatabase } from './templatebuilder';
+import { extractTemplateForDatabase, templateNameFromUri } from './templatebuilder';
 
 describe('Template Builder - extractTemplateForDatabase', () => {
     it('should perfectly extract ALL attributes from a template instance including logo and metadata', () => {
@@ -67,5 +67,38 @@ describe('Template Builder - extractTemplateForDatabase', () => {
         expect(result.logic.codes).toHaveLength(1);
         expect(result.logic.codes[0].id).toBe('logic/main.ts');
         expect(result.logic.codes[0].value).toContain('function execute()');
+    });
+});
+
+// cicero-core validates `package.json.name` against `[a-z0-9_-]` when
+// `templateFromDatabase` feeds the reconstructed archive back through
+// `Template.fromArchive`. Every URI shape the RI stores carries characters
+// outside that set, so an unsanitized name made convert/trigger fail with
+// "template name can only contain lowercase alphanumerics, _ or -".
+describe('Template Builder - templateNameFromUri', () => {
+    it('strips the scheme and version from an archive URI', () => {
+        // The URI POST /templates/archive assigns.
+        expect(templateNameFromUri('archive:latedeliveryandpenalty@1.0.0'))
+            .toBe('latedeliveryandpenalty');
+    });
+
+    it('strips the .cta extension and version from a remote archive URL', () => {
+        // The URI POST /agreements assigns when it fetches a remote template.
+        expect(templateNameFromUri('https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta'))
+            .toBe('latedeliveryandpenalty');
+    });
+
+    it('uses the fragment of a resource URI', () => {
+        expect(templateNameFromUri('resource:org.accordproject.protocol@1.0.0.Template#dan2'))
+            .toBe('dan2');
+    });
+
+    it('lowercases and replaces characters cicero rejects', () => {
+        expect(templateNameFromUri('archive:My Template!@2.0.0')).toBe('my-template');
+    });
+
+    it('falls back to a default name when the URI yields nothing usable', () => {
+        expect(templateNameFromUri('')).toBe('dynamic-template');
+        expect(templateNameFromUri('archive:@1.0.0')).toBe('dynamic-template');
     });
 });

--- a/server/handlers/templatebuilder.ts
+++ b/server/handlers/templatebuilder.ts
@@ -1,4 +1,4 @@
-import { Template as ApTemplate } from '@accordproject/cicero-core';
+import { Template as ApTemplate, TemplateLibrary } from '@accordproject/cicero-core';
 import AdmZip from "adm-zip";
 import { Template } from '../db/schema';
 
@@ -33,8 +33,9 @@ interface ApTemplateInstance {
  *
  * cicero-core only accepts `[a-z0-9_-]` in `package.json.name`, so the raw last
  * segment of a URI cannot be used as-is: every URI shape the RI stores carries
- * characters cicero rejects — `archive:latedeliveryandpenalty@1.0.0` (the URI
- * `POST /templates/archive` assigns) keeps its scheme and `@version`, and
+ * characters cicero rejects — `ap://latedeliveryandpenalty@1.0.1#<hash>` (the
+ * URI `POST /templates/archive` assigns) keeps its scheme, `@version` and hash
+ * fragment, and
  * `https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta`
  * (the URI `POST /agreements` assigns when it fetches a remote archive) keeps
  * `@1.0.0` after the `.cta` is stripped. Feeding either back through
@@ -50,6 +51,21 @@ export function templateNameFromUri(uri: string): string {
         return fallback;
     }
 
+    const sanitize = (value: string) =>
+        value.toLowerCase().replace(/[^a-z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
+
+    // An `ap://` URI's fragment is the archive's content hash, not its name, so
+    // it is the one shape where the fragment must be ignored. Let cicero parse
+    // it rather than second-guessing the syntax it defines.
+    if (TemplateLibrary.acceptsURI(uri)) {
+        try {
+            const { templateName } = TemplateLibrary.parseURI(uri) as { templateName: string };
+            return sanitize(templateName) || fallback;
+        } catch (err) {
+            // Malformed `ap://` URI — fall through to the generic handling.
+        }
+    }
+
     // `resource:...#name` identifies the template after the fragment; every
     // other shape puts it in the last path segment.
     let name = uri.includes('#')
@@ -61,9 +77,8 @@ export function templateNameFromUri(uri: string): string {
     // Drop a trailing `@version`, keeping npm-style scopes (`@scope/name` has
     // already lost its scope to the path split above).
     name = name.replace(/@[^@]*$/, '');
-    name = name.toLowerCase().replace(/[^a-z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
 
-    return name || fallback;
+    return sanitize(name) || fallback;
 }
 
 /**

--- a/server/handlers/templatebuilder.ts
+++ b/server/handlers/templatebuilder.ts
@@ -29,6 +29,44 @@ interface ApTemplateInstance {
 }
 
 /**
+ * Derives a Cicero-legal template package name from a stored template URI.
+ *
+ * cicero-core only accepts `[a-z0-9_-]` in `package.json.name`, so the raw last
+ * segment of a URI cannot be used as-is: every URI shape the RI stores carries
+ * characters cicero rejects — `archive:latedeliveryandpenalty@1.0.0` (the URI
+ * `POST /templates/archive` assigns) keeps its scheme and `@version`, and
+ * `https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta`
+ * (the URI `POST /agreements` assigns when it fetches a remote archive) keeps
+ * `@1.0.0` after the `.cta` is stripped. Feeding either back through
+ * `Template.fromArchive` threw `template name can only contain lowercase
+ * alphanumerics, _ or -`, which broke every convert/trigger call on such a row.
+ *
+ * @param uri - The template row's URI
+ * @returns A name safe to write into the reconstructed archive's package.json
+ */
+export function templateNameFromUri(uri: string): string {
+    const fallback = 'dynamic-template';
+    if (!uri) {
+        return fallback;
+    }
+
+    // `resource:...#name` identifies the template after the fragment; every
+    // other shape puts it in the last path segment.
+    let name = uri.includes('#')
+        ? uri.split('#').pop() || ''
+        : uri.split('/').pop() || '';
+
+    name = name.replace(/\.cta$/i, '');
+    name = name.replace(/^[a-z][a-z0-9+.\-]*:/i, '');
+    // Drop a trailing `@version`, keeping npm-style scopes (`@scope/name` has
+    // already lost its scope to the path split above).
+    name = name.replace(/@[^@]*$/, '');
+    name = name.toLowerCase().replace(/[^a-z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
+
+    return name || fallback;
+}
+
+/**
  * Reconstructs a Cicero Template instance from a database template record by creating
  * an in-memory zip archive containing the template's package.json, grammar, models, and logic.
  * 
@@ -42,14 +80,8 @@ interface ApTemplateInstance {
 export async function templateFromDatabase(db: typeof Template | any): Promise<ApTemplate> {
     const zip = new AdmZip();
     
-    let templateName = 'dynamic-template';
     const uriString = db.uri ? db.uri.toString() : '';
-    
-    if (uriString.includes('#')) {
-        templateName = uriString.split('#').pop() || templateName;
-    } else {
-        templateName = uriString.split('/').pop()?.replace('.cta', '') || templateName;
-    }
+    const templateName = templateNameFromUri(uriString);
 
     const packageJson = {
         name: templateName,

--- a/server/handlers/templates.test.ts
+++ b/server/handlers/templates.test.ts
@@ -169,7 +169,7 @@ describe('POST /templates/archive', () => {
     });
 
     it('creates a template from a valid archive and returns 201', async () => {
-        const createdTemplate = { id: 1, uri: 'archive:foo@1.0.0', hash: 'abc' };
+        const createdTemplate = { id: 1, uri: 'ap://foo@1.0.0#abc', hash: 'abc' };
         (mockedTemplateService.createTemplateFromArchive as any).mockResolvedValueOnce(createdTemplate);
 
         const res = await request(app)

--- a/server/services/templateService.test.ts
+++ b/server/services/templateService.test.ts
@@ -274,7 +274,8 @@ describe('templateService', () => {
 
             expect(db.insert).toHaveBeenCalled();
             expect(result.hash).toBeTruthy();
-            expect(result.uri).toMatch(/^archive:latedeliveryandpenalty-typescript@/);
+            // Accord Project template URI: ap://<name>@<version>#<content hash>
+            expect(result.uri).toMatch(/^ap:\/\/latedeliveryandpenalty-typescript@0\.0\.1#[0-9a-f]{64}$/);
             expect(result.metadata).toMatchObject({ cicero: '^0.25.0' });
         });
 

--- a/server/services/templateService.ts
+++ b/server/services/templateService.ts
@@ -141,7 +141,11 @@ export async function createTemplateFromArchive(
         return existing[0];
     }
 
-    const uri = `archive:${packageJson.name}@${packageJson.version}`;
+    // Accord Project template URI syntax — `ap://<name>@<version>#<hash>`, the
+    // same form the template library index publishes and `TemplateLibrary`
+    // parses. The fragment is the archive's content hash, so the URI a client
+    // gets back identifies these exact bytes.
+    const uri = `ap://${packageJson.name}@${packageJson.version}#${hash}`;
     const data = extractTemplateForDatabase(apTemplate, uri, hash) as TemplateInsert;
     try {
         return await createTemplate(db, data);


### PR DESCRIPTION
## Summary

Follows #237 (now merged) — documents getting a template into a cold-started RI, switches the URI `POST /templates/archive` assigns to Accord Project's `ap://` syntax, and fixes a bug that made both paths fail at convert/trigger time. Rebased onto `main` and retargeted now that #237 has landed.

A fresh RI has an empty database, and the only documented way to load a template was to hand-write the `POST /templates` body with an escaped Concerto model and template text inline.

- **`server/README.md`** — new "Using a Template from templates.accordproject.org" section, in two parts:
  - **Quick start** — point an agreement straight at a hosted `.cta`. `POST /agreements` resolves an `http(s)` template URI through `HttpTemplateRetriever`, so one request produces a draftable agreement and the `/templates` resource never enters the picture. Then `convert/html`.
  - **Deploying an archive explicitly** — `POST /templates/archive`, framed for what it is actually good for: archives you built or edited locally, servers without network egress, and registering a template (with an up-front typed rejection) before any agreement exists.
  - **Cicero version compatibility**, shared by both: how to read an archive's declared range, and what a mismatch looks like on each route — a plain `500` out of `POST /agreements` carrying cicero's own message, vs. the typed `422` out of `POST /templates/archive`. Deliberately says nothing about what the template library currently publishes, so it does not go stale when the library republishes.
- **`README.md`** — Quick Start now drafts an agreement from a hosted archive, and links on for the upload path.
- **`server/services/templateService.ts`** — assign `ap://` URIs instead of a bespoke `archive:` scheme.
- **`server/handlers/templatebuilder.ts`** — new `templateNameFromUri` helper (+ unit tests).

## `ap://` template URIs

`createTemplateFromArchive` minted its own `archive:<name>@<version>`. Accord Project already has a URI syntax for exactly this — `ap://<name>@<version>#<hash>` — which the [template library index](https://templates.accordproject.org/template-library.json) publishes and cicero-core's `TemplateLibrary.parseURI` accepts, so uploads now get that instead. The fragment is the archive's content hash, so the URI handed back identifies those exact bytes.

## The templatebuilder fix

`templateFromDatabase` derived the reconstructed archive's `package.json.name` from the row's URI verbatim. cicero-core only accepts `[a-z0-9_-]` there, and neither URI the RI stores survives that:

- `https://templates.accordproject.org/archives/latedeliveryandpenalty@1.0.0.cta` — what the quick-start path stores — keeps `@1.0.0` once `.cta` is stripped
- `ap://latedeliveryandpenalty@1.0.1#<hash>` — what the upload path assigns — keeps its scheme, `@version` and hash fragment

Both threw `template name can only contain lowercase alphanumerics, _ or -` out of `Template.fromArchive`, so `GET /agreements/:id/convert/:format` and `POST /agreements/:id/trigger` failed for every such row. The first case is pre-existing on `main` and is exactly the quick-start path this PR documents; the second means a template deployed via `POST /templates/archive` could never be drafted. The name is now derived through `templateNameFromUri`, which parses `ap://` URIs with `TemplateLibrary.parseURI` (their fragment is the hash, not the name) and otherwise drops the scheme, the `.cta` extension and any `@version` before sanitizing.

## Validation

Validated end to end against `latedeliveryandpenalty` as it stands in [cicero-template-library#526](https://github.com/accordproject/cicero-template-library/pull/526) ("Apply Cicero v2 dependency upgrade to active templates"), built from that PR's source and run through the same code path the RI uses (`Template.fromArchive` → `extractTemplateForDatabase` → `templateFromDatabase` → `TemplateArchiveProcessor`), against the cicero-core `2.1.1` this repo pins:

- accepted with no version error — it declares `"cicero": "^2.0.0"` at version `1.0.1`
- stored as `ap://latedeliveryandpenalty@1.0.1#<hash>`, and rebuilding from that row succeeds — this is what the `templateNameFromUri` fix unblocks; without it both URI shapes throw
- `draft` returns the markdown and HTML shown in the README
- `trigger` returns a `LateDeliveryAndPenaltyResponse` (`MonetaryAmount` penalty, `buyerMayTerminate`) plus a `PaymentObligationEvent`

Two things reviewers may want to know, kept out of the README on purpose since both are about the library's current state rather than this repo's behaviour: the archives published on templates.accordproject.org today declare `"cicero": "^1.0.0"` and so are rejected by the RI's cicero-core 2.x until #526 lands and they are republished, and the published `1.0.0` archive additionally cannot be triggered because its `logic/logic.ts` imports generated classes from `./generated/...` as values while the archive stores them flat under `logic/` (#526 makes those imports type-only, which fixes it). Both were re-checked against the live library at the time of the rebase and still hold.

## Test plan

- [x] `npm test` in `server/` — 11 suites / 267 tests pass on the rebase (6 new `templateNameFromUri` cases; `templateService`/`templates` archive tests updated for the `ap://` URI)
- [x] `npx tsc -p .` — clean
- [x] End-to-end validation described above, re-run after the rebase against `main`'s dependency set