### PR TITLE
feat(mcp): paged resource URIs for apap://templates and apap://agreements (closes #217)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,10 @@ jobs:
               END IF;
           END $$;
 
+          -- Return to the postgres superuser role before DROP: `rls_tester`
+          -- only has GRANT SELECT (not ownership) so a DROP as that role
+          -- fails with "must be owner of table _rls_smoke".
+          RESET ROLE;
           DROP TABLE _rls_smoke;
           SQL
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,10 +110,18 @@ jobs:
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 <<'SQL'
           CREATE TABLE _rls_smoke (id int PRIMARY KEY, owner text NOT NULL);
           ALTER TABLE _rls_smoke ENABLE ROW LEVEL SECURITY;
-          ALTER TABLE _rls_smoke FORCE ROW LEVEL SECURITY;
           CREATE POLICY p_owner ON _rls_smoke
               USING (owner = current_setting('app.user_id', true));
           INSERT INTO _rls_smoke VALUES (1, 'alice'), (2, 'bob');
+
+          -- Superusers bypass RLS regardless of FORCE ROW LEVEL SECURITY, and
+          -- the CI service runs as `postgres` (SUPERUSER). Demote to a fresh
+          -- NOSUPERUSER NOBYPASSRLS role for the assertions so the policy
+          -- actually applies. GRANT SELECT so the role can read the throwaway
+          -- table.
+          CREATE ROLE rls_tester NOSUPERUSER NOBYPASSRLS;
+          GRANT SELECT ON _rls_smoke TO rls_tester;
+          SET ROLE rls_tester;
 
           SELECT set_config('app.user_id', 'alice', false);
           DO $$

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,62 @@ jobs:
           POSTGRES_URL: postgres://postgres:1baddeed@localhost:5432/postgres
         run: npx drizzle-kit push --config drizzle.config.ts
 
+      # Follow-up to Niall's #231 review: "postgres-18-smoke only applies the
+      # schema, not that RLS still isolates rows on 18." APAP itself does not
+      # yet enable ROW LEVEL SECURITY on any table (the auth chain in
+      # handlers/crud.ts is still commented pending the A2A + MCP auth PRs),
+      # so this step verifies that the *PG18 RLS feature itself* has not
+      # regressed by running a self-contained isolation test against a
+      # throwaway table. If PG18 ever ships a change that breaks RLS
+      # row-visibility semantics, this step catches it before APAP's own
+      # tables start using RLS.
+      - name: Verify PG18 RLS isolation semantics with a synthetic policy
+        env:
+          PGPASSWORD: 1baddeed
+        shell: bash
+        run: |
+          set -euo pipefail
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE TABLE _rls_smoke (id int PRIMARY KEY, owner text NOT NULL);
+          ALTER TABLE _rls_smoke ENABLE ROW LEVEL SECURITY;
+          ALTER TABLE _rls_smoke FORCE ROW LEVEL SECURITY;
+          CREATE POLICY p_owner ON _rls_smoke
+              USING (owner = current_setting('app.user_id', true));
+          INSERT INTO _rls_smoke VALUES (1, 'alice'), (2, 'bob');
+
+          SELECT set_config('app.user_id', 'alice', false);
+          DO $$
+          DECLARE cnt int;
+          BEGIN
+              SELECT count(*) INTO cnt FROM _rls_smoke;
+              IF cnt <> 1 THEN
+                  RAISE EXCEPTION 'RLS regression: alice saw % rows, expected 1', cnt;
+              END IF;
+          END $$;
+
+          SELECT set_config('app.user_id', 'bob', false);
+          DO $$
+          DECLARE cnt int;
+          BEGIN
+              SELECT count(*) INTO cnt FROM _rls_smoke;
+              IF cnt <> 1 THEN
+                  RAISE EXCEPTION 'RLS regression: bob saw % rows, expected 1', cnt;
+              END IF;
+          END $$;
+
+          SELECT set_config('app.user_id', 'nobody', false);
+          DO $$
+          DECLARE cnt int;
+          BEGIN
+              SELECT count(*) INTO cnt FROM _rls_smoke;
+              IF cnt <> 0 THEN
+                  RAISE EXCEPTION 'RLS regression: unknown principal saw % rows, expected 0', cnt;
+              END IF;
+          END $$;
+
+          DROP TABLE _rls_smoke;
+          SQL
+
   publish:
     needs:
       - build

--- a/server/handlers/mcp.test.ts
+++ b/server/handlers/mcp.test.ts
@@ -46,6 +46,7 @@ function createMockDb() {
         select: jest.fn().mockReturnThis(),
         from: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
         offset: jest.fn().mockReturnThis(),
         insert: jest.fn().mockReturnThis(),

--- a/server/handlers/mcp.test.ts
+++ b/server/handlers/mcp.test.ts
@@ -371,9 +371,17 @@ describe('pageOpts parser for paged resource URIs', () => {
     });
 
     it('returns undefined for non-numeric garbage instead of NaN', () => {
-        // Anything that fails parseInt (or fails Number.isFinite after) drops
-        // to the service default rather than propagating NaN into the query.
         expect(pageOpts({ limit: 'abc', offset: 'xyz' })).toEqual({ limit: undefined, offset: undefined });
+    });
+
+    it('rejects parseInt-friendly garbage that would silently truncate', () => {
+        // Strict-integer regex catches values that `parseInt(v, 10)` would
+        // silently truncate to a plausible-looking integer. These should hit
+        // the service default rather than accept a partial parse.
+        expect(pageOpts({ limit: '50abc' })).toEqual({ limit: undefined, offset: undefined });
+        expect(pageOpts({ limit: '50.5' })).toEqual({ limit: undefined, offset: undefined });
+        expect(pageOpts({ limit: '1e2' })).toEqual({ limit: undefined, offset: undefined });
+        expect(pageOpts({ offset: ' 50 ' })).toEqual({ limit: undefined, offset: 50 });
     });
 
     it('passes through out-of-range values so the service layer clamps them', () => {
@@ -571,6 +579,15 @@ describe('MCP Handler', () => {
                 expect(result.contents).toHaveLength(1);
                 expect((result.contents[0] as any).uri).toBe('apap://templates/1');
             });
+
+            // Cache-hint inheritance from #201 is verified by code reading:
+            // both paged callbacks route through the shared `getTemplates` /
+            // `getAgreements` functions (mcp.ts:325, mcp.ts:333) that spread
+            // `...CACHE_HINTS.templateList` / `.agreementList` (mcp.ts:227,
+            // mcp.ts:258) into each content entry. Adding a runtime assertion
+            // here fails today because the SDK's `ReadResourceResult` schema
+            // strips top-level non-standard fields (pre-existing #199/#201
+            // shape issue, out of scope for #217).
 
             it('apap://templates?limit=1000 clamps to 100 via the service', async () => {
                 // pageOpts passes 1000 through; the service clamps to 100.

--- a/server/handlers/mcp.test.ts
+++ b/server/handlers/mcp.test.ts
@@ -581,6 +581,26 @@ describe('MCP Handler', () => {
                 expect((result.contents[0] as any).uri).toBe('apap://templates/1');
             });
 
+            // Regression guard for the stable-ordering fix Niall asked for in
+            // his #243 review: if someone deletes `.orderBy(asc(Template.id))`
+            // from `listTemplates` (or `.orderBy(asc(Agreement.id))` from
+            // `listAgreements`), paged reads silently return unstable rows
+            // between pages. This asserts the fluent chain saw `orderBy()` at
+            // all; the specific column argument is owned by the service test
+            // that pins the SQL construction. Same guard for templates and
+            // agreements since both share the drop-risk.
+            it('apap://templates paged read invokes .orderBy on the fluent chain (stable-order guard)', async () => {
+                mockDb._setReturn([templateRow]);
+                await client.readResource({ uri: 'apap://templates?limit=50&offset=100' });
+                expect(mockDb.orderBy).toHaveBeenCalled();
+            });
+
+            it('apap://agreements paged read invokes .orderBy on the fluent chain (stable-order guard)', async () => {
+                mockDb._setReturn([agreementRow]);
+                await client.readResource({ uri: 'apap://agreements?limit=50&offset=100' });
+                expect(mockDb.orderBy).toHaveBeenCalled();
+            });
+
             // Cache-hint inheritance from #201 is verified by code reading:
             // both paged callbacks route through the shared `getTemplates` /
             // `getAgreements` functions (mcp.ts:325, mcp.ts:333) that spread

--- a/server/handlers/mcp.test.ts
+++ b/server/handlers/mcp.test.ts
@@ -26,6 +26,7 @@ import mcpRouter, {
     serviceErrorToCallToolResult,
     serviceErrorToResourceError,
     buildApiErrorMessage,
+    pageOpts,
     PROTOCOL_CTO,
     SERVER_INSTRUCTIONS,
     CACHE_HINTS,
@@ -349,6 +350,46 @@ describe('SEP-2549 cache hints exposed by the MCP handler', () => {
     });
 });
 
+// Paged MCP resource URIs (#217): `apap://templates{?limit,offset}` and
+// `apap://agreements{?limit,offset}`. `pageOpts` is the pure parser that
+// converts RFC 6570 form-style variables into safe integers for the service
+// layer. The service-layer clamp ([1, 100]) is already covered by
+// services/templateService.test.ts and services/agreementService.test.ts;
+// these tests only pin the callback-plumbing shape and the parser boundaries.
+describe('pageOpts parser for paged resource URIs', () => {
+    it('parses numeric limit and offset strings', () => {
+        expect(pageOpts({ limit: '50', offset: '100' })).toEqual({ limit: 50, offset: 100 });
+    });
+
+    it('returns undefined for absent variables so the service default applies', () => {
+        expect(pageOpts({})).toEqual({ limit: undefined, offset: undefined });
+        expect(pageOpts(undefined)).toEqual({ limit: undefined, offset: undefined });
+    });
+
+    it('returns undefined for empty-string variables (?limit=&offset=)', () => {
+        expect(pageOpts({ limit: '', offset: '' })).toEqual({ limit: undefined, offset: undefined });
+    });
+
+    it('returns undefined for non-numeric garbage instead of NaN', () => {
+        // Anything that fails parseInt (or fails Number.isFinite after) drops
+        // to the service default rather than propagating NaN into the query.
+        expect(pageOpts({ limit: 'abc', offset: 'xyz' })).toEqual({ limit: undefined, offset: undefined });
+    });
+
+    it('passes through out-of-range values so the service layer clamps them', () => {
+        // No double-clamp here. Service-layer test coverage owns the [1, 100] cap.
+        expect(pageOpts({ limit: '1000', offset: '-5' })).toEqual({ limit: 1000, offset: -5 });
+        expect(pageOpts({ limit: '0' })).toEqual({ limit: 0, offset: undefined });
+    });
+
+    it('picks the first element when a variable is exploded into an array', () => {
+        // RFC 6570 exploded form (`{?limit*}`) would surface as an array. We
+        // aren't registering exploded params, but the callback signature admits
+        // string | string[], so cover the branch defensively.
+        expect(pageOpts({ limit: ['50', '75'] })).toEqual({ limit: 50, offset: undefined });
+    });
+});
+
 describe('MCP Handler', () => {
     let app: express.Application;
     let mockDb: ReturnType<typeof createMockDb>;
@@ -501,6 +542,106 @@ describe('MCP Handler', () => {
 
             const content = result.content as any[];
             expect(content[0].type).toBe('text');
+        });
+
+        // =====================================================================
+        // Paged resource URIs — apap://templates{?limit,offset} (#217)
+        // =====================================================================
+        //
+        // These tests pin the SDK dispatch shape: an exact-string static URI
+        // hits the bare-URI callback (backwards compat with clients that don't
+        // know about the paging surface); a URI with both `?limit=X&offset=Y`
+        // hits the ResourceTemplate callback with the values threaded through
+        // to the service.
+        //
+        // Service-layer clamping ([1, 100]) is verified in the service test
+        // files; here we only verify what the mockDb chain was asked for, so
+        // the assertion is `db.limit` / `db.offset` were called with the right
+        // integers.
+        describe('paged resource URIs (#217)', () => {
+            const templateRow = { id: 1, uri: 'test://template/1', author: 'A' };
+            const agreementRow = { id: 2, uri: 'test://agreement/2', data: { foo: 'bar' } };
+
+            it('apap://templates?limit=50&offset=100 threads paging into the service', async () => {
+                mockDb._setReturn([templateRow]);
+                const result = await client.readResource({ uri: 'apap://templates?limit=50&offset=100' });
+
+                expect(mockDb.limit).toHaveBeenCalledWith(50);
+                expect(mockDb.offset).toHaveBeenCalledWith(100);
+                expect(result.contents).toHaveLength(1);
+                expect((result.contents[0] as any).uri).toBe('apap://templates/1');
+            });
+
+            it('apap://templates?limit=1000 clamps to 100 via the service', async () => {
+                // pageOpts passes 1000 through; the service clamps to 100.
+                mockDb._setReturn([]);
+                await client.readResource({ uri: 'apap://templates?limit=1000&offset=0' });
+
+                expect(mockDb.limit).toHaveBeenCalledWith(100);
+                expect(mockDb.offset).toHaveBeenCalledWith(0);
+            });
+
+            it('apap://templates?limit=0 clamps to 1 via the service', async () => {
+                mockDb._setReturn([]);
+                await client.readResource({ uri: 'apap://templates?limit=0&offset=0' });
+
+                expect(mockDb.limit).toHaveBeenCalledWith(1);
+                expect(mockDb.offset).toHaveBeenCalledWith(0);
+            });
+
+            it('apap://templates (bare URI) still returns limit=100 offset=0 (backwards compat)', async () => {
+                mockDb._setReturn([templateRow]);
+                const result = await client.readResource({ uri: 'apap://templates' });
+
+                expect(mockDb.limit).toHaveBeenCalledWith(100);
+                expect(mockDb.offset).toHaveBeenCalledWith(0);
+                expect(result.contents).toHaveLength(1);
+            });
+
+            it('apap://agreements?limit=50&offset=100 threads paging into the service', async () => {
+                mockDb._setReturn([agreementRow]);
+                const result = await client.readResource({ uri: 'apap://agreements?limit=50&offset=100' });
+
+                expect(mockDb.limit).toHaveBeenCalledWith(50);
+                expect(mockDb.offset).toHaveBeenCalledWith(100);
+                expect(result.contents).toHaveLength(1);
+                expect((result.contents[0] as any).uri).toBe('apap://agreements/2');
+            });
+
+            it('apap://agreements (bare URI) still returns limit=100 offset=0 (backwards compat)', async () => {
+                mockDb._setReturn([agreementRow]);
+                const result = await client.readResource({ uri: 'apap://agreements' });
+
+                expect(mockDb.limit).toHaveBeenCalledWith(100);
+                expect(mockDb.offset).toHaveBeenCalledWith(0);
+                expect(result.contents).toHaveLength(1);
+            });
+
+            // Empty query-string values (`?limit=&offset=`): the SDK's
+            // UriTemplate regex requires `=([^&]+)` per param — non-empty is
+            // mandatory. So this URI matches NEITHER the static exact-URI
+            // resource nor the template, and the SDK raises
+            // ResourceNotFoundError. Pin the behavior so we notice if the SDK
+            // ever loosens it (in which case pageOpts' empty-string branch
+            // would take over and default to full-page).
+            it('apap://templates?limit=&offset= surfaces the SDK ResourceNotFoundError', async () => {
+                await expect(
+                    client.readResource({ uri: 'apap://templates?limit=&offset=' }),
+                ).rejects.toThrow(/apap:\/\/templates\?limit=&offset=/);
+            });
+
+            // Partial URI (offset param entirely absent, not empty). The SDK's
+            // UriTemplate regex for `{?limit,offset}` compiles both params as
+            // required and non-empty, so this URI matches NEITHER the static
+            // exact-URI resource nor the template — the SDK raises
+            // ResourceNotFoundError. Same failure shape as the empty-string
+            // case above; pinned separately because "param absent" and "param
+            // empty" are different SDK code paths.
+            it('apap://templates?limit=50 (partial URI, offset absent) surfaces ResourceNotFoundError', async () => {
+                await expect(
+                    client.readResource({ uri: 'apap://templates?limit=50' }),
+                ).rejects.toThrow(/apap:\/\/templates\?limit=50/);
+            });
         });
     });
 });

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -107,6 +107,20 @@ async function makeApiRequest(url: string, options: RequestInit = {}) {
     });
 }
 
+// Parses `{ limit, offset }` from RFC 6570 form-style template variables into
+// safe integers for the paged resource callbacks (#217). Non-numeric or absent
+// values become `undefined` so the service layer applies its own default (100 /
+// 0) and clamp ([1, 100]); no double-clamp here.
+export function pageOpts(variables: Record<string, string | string[]> | undefined): { limit?: number; offset?: number } {
+    const pick = (v: string | string[] | undefined): number | undefined => {
+        const raw = Array.isArray(v) ? v[0] : v;
+        if (raw === undefined || raw === '') return undefined;
+        const n = parseInt(raw, 10);
+        return Number.isFinite(n) ? n : undefined;
+    };
+    return { limit: pick(variables?.limit), offset: pick(variables?.offset) };
+}
+
 // Builds a meaningful error message from a failed API response so that MCP clients
 // can tell apart a 404 (resource missing) from a 400 (bad input) or a 500 (server issue).
 // Without this, every failure just says "Failed to load ..." which is impossible to debug.
@@ -196,9 +210,14 @@ async function getAgreement(db: Database, uri: string, variables: { agreementId:
 // Direct service call, no HTTP loop. This is the slice-1 payoff: a bug fix in
 // `templateService.listTemplates` now propagates to both the MCP resource
 // callback and any future REST caller without going through Express.
-async function getTemplates(db: Database, uri: URL) {
-    console.log({ type: 'get_templates_requested', uri: uri.toString() });
-    const templates = await listTemplates(db);
+//
+// Optional `opts` carries the paged-URI query variables (`{?limit,offset}`)
+// per RFC 6570 form-style expansion. The service clamps to [1, 100] internally
+// so we never double-clamp here; `undefined` values fall back to the same
+// full-page default the bare `apap://templates` URI uses (limit=100, offset=0).
+async function getTemplates(db: Database, uri: URL, opts: { limit?: number; offset?: number } = {}) {
+    console.log({ type: 'get_templates_requested', uri: uri.toString(), ...opts });
+    const templates = await listTemplates(db, opts);
     console.log({ type: 'fetched_templates_success', count: templates.length });
     return {
         contents: templates.map((t) => ({
@@ -216,9 +235,9 @@ async function getTemplates(db: Database, uri: URL) {
  * @details Loads the agreement collection from the local REST API and serializes
  * each item into the MCP resource format expected by agreement resources.
  */
-async function getAgreements(db: Database, uri: URL) {
-    console.log({ type: 'get_agreements_requested', uri: uri.toString() });
-    const agreements = await listAgreements(db);
+async function getAgreements(db: Database, uri: URL, opts: { limit?: number; offset?: number } = {}) {
+    console.log({ type: 'get_agreements_requested', uri: uri.toString(), ...opts });
+    const agreements = await listAgreements(db, opts);
     console.log({ type: 'fetched_agreements_success', count: agreements.length });
     return {
         // FIX for issue #128: The previous version spread the full agreement object
@@ -287,6 +306,31 @@ export const getServer = (db: Database) => {
         "apap://agreements",
         { mimeType: "application/json" },
         (uri: URL) => getAgreements(db, uri),
+    );
+
+    // Paged variants for #217: RFC 6570 form-style query expansion
+    // (`{?limit,offset}`). The SDK dispatcher (mcp.mjs `resources/read`) checks
+    // exact-string static resources first, then iterates registered templates
+    // and calls `UriTemplate.match(uri)`. Bare `apap://templates` still hits the
+    // static resource above; `apap://templates?limit=50&offset=100` hits the
+    // template below. Callback receives `{ limit, offset }` as string variables;
+    // service clamps to [1, 100] and defaults to full-page when a var is missing
+    // (SDK regex requires both params present + non-empty, so the `?? '100'`
+    // fallback here is defensive coverage for future SDK laxity).
+    server.registerResource(
+        'templates-page',
+        new ResourceTemplate('apap://templates{?limit,offset}', { list: undefined }),
+        { title: 'Templates (paged)', mimeType: 'application/json' },
+        (uri: URL, variables: Record<string, string | string[]>) =>
+            getTemplates(db, uri, pageOpts(variables)),
+    );
+
+    server.registerResource(
+        'agreements-page',
+        new ResourceTemplate('apap://agreements{?limit,offset}', { list: undefined }),
+        { title: 'Agreements (paged)', mimeType: 'application/json' },
+        (uri: URL, variables: Record<string, string | string[]>) =>
+            getAgreements(db, uri, pageOpts(variables)),
     );
 
     // register resource template for agreements

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -298,7 +298,13 @@ export const getServer = (db: Database) => {
         }),
     );
 
-    // register the templates
+    // register the templates. NOTE (#217 dispatch order): the SDK checks these
+    // exact-string static resources BEFORE iterating the `{?limit,offset}`
+    // templates registered below. Keep them registered; without them, a bare
+    // `apap://templates` read would fall through to the paged template's regex
+    // (which requires both params non-empty) and surface as
+    // ResourceNotFoundError, breaking backwards-compat for clients that page
+    // via the default full-page URI.
     server.registerResource(
         'templates',
         "apap://templates",
@@ -306,7 +312,7 @@ export const getServer = (db: Database) => {
         (uri: URL) => getTemplates(db, uri),
     );
 
-    // register the agreements
+    // register the agreements (see #217 dispatch-order note on templates above).
     server.registerResource(
         'agreements',
         "apap://agreements",

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -108,15 +108,21 @@ async function makeApiRequest(url: string, options: RequestInit = {}) {
 }
 
 // Parses `{ limit, offset }` from RFC 6570 form-style template variables into
-// safe integers for the paged resource callbacks (#217). Non-numeric or absent
-// values become `undefined` so the service layer applies its own default (100 /
-// 0) and clamp ([1, 100]); no double-clamp here.
+// safe integers for the paged resource callbacks (#217). Non-numeric, partial,
+// or absent values become `undefined` so the service layer applies its own
+// default (100 / 0) and clamp ([1, 100]); no double-clamp here.
+//
+// Strict-integer regex rejects `parseInt`-friendly garbage that would silently
+// truncate: '50abc' -> undefined (not 50), '50.5' -> undefined (not 50), '1e2'
+// -> undefined (not 100). Trailing whitespace is tolerated via `.trim()`.
 export function pageOpts(variables: Record<string, string | string[]> | undefined): { limit?: number; offset?: number } {
     const pick = (v: string | string[] | undefined): number | undefined => {
         const raw = Array.isArray(v) ? v[0] : v;
-        if (raw === undefined || raw === '') return undefined;
-        const n = parseInt(raw, 10);
-        return Number.isFinite(n) ? n : undefined;
+        if (raw === undefined) return undefined;
+        const trimmed = raw.trim();
+        if (trimmed === '' || !/^-?\d+$/.test(trimmed)) return undefined;
+        const n = Number(trimmed);
+        return Number.isSafeInteger(n) ? n : undefined;
     };
     return { limit: pick(variables?.limit), offset: pick(variables?.offset) };
 }

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -314,9 +314,13 @@ export const getServer = (db: Database) => {
     // and calls `UriTemplate.match(uri)`. Bare `apap://templates` still hits the
     // static resource above; `apap://templates?limit=50&offset=100` hits the
     // template below. Callback receives `{ limit, offset }` as string variables;
-    // service clamps to [1, 100] and defaults to full-page when a var is missing
-    // (SDK regex requires both params present + non-empty, so the `?? '100'`
-    // fallback here is defensive coverage for future SDK laxity).
+    // `pageOpts` coerces to safe integers or `undefined`, and the service layer
+    // applies its own default (100 / 0) and clamp ([1, 100]). Today the SDK's
+    // UriTemplate regex requires both params present + non-empty, so out-of-band
+    // URIs (`?limit=&offset=` or `?limit=50` alone) surface as
+    // ResourceNotFoundError before the callback ever runs (pinned in tests).
+    // `pageOpts` returning `undefined` for empty/absent values is defensive
+    // coverage for the day the SDK loosens that regex.
     server.registerResource(
         'templates-page',
         new ResourceTemplate('apap://templates{?limit,offset}', { list: undefined }),

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,12 +13,12 @@
         "@accordproject/cicero-core": "2.1.1",
         "@accordproject/concerto-core": "4.1.5",
         "@accordproject/concerto-util": "4.1.5",
-        "@accordproject/template-engine": "^4.0.0",
-        "@modelcontextprotocol/client": "^2.0.0",
-        "@modelcontextprotocol/core": "^2.0.0",
-        "@modelcontextprotocol/express": "^2.0.0",
-        "@modelcontextprotocol/node": "^2.0.0",
-        "@modelcontextprotocol/server": "^2.0.0",
+        "@accordproject/template-engine": "4.0.0",
+        "@modelcontextprotocol/client": "2.0.0",
+        "@modelcontextprotocol/core": "2.0.0",
+        "@modelcontextprotocol/express": "2.0.0",
+        "@modelcontextprotocol/node": "2.0.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "adm-zip": "0.6.0",
         "dotenv": "16.5.0",
         "drizzle-orm": "0.45.2",
@@ -29,8 +29,7 @@
         "openapi-backend": "5.12.0",
         "postgres": "3.4.5",
         "source-map-support": "0.5.10",
-        "undefined": "^0.1.0",
-        "zod": "^4.4.3"
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@types/adm-zip": "0.5.7",
@@ -10490,12 +10489,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undefined": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/undefined/-/undefined-0.1.0.tgz",
-      "integrity": "sha512-NkvZ+cpfGNrQvaCMPr2DytKuQfUTTUUloyqxhjLIzUm6OIBBgjH0zUIObsDejlvNHXBmXNCEt4IOFE6HB+ourA==",
-      "deprecated": "this package has been deprecated"
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",

--- a/server/package.json
+++ b/server/package.json
@@ -31,12 +31,12 @@
     "@accordproject/cicero-core": "2.1.1",
     "@accordproject/concerto-core": "4.1.5",
     "@accordproject/concerto-util": "4.1.5",
-    "@accordproject/template-engine": "^4.0.0",
-    "@modelcontextprotocol/client": "^2.0.0",
-    "@modelcontextprotocol/core": "^2.0.0",
-    "@modelcontextprotocol/express": "^2.0.0",
-    "@modelcontextprotocol/node": "^2.0.0",
-    "@modelcontextprotocol/server": "^2.0.0",
+    "@accordproject/template-engine": "4.0.0",
+    "@modelcontextprotocol/client": "2.0.0",
+    "@modelcontextprotocol/core": "2.0.0",
+    "@modelcontextprotocol/express": "2.0.0",
+    "@modelcontextprotocol/node": "2.0.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "adm-zip": "0.6.0",
     "dotenv": "16.5.0",
     "drizzle-orm": "0.45.2",
@@ -47,8 +47,7 @@
     "openapi-backend": "5.12.0",
     "postgres": "3.4.5",
     "source-map-support": "0.5.10",
-    "undefined": "^0.1.0",
-    "zod": "^4.4.3"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@types/adm-zip": "0.5.7",

--- a/server/services/agreementService.ts
+++ b/server/services/agreementService.ts
@@ -40,7 +40,13 @@ export async function listAgreements(
 ): Promise<AgreementRow[]> {
     const limit = Math.min(100, Math.max(1, opts.limit ?? 100));
     const offset = Math.max(0, opts.offset ?? 0);
-    return db.select().from(Agreement).limit(limit).offset(offset);
+    // Stable pagination: without an explicit order, Postgres is free to return
+    // rows in any order between the (limit=50, offset=0) and (limit=50,
+    // offset=50) requests the paged `apap://agreements{?limit,offset}` MCP
+    // resource issues, which can duplicate or skip rows. Mirrors the
+    // asc(Agreement.id) default #225 landed for `listAgreementsPaged` so REST
+    // and MCP page over the same stable order.
+    return db.select().from(Agreement).orderBy(asc(Agreement.id)).limit(limit).offset(offset);
 }
 
 /** Replaces: makeApiRequest(`${API_BASE_URL}/agreements/${id}`) */

--- a/server/services/templateService.ts
+++ b/server/services/templateService.ts
@@ -57,7 +57,13 @@ export async function listTemplates(
 ): Promise<TemplateRow[]> {
     const limit = Math.min(100, Math.max(1, opts.limit ?? 100));
     const offset = Math.max(0, opts.offset ?? 0);
-    return db.select().from(Template).limit(limit).offset(offset);
+    // Stable pagination: without an explicit order, Postgres is free to return
+    // rows in any order between the (limit=50, offset=0) and (limit=50,
+    // offset=50) requests the paged `apap://templates{?limit,offset}` MCP
+    // resource issues, which can duplicate or skip rows. Mirrors the
+    // asc(Template.id) default #225 landed for `listTemplatesPaged` so REST
+    // and MCP page over the same stable order.
+    return db.select().from(Template).orderBy(asc(Template.id)).limit(limit).offset(offset);
 }
 
 /** Replaces: makeApiRequest(`${API_BASE_URL}/templates/${id}`) */


### PR DESCRIPTION
## Summary

Adds paged resource URIs for the two large-collection MCP resources on APAP:

- `apap://templates{?limit,offset}`: paged read of templates
- `apap://agreements{?limit,offset}`: paged read of agreements

Bare `apap://templates` and `apap://agreements` keep working and return page 1 (limit=100, offset=0), so existing readers are unaffected. The paged forms are progressive enhancement for clients that construct query-param resource URIs.

Closes #217.

## Design authority

Wire shape ratified by @niallroche in [#217 comment](https://github.com/accordproject/apap/issues/217#issuecomment-5237352992) after the URI-vs-tool proposal thread. This is the "closing PR of slice 3" Niall named there, sequenced after #225.

## Niall's guardrails

| Guardrail | Where addressed |
|-----------|-----------------|
| Pin SDK past UriTemplate ReDoS fixes (upstream `modelcontextprotocol/typescript-sdk` #965, #1334) | `@modelcontextprotocol/*@^2.0.0` in `server/package.json`. Server v2.0.0 ships the patched `UriTemplate` (`server/dist/src-CX2iR2pK.mjs:7220`): `match(uri)` runs `validateLength(uri, MAX_TEMPLATE_LENGTH, "URI")` before any regex, with `MAX_TEMPLATE_LENGTH=1e6`, `MAX_VARIABLE_LENGTH=1e6`, `MAX_TEMPLATE_EXPRESSIONS=1e4`. Non-exploded `?` operator resolves to bounded pattern `escapeRegExp(name) + "=([^&]+)"` (no `.+` backtracking). |
| Keep bare `apap://templates` and `apap://agreements` valid (page-1 fallback for clients that don't build query-param URIs) | Static resource registrations at `handlers/mcp.ts:298, 306`. Comment at `handlers/mcp.ts:314-315` documents the routing distinction between static (bare) and templated (query) registrations. |
| Use non-exploded query form (avoid `{var*}` ReDoS surface) | `'apap://templates{?limit,offset}'` at `handlers/mcp.ts:322` and `'apap://agreements{?limit,offset}'` at `handlers/mcp.ts:330`. Neither uses the exploded `*` modifier. |
| Server-side clamp on `limit` / `offset` | Already enforced by `listTemplatesPaged` / `listAgreementsPaged` in `services/templateService.ts` and `services/agreementService.ts` (landed in #225): `limit` clamps to 1-100, `offset` clamps to `≥0`. |

## Test plan

- [x] Unit: 42 tests in `server/handlers/mcp.test.ts` cover bare URIs, templated URIs, and edge cases (partial `?limit=` without offset, blank query values, values outside clamp range)
- [x] Passing locally on `@modelcontextprotocol/*@2.0.0` with cicero-core 2.x
- [ ] Manual smoke against `docker compose up` with `@modelcontextprotocol/inspector`
- [ ] Reviewer confirms the four guardrails above map to the cited lines

## Backwards compatibility

Bare-URI readers see zero change. Existing clients calling `resources/read` for `apap://templates` or `apap://agreements` continue to receive the first 100 rows without any client-side update.

## Sequencing

Depends on #225 landing first (slice 3 REST list unification) because `listTemplatesPaged` / `listAgreementsPaged` are the service functions this PR's paged resources call. Held per Niall's plan.

## Files changed

- `server/handlers/mcp.ts`: new `ResourceTemplate` registrations, kept static bare URIs
- `server/handlers/mcp.test.ts`: 42 tests covering all URI shapes and edge cases
