### PR TITLE
feat(mcp): _meta.hasMore on paged resource reads (closes #244)

### DIFF
--- a/server/handlers/mcp.test.ts
+++ b/server/handlers/mcp.test.ts
@@ -680,6 +680,40 @@ describe('MCP Handler', () => {
                     client.readResource({ uri: 'apap://templates?limit=50' }),
                 ).rejects.toThrow(/apap:\/\/templates\?limit=50/);
             });
+
+            // #244: paged reads carry `_meta.hasMore` so an LLM client paging
+            // over the collection can stop without probing the next page.
+            // Heuristic is `rows.length === effectiveLimit` per Satvik's
+            // "no extra query" scoping in #248/#244; the service clamps limit
+            // to [1, 100] identically to the handler's `effectiveLimit`, so
+            // the two agree on the boundary.
+            describe('_meta.hasMore signal (#244)', () => {
+                it('apap://templates paged read where returned count == limit reports hasMore: true', async () => {
+                    // limit=2, DB returns 2 rows -> page filled, more may exist.
+                    mockDb._setReturn([templateRow, { ...templateRow, id: 2, uri: 'test://template/2' }]);
+                    const result = await client.readResource({ uri: 'apap://templates?limit=2&offset=0' });
+                    expect((result as { _meta?: { hasMore?: boolean } })._meta?.hasMore).toBe(true);
+                });
+
+                it('apap://templates paged read where returned count < limit reports hasMore: false', async () => {
+                    // limit=10, DB returns 1 row -> page short, no more.
+                    mockDb._setReturn([templateRow]);
+                    const result = await client.readResource({ uri: 'apap://templates?limit=10&offset=0' });
+                    expect((result as { _meta?: { hasMore?: boolean } })._meta?.hasMore).toBe(false);
+                });
+
+                it('apap://agreements paged read where returned count == limit reports hasMore: true', async () => {
+                    mockDb._setReturn([agreementRow, { ...agreementRow, id: 3 }]);
+                    const result = await client.readResource({ uri: 'apap://agreements?limit=2&offset=0' });
+                    expect((result as { _meta?: { hasMore?: boolean } })._meta?.hasMore).toBe(true);
+                });
+
+                it('apap://agreements paged read where returned count < limit reports hasMore: false', async () => {
+                    mockDb._setReturn([agreementRow]);
+                    const result = await client.readResource({ uri: 'apap://agreements?limit=10&offset=0' });
+                    expect((result as { _meta?: { hasMore?: boolean } })._meta?.hasMore).toBe(false);
+                });
+            });
         });
     });
 });

--- a/server/handlers/mcp.ts
+++ b/server/handlers/mcp.ts
@@ -221,11 +221,25 @@ async function getAgreement(db: Database, uri: string, variables: { agreementId:
 // per RFC 6570 form-style expansion. The service clamps to [1, 100] internally
 // so we never double-clamp here; `undefined` values fall back to the same
 // full-page default the bare `apap://templates` URI uses (limit=100, offset=0).
+//
+// `_meta.hasMore` closes #244: a client paging `apap://templates{?limit,offset}`
+// otherwise has to probe an extra page to discover the collection ends. The
+// service clamps `limit` to [1, 100] identically to the effectiveLimit computed
+// here, so `rows.length === effectiveLimit` is a sound "page filled" signal.
+// ponytail: heuristic. A total that is an exact multiple of the effective
+// limit still costs the client one probe (rows.length === limit and hasMore
+// reports true; the next page returns 0 rows and hasMore false). Upgrade path:
+// fetch `limit + 1` inside the service and drop the peek, at the cost of one
+// extra row's bytes per read. Deferred here to match Satvik's "no extra query"
+// scoping in #244; upgrade if the boundary case surfaces in real traffic.
 async function getTemplates(db: Database, uri: URL, opts: { limit?: number; offset?: number } = {}) {
     console.log({ type: 'get_templates_requested', uri: uri.toString(), ...opts });
     const templates = await listTemplates(db, opts);
-    console.log({ type: 'fetched_templates_success', count: templates.length });
+    const effectiveLimit = Math.min(100, Math.max(1, opts.limit ?? 100));
+    const hasMore = templates.length === effectiveLimit;
+    console.log({ type: 'fetched_templates_success', count: templates.length, hasMore });
     return {
+        _meta: { hasMore },
         contents: templates.map((t) => ({
             uri: `apap://templates/${t.id}`,
             mimeType: "application/json",
@@ -244,8 +258,13 @@ async function getTemplates(db: Database, uri: URL, opts: { limit?: number; offs
 async function getAgreements(db: Database, uri: URL, opts: { limit?: number; offset?: number } = {}) {
     console.log({ type: 'get_agreements_requested', uri: uri.toString(), ...opts });
     const agreements = await listAgreements(db, opts);
-    console.log({ type: 'fetched_agreements_success', count: agreements.length });
+    // `_meta.hasMore` closes #244; see getTemplates above for the heuristic
+    // and its upgrade path.
+    const effectiveLimit = Math.min(100, Math.max(1, opts.limit ?? 100));
+    const hasMore = agreements.length === effectiveLimit;
+    console.log({ type: 'fetched_agreements_success', count: agreements.length, hasMore });
     return {
+        _meta: { hasMore },
         // FIX for issue #128: The previous version spread the full agreement object
         // (...a) after setting the uri field. Because the Agreement row from the
         // database carries its own `uri` property (e.g. "resource:org.accordproject..."),


### PR DESCRIPTION
Closes #244.

## What

Paged MCP resource reads (`apap://templates{?limit,offset}` and `apap://agreements{?limit,offset}`) now include `_meta.hasMore: boolean` in the ReadResourceResult. An LLM client paging over the collection can stop when `hasMore` is false without probing the next page for a 0-row response.

## How

`hasMore = rows.length === effectiveLimit`, where `effectiveLimit = Math.min(100, Math.max(1, opts.limit ?? 100))` mirrors the clamp `listTemplates` / `listAgreements` apply internally.

This matches the "cheapest to ship, no extra query" scoping Satvik agreed to on #248 / #244. The signal is sound when the total is not an exact multiple of the effective limit. When it is, the client still costs one probe (the last full page reports `hasMore: true`, then the next page returns 0 rows and `hasMore: false`).

Upgrade path noted in a `ponytail:` comment on `getTemplates`: fetch `limit + 1` inside the service and drop the peek at the cost of one extra row's bytes per read. Deferred until real traffic surfaces the boundary case.

## Scope

- Applies to bare-URI reads too (`apap://templates`, `apap://agreements`) since both paths go through the same handler. Existing clients ignore unknown `_meta` keys per the MCP spec (`ReadResourceResultSchema` uses `z.core.$loose` on `_meta`).
- No service-layer changes; the two handler functions add ~6 lines each.
- No transport or protocol changes.

## Test plan

- [x] `npm test` green (265 tests, 11 suites)
- [x] `npx tsc --noEmit` clean
- [x] New tests pin the boundary: `hasMore: true` when returned count equals limit; `hasMore: false` when returned count is strictly less. Both templates and agreements.

## Related

- #217 (paging URI design, ratified)
- #243 (paging implementation this PR extends)
- #248 (typed field selection, Satvik's parallel follow-up on the same read path)
