### PR TITLE
fix(tests): bump cicero fixture assertion to ^2.0.0 for cicero-core 2.x upgrade

### DIFF
--- a/server/services/templateService.test.ts
+++ b/server/services/templateService.test.ts
@@ -275,7 +275,7 @@ describe('templateService', () => {
             expect(db.insert).toHaveBeenCalled();
             expect(result.hash).toBeTruthy();
             expect(result.uri).toMatch(/^archive:latedeliveryandpenalty-typescript@/);
-            expect(result.metadata).toMatchObject({ cicero: '^0.25.0' });
+            expect(result.metadata).toMatchObject({ cicero: '^2.0.0' });
         });
 
         it('returns the existing row without inserting when the hash already exists', async () => {


### PR DESCRIPTION
## What

One-line assertion bump in `server/services/templateService.test.ts:278`.

```diff
-expect(result.metadata).toMatchObject({ cicero: '^0.25.0' });
+expect(result.metadata).toMatchObject({ cicero: '^2.0.0' });
```

## Why

Main went red immediately after **#237** merged on top of **#236**.

**#237** added `POST /templates/archive` with a test asserting the parsed archive's `metadata.cicero` equals `^0.25.0`. **#237** was branched before **#236** (cicero-core 2.x upgrade) landed, so:

- CI on the **#237** PR ran against a pre-**#236** base and passed, since the fixture's `package.json.accordproject.cicero` was still `^0.25.0` at that time.
- **#236** bumped the fixture's declared cicero range to `^2.0.0` alongside the cicero-core 2.x upgrade.
- When **#237** merged at `41ec0ce`, the test now runs against the `^2.0.0` fixture and asserts `^0.25.0`, mismatch.

Received value on current main is `^2.0.0`, so the fix updates the assertion literal to match.

## Scope

- No production code change. Test-only.
- Only `services/templateService.test.ts` is affected. `handlers/templatebuilder.test.ts` uses mocked cicero and legitimately keeps its `^0.25.0` literal.
- Verified locally: `npm test -- services/templateService.test.ts handlers/templates.test.ts handlers/templatebuilder.test.ts` -> **34 passed / 0 failed**.

## Follow-up thought

Consider whether the fixture's cicero range should be treated as a runtime value rather than an assertion literal, so a future cicero-core bump does not require a matching test edit. Out of scope for this hotfix.

## Attribution

Original template test authored by @mttrbrts in **#237**. This PR just realigns the assertion literal with the fixture on main.

Signed-off-by: Jay Guwalani <guwalanijj@gmail.com>